### PR TITLE
build(cuda): auto-detect the native GPU architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ CUDA distribution appropriate for the machine. Known-good configurations are:
 | Thor-U | `sm_101` | CUDA 12.8 |
 | Jetson AGX Orin | `sm_87` | CUDA 12.6 and 13.2 |
 
-Set the toolkit path and the architecture before building. Do not omit the
-architecture on Jetson:
+Set the toolkit path before building. On a native build, ApxInf queries the
+CUDA runtime and automatically selects the architecture of the visible GPU:
 
 ```bash
 export CUDA_PATH=/usr/local/cuda
 export PATH="${CUDA_PATH}/bin:$PATH"
-export APXINF_CUDA_ARCH=sm_110  # use sm_101 for Thor-U or sm_87 for Orin
+unset APXINF_CUDA_ARCH APXINF_CUDA_ARCH_CUTLASS
 
 nvcc --version
 test -f "${CUDA_PATH}/include/cuda_runtime.h"
@@ -85,6 +85,21 @@ test -f "${CUDA_PATH}/include/cuda_runtime.h"
 The build itself locates `nvcc` through `CUDA_PATH`; the `PATH` entry is what
 makes the `nvcc --version` check above work on a shell that has no CUDA on its
 default path.
+
+Set `APXINF_CUDA_ARCH` explicitly when cross-compiling, building in a container
+without a visible GPU, or producing binaries for a different machine. Prefer a
+one-shot override so later native builds still use hardware detection:
+
+```bash
+APXINF_CUDA_ARCH=sm_110 cargo build --release --features cuda
+# Use sm_101 for Thor-U or sm_87 for Orin.
+```
+
+The override always takes precedence over hardware detection. If visible GPUs
+have different compute capabilities, restrict the build with
+`CUDA_VISIBLE_DEVICES` or set `APXINF_CUDA_ARCH`. The corresponding
+architecture-specific CUTLASS target (for example `sm_110a`) is selected
+automatically and can be overridden with `APXINF_CUDA_ARCH_CUTLASS`.
 
 If CUDA is installed elsewhere, point `CUDA_PATH` at that directory. The
 runtime libraries must also be visible to the system dynamic linker.

--- a/crates/apxinf-cuda/build.rs
+++ b/crates/apxinf-cuda/build.rs
@@ -1,5 +1,10 @@
 use std::env;
 
+#[path = "build_support/cuda_arch.rs"]
+mod cuda_arch;
+
+use cuda_arch::{is_cutlass_sm100_family, select_cuda_arch, ArchSource};
+
 const FNV1A_128_OFFSET: u128 = 0x6c62272e07bb014262b821756295c58d;
 const FNV1A_128_PRIME: u128 = 0x0000000001000000000000000000013b;
 
@@ -93,13 +98,6 @@ fn emit_rerun_if_changed_tree(root: &std::path::Path) {
     }
 }
 
-fn is_cutlass_sm100_family(arch: &str) -> bool {
-    matches!(
-        arch,
-        "sm_100" | "sm_100a" | "sm_101" | "sm_101a" | "sm_110" | "sm_110a" | "sm_120" | "sm_120a"
-    )
-}
-
 fn is_fa2_sm80_family(arch: &str) -> bool {
     matches!(arch, "sm_80" | "sm_86" | "sm_87" | "sm_89")
 }
@@ -115,6 +113,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH");
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH_CUTLASS");
     println!("cargo:rerun-if-env-changed=APXINF_KERNEL_BUILD_ID");
+    println!("cargo:rerun-if-env-changed=CUDA_VISIBLE_DEVICES");
+    println!("cargo:rerun-if-env-changed=NVIDIA_VISIBLE_DEVICES");
+    println!("cargo:rerun-if-changed=build_support/cuda_arch.rs");
     // Only try to link CUDA if the toolkit is available.
     let cuda_path = env::var("CUDA_PATH")
         .or_else(|_| env::var("CUDA_HOME"))
@@ -191,27 +192,49 @@ fn main() {
             println!("cargo:rerun-if-changed={kernels_dir}");
             println!("cargo:rerun-if-changed={adapters_dir}");
             emit_rerun_if_changed_tree(std::path::Path::new(&adapters_dir));
-            // Pick a target arch: explicit override > aarch64→sm_101 (Drive OS
-            // Thor, Blackwell automotive) > x86_64 leaves nvcc's default (lets
-            // the host JIT for whatever GPU is present, preserving prior
-            // behavior on desktop RTX cards).
+            // Pick a target arch: explicit override > native CUDA device
+            // detection. Never infer a GPU architecture from the CPU target:
+            // Orin, Thor-U, and Thor are all aarch64 but require different
+            // device code. Cross-compilation therefore requires an override.
             let arch_for_target = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-            let nvcc_arch: Option<String> = env::var("APXINF_CUDA_ARCH").ok().or_else(|| {
-                if arch_for_target == "aarch64" {
-                    Some("sm_101".into())
+            let out_dir = env::var("OUT_DIR").unwrap();
+            let nvcc = {
+                let bundled = format!("{cuda_path}/bin/nvcc");
+                if std::path::Path::new(&bundled).exists() {
+                    bundled
                 } else {
-                    None
+                    "nvcc".to_string()
                 }
+            };
+            let host = env::var("HOST").unwrap_or_default();
+            let target = env::var("TARGET").unwrap_or_default();
+            let selection = select_cuda_arch(
+                env::var("APXINF_CUDA_ARCH").ok(),
+                env::var("APXINF_CUDA_ARCH_CUTLASS").ok(),
+                &host,
+                &target,
+                std::path::Path::new(&nvcc),
+                std::path::Path::new(&out_dir),
+            )
+            .unwrap_or_else(|error| {
+                panic!(
+                    "CUDA architecture selection failed: {error}\n\
+                     Set APXINF_CUDA_ARCH explicitly when auto-detection is unavailable \
+                     (Orin: sm_87, Thor-U: sm_101, Thor: sm_110)."
+                )
             });
-            let cutlass_arch = env::var("APXINF_CUDA_ARCH_CUTLASS").ok().or_else(|| {
-                nvcc_arch.as_ref().map(|arch| {
-                    if is_cutlass_sm100_family(arch) && !arch.ends_with('a') {
-                        format!("{arch}a")
-                    } else {
-                        arch.clone()
-                    }
-                })
-            });
+            match &selection.source {
+                ArchSource::Explicit => println!(
+                    "cargo:warning=ApxInf CUDA architecture: {} (explicit), CUTLASS: {}",
+                    selection.nvcc_arch, selection.cutlass_arch
+                ),
+                ArchSource::Detected { device_count } => println!(
+                    "cargo:warning=ApxInf CUDA architecture: {} (auto-detected from {device_count} visible GPU(s)), CUTLASS: {}",
+                    selection.nvcc_arch, selection.cutlass_arch
+                ),
+            }
+            let nvcc_arch = Some(selection.nvcc_arch);
+            let cutlass_arch = Some(selection.cutlass_arch);
             let kernel_build_id = env::var("APXINF_KERNEL_BUILD_ID").unwrap_or_else(|_| {
                 computed_kernel_build_id(
                     std::path::Path::new(&manifest_dir),
@@ -342,15 +365,6 @@ fn main() {
             }
 
             if !kernel_files.is_empty() {
-                let out_dir = env::var("OUT_DIR").unwrap();
-                let nvcc = {
-                    let bundled = format!("{cuda_path}/bin/nvcc");
-                    if std::path::Path::new(&bundled).exists() {
-                        bundled
-                    } else {
-                        "nvcc".to_string()
-                    }
-                };
                 let target_include_dirs = [
                     format!("{cuda_path}/include"),
                     format!("{cuda_path}/targets/{arch}/include"),

--- a/crates/apxinf-cuda/build_support/cuda_arch.rs
+++ b/crates/apxinf-cuda/build_support/cuda_arch.rs
@@ -1,0 +1,331 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const DEVICE_PROBE_SOURCE: &str = r#"
+#include <cuda_runtime_api.h>
+#include <cstdio>
+
+int main() {
+    int device_count = 0;
+    cudaError_t status = cudaGetDeviceCount(&device_count);
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "cudaGetDeviceCount failed: %s\n", cudaGetErrorString(status));
+        return 2;
+    }
+    if (device_count == 0) {
+        std::fprintf(stderr, "CUDA reported zero visible devices\n");
+        return 3;
+    }
+
+    for (int device = 0; device < device_count; ++device) {
+        cudaDeviceProp properties{};
+        status = cudaGetDeviceProperties(&properties, device);
+        if (status != cudaSuccess) {
+            std::fprintf(
+                stderr,
+                "cudaGetDeviceProperties(%d) failed: %s\n",
+                device,
+                cudaGetErrorString(status));
+            return 4;
+        }
+        std::printf(
+            "APXINF_CUDA_DEVICE %d %d %d %s\n",
+            device,
+            properties.major,
+            properties.minor,
+            properties.name);
+    }
+    return 0;
+}
+"#;
+
+const ARCH_CHECK_SOURCE: &str = r#"
+__global__ void apxinf_cuda_arch_check() {}
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ComputeCapability {
+    major: u32,
+    minor: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArchSource {
+    Explicit,
+    Detected { device_count: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchSelection {
+    pub nvcc_arch: String,
+    pub cutlass_arch: String,
+    pub source: ArchSource,
+}
+
+pub fn is_cutlass_sm100_family(arch: &str) -> bool {
+    matches!(
+        arch,
+        "sm_100" | "sm_100a" | "sm_101" | "sm_101a" | "sm_110" | "sm_110a" | "sm_120" | "sm_120a"
+    )
+}
+
+pub fn select_cuda_arch(
+    explicit_nvcc_arch: Option<String>,
+    explicit_cutlass_arch: Option<String>,
+    host: &str,
+    target: &str,
+    nvcc: &Path,
+    out_dir: &Path,
+) -> Result<ArchSelection, String> {
+    let (nvcc_arch, source) = if let Some(arch) = explicit_nvcc_arch {
+        (validate_arch_name(&arch)?.to_owned(), ArchSource::Explicit)
+    } else {
+        if host != target {
+            return Err(format!(
+                "cannot auto-detect the target GPU while cross-compiling ({host} -> {target})"
+            ));
+        }
+        let capabilities = detect_compute_capabilities(nvcc, out_dir)?;
+        let device_count = capabilities.len();
+        (
+            select_uniform_arch(&capabilities)?,
+            ArchSource::Detected { device_count },
+        )
+    };
+
+    let cutlass_arch = match explicit_cutlass_arch {
+        Some(arch) => validate_arch_name(&arch)?.to_owned(),
+        None => cutlass_arch_for(&nvcc_arch),
+    };
+
+    validate_nvcc_arch(nvcc, out_dir, &nvcc_arch)?;
+    if cutlass_arch != nvcc_arch {
+        validate_nvcc_arch(nvcc, out_dir, &cutlass_arch)?;
+    }
+
+    Ok(ArchSelection {
+        nvcc_arch,
+        cutlass_arch,
+        source,
+    })
+}
+
+fn validate_arch_name(arch: &str) -> Result<&str, String> {
+    let Some(suffix) = arch.strip_prefix("sm_") else {
+        return Err(format!(
+            "invalid CUDA architecture {arch:?}; expected a value such as sm_87, sm_101, or sm_110"
+        ));
+    };
+    let digits = suffix.strip_suffix('a').unwrap_or(suffix);
+    if digits.len() < 2 || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(format!(
+            "invalid CUDA architecture {arch:?}; expected a value such as sm_87, sm_101, or sm_110"
+        ));
+    }
+    Ok(arch)
+}
+
+fn cutlass_arch_for(nvcc_arch: &str) -> String {
+    if is_cutlass_sm100_family(nvcc_arch) && !nvcc_arch.ends_with('a') {
+        format!("{nvcc_arch}a")
+    } else {
+        nvcc_arch.to_owned()
+    }
+}
+
+fn select_uniform_arch(capabilities: &[ComputeCapability]) -> Result<String, String> {
+    if capabilities.is_empty() {
+        return Err("CUDA reported zero visible devices".to_owned());
+    }
+
+    let unique: BTreeSet<_> = capabilities.iter().copied().collect();
+    if unique.len() != 1 {
+        let architectures = unique
+            .into_iter()
+            .map(capability_to_arch)
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(format!(
+            "visible CUDA devices have different architectures ({architectures})"
+        ));
+    }
+
+    Ok(capability_to_arch(*unique.iter().next().unwrap()))
+}
+
+fn capability_to_arch(capability: ComputeCapability) -> String {
+    format!("sm_{}{}", capability.major, capability.minor)
+}
+
+fn detect_compute_capabilities(
+    nvcc: &Path,
+    out_dir: &Path,
+) -> Result<Vec<ComputeCapability>, String> {
+    let source = out_dir.join("apxinf_cuda_device_probe.cu");
+    let executable = executable_path(out_dir, "apxinf_cuda_device_probe");
+    std::fs::write(&source, DEVICE_PROBE_SOURCE)
+        .map_err(|error| format!("write CUDA device probe {}: {error}", source.display()))?;
+
+    let compile = Command::new(nvcc)
+        .args(["-std=c++17", "-O0"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&executable)
+        .output()
+        .map_err(|error| format!("run {} for CUDA device probe: {error}", nvcc.display()))?;
+    ensure_success("compile CUDA device probe", &compile)?;
+
+    let probe = Command::new(&executable)
+        .output()
+        .map_err(|error| format!("run CUDA device probe {}: {error}", executable.display()))?;
+    ensure_success("run CUDA device probe", &probe)?;
+
+    parse_probe_output(&String::from_utf8_lossy(&probe.stdout))
+}
+
+fn parse_probe_output(output: &str) -> Result<Vec<ComputeCapability>, String> {
+    let mut capabilities = Vec::new();
+    for line in output.lines() {
+        let mut fields = line.split_whitespace();
+        if fields.next() != Some("APXINF_CUDA_DEVICE") {
+            continue;
+        }
+        let device = fields
+            .next()
+            .ok_or_else(|| format!("malformed CUDA device probe output: {line:?}"))?;
+        let major = fields
+            .next()
+            .ok_or_else(|| format!("missing compute capability for CUDA device {device}"))?
+            .parse::<u32>()
+            .map_err(|error| {
+                format!("invalid compute capability for CUDA device {device}: {error}")
+            })?;
+        let minor = fields
+            .next()
+            .ok_or_else(|| format!("missing compute capability for CUDA device {device}"))?
+            .parse::<u32>()
+            .map_err(|error| {
+                format!("invalid compute capability for CUDA device {device}: {error}")
+            })?;
+        capabilities.push(ComputeCapability { major, minor });
+    }
+
+    if capabilities.is_empty() {
+        Err(format!(
+            "CUDA device probe produced no device records; stdout was {output:?}"
+        ))
+    } else {
+        Ok(capabilities)
+    }
+}
+
+fn validate_nvcc_arch(nvcc: &Path, out_dir: &Path, arch: &str) -> Result<(), String> {
+    let source = out_dir.join("apxinf_cuda_arch_check.cu");
+    let object = out_dir.join(format!("apxinf_cuda_arch_check_{arch}.o"));
+    std::fs::write(&source, ARCH_CHECK_SOURCE).map_err(|error| {
+        format!(
+            "write NVCC architecture check {}: {error}",
+            source.display()
+        )
+    })?;
+
+    let output = Command::new(nvcc)
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&object)
+        .arg(format!("-arch={arch}"))
+        .output()
+        .map_err(|error| format!("run {} to validate {arch}: {error}", nvcc.display()))?;
+    ensure_success(&format!("validate CUDA architecture {arch}"), &output)
+}
+
+fn ensure_success(action: &str, output: &Output) -> Result<(), String> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    Err(format!(
+        "{action} failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        if stdout.is_empty() {
+            "<empty>"
+        } else {
+            stdout.as_str()
+        },
+        if stderr.is_empty() {
+            "<empty>"
+        } else {
+            stderr.as_str()
+        }
+    ))
+}
+
+fn executable_path(out_dir: &Path, stem: &str) -> PathBuf {
+    out_dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_compute_capabilities() {
+        let parsed = parse_probe_output(
+            "APXINF_CUDA_DEVICE 0 11 0 NVIDIA Thor\nAPXINF_CUDA_DEVICE 1 11 0 NVIDIA Thor\n",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ComputeCapability { major: 11, minor: 0 },
+                ComputeCapability { major: 11, minor: 0 }
+            ]
+        );
+        assert_eq!(select_uniform_arch(&parsed).unwrap(), "sm_110");
+    }
+
+    #[test]
+    fn rejects_mixed_visible_architectures() {
+        let capabilities = [
+            ComputeCapability { major: 8, minor: 7 },
+            ComputeCapability { major: 11, minor: 0 },
+        ];
+        let error = select_uniform_arch(&capabilities).unwrap_err();
+        assert!(error.contains("sm_87, sm_110"), "{error}");
+    }
+
+    #[test]
+    fn maps_known_blackwell_targets_to_arch_specific_cutlass() {
+        assert_eq!(cutlass_arch_for("sm_101"), "sm_101a");
+        assert_eq!(cutlass_arch_for("sm_110"), "sm_110a");
+        assert_eq!(cutlass_arch_for("sm_87"), "sm_87");
+        assert_eq!(cutlass_arch_for("sm_110a"), "sm_110a");
+    }
+
+    #[test]
+    fn validates_architecture_names() {
+        for valid in ["sm_87", "sm_101", "sm_110a"] {
+            assert_eq!(validate_arch_name(valid).unwrap(), valid);
+        }
+        for invalid in ["", "87", "compute_87", "sm_", "sm_xx", "sm_87aa"] {
+            assert!(validate_arch_name(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn cross_compilation_never_probes_the_host_gpu() {
+        let error = select_cuda_arch(
+            None,
+            None,
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+            Path::new("nvcc-must-not-run"),
+            Path::new("unused-out-dir"),
+        )
+        .unwrap_err();
+        assert!(error.contains("cross-compiling"), "{error}");
+    }
+}

--- a/crates/apxinf-cuda/tests/cuda_arch.rs
+++ b/crates/apxinf-cuda/tests/cuda_arch.rs
@@ -1,0 +1,2 @@
+#[path = "../build_support/cuda_arch.rs"]
+mod cuda_arch;


### PR DESCRIPTION
- Remove the incorrect aarch64-to-sm_101 default
- Preserve APXINF_CUDA_ARCH for cross-compilation
- Reject mixed visible GPU architectures
- Validate selected targets with nvcc
- Select architecture-specific CUTLASS targets automatically


- Validated on Jetson AGX Orin with CUDA 12.6：
1. Automatically selected sm_87
2. Release CUDA build passed
3. Architecture selector tests passed