### PR TITLE
feat(apxinf): lerobot adapter for drop-in policy swap

### DIFF
--- a/python/apxinf/README.md
+++ b/python/apxinf/README.md
@@ -16,6 +16,8 @@ apxinf/
 │   ├── auto.py       AutoPolicy: checkpoint -> concrete policy by config type
 │   └── impls/        concrete per-model policies (the part that grows)
 │       └── pi05.py       Pi05Policy (registered as "pi05")
+├── adapters/     downstream: expose a Policy through a foreign API (lazy imports)
+│   └── lerobot.py   ApxInfPolicy — drop-in policy for a lerobot control loop
 └── __init__.py   facade: Model (lazy), Pi05Policy, AutoPolicy, Policy, steps
 ```
 
@@ -139,6 +141,55 @@ implementation.
 anchor point for future models (a `GrootPolicy` satisfies the same contract),
 for `AutoPolicy` dispatch, and for a future lerobot adaptor — no inheritance
 required, structural typing only.
+
+## lerobot interop
+
+`apxinf.adapters.lerobot.ApxInfPolicy` wraps any `Policy` in the surface a
+**hand-written lerobot control loop** calls, so a lerobot user keeps their robot,
+cameras, dataset-feature plumbing and action dispatch and swaps only the policy:
+
+```python
+from apxinf.adapters.lerobot import ApxInfPolicy
+
+model = ApxInfPolicy.from_pretrained(ckpt_dir, device="cuda:0", precision="bf16")
+preprocess, postprocess = model.make_pre_post_processors()
+
+obs   = robot.get_observation()                                   # lerobot's
+frame = model.build_inference_frame(obs, ds_features=feats, task=task)
+action = postprocess(model.select_action(preprocess(frame)))
+robot.send_action(make_robot_action(action, feats))               # lerobot's
+```
+
+See `examples/lerobot_loop.py` (runs with `--mock-robot`, no hardware needed).
+
+**Supported:** lerobot `robots`/`cameras`/`teleoperators`, `hw_to_dataset_features`,
+`build_dataset_frame`, `make_robot_action`, `LeRobotDataset` recording,
+hand-written gym eval loops, chunk-at-a-time via `predict_action_chunk`.
+
+**Not supported:** the `lerobot-eval` / `lerobot-rollout` CLIs and `make_policy`
+(they resolve a policy class out of lerobot's registry — that needs a
+`lerobot_policy_*` plugin distribution); training / fine-tuning / PEFT
+(structurally impossible — the engine has no autograd); RTC inference; lerobot's
+async-inference server (`apxinf.serving` covers that need); `torch.compile`.
+
+**Two seams, one default.** lerobot's `build_inference_frame` is
+`build_dataset_frame` (numpy `HWC` `uint8`) followed by
+`prepare_observation_for_inference` (H2D, `/255`, `CHW`, batch dim). The adapter's
+`build_inference_frame` runs **only the first** — that layer is already what
+`Policy.infer` eats. A frame that went through the second is also accepted and
+undone, but costs a device→host copy per tick, so the numpy seam is the default.
+
+**Whose pre/post runs: ours.** apxinf's `Pipeline` does all of resize, tokenize,
+noise and unnormalize — what the golden tests anchor the checkpoint's numerics to.
+lerobot splits the same work differently (resize and prior noise live *inside* its
+policy; normalize lives in its processor pipeline), so pipelines from its
+`make_pre_post_processors` are **not** interchangeable with ours — feeding their
+output here would drop resize/noise and double-normalize. `ApxInfPolicy`'s own
+`make_pre_post_processors()` therefore returns pass-throughs that preserve the
+call shape and nothing more.
+
+Install with `pip install -e '.[lerobot]'` (adds torch for the tensor boundary;
+lerobot itself is not pinned — bring your own version).
 
 ## Camera views
 

--- a/python/apxinf/apxinf/adapters/__init__.py
+++ b/python/apxinf/apxinf/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Adapters that expose an :class:`apxinf.Policy` through a *foreign* API.
+
+Like :mod:`apxinf.serving`, this package sits *downstream* of the policy layer: it
+consumes the ``Policy`` contract (``obs dict -> result dict``) and translates it
+into somebody else's calling convention. Nothing in ``policies`` / ``processors``
+depends back on it, and it is kept out of the top-level ``apxinf`` namespace and
+imported only on demand, so ``import apxinf`` never pulls in an adapter's heavy
+optional dependencies (``torch`` for the lerobot adapter, as ``msgpack`` /
+``websockets`` for ``serving``). Import explicitly::
+
+    from apxinf.adapters.lerobot import ApxInfPolicy
+
+An adapter is *not* a place for new inference logic. If an adapter needs to change
+numerics, that belongs in a processor step or a policy instead.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/python/apxinf/apxinf/adapters/lerobot.py
+++ b/python/apxinf/apxinf/adapters/lerobot.py
@@ -1,0 +1,492 @@
+"""Drive an :class:`apxinf.Policy` from a lerobot-shaped control loop.
+
+:class:`ApxInfPolicy` stands in for a lerobot policy object (``PI0Policy`` &c.) in
+a **hand-written control loop**, so a lerobot user keeps their robot, cameras,
+dataset-feature plumbing and action dispatch and swaps only the policy::
+
+    - from lerobot.policies.pi0 import PI0Policy
+    - from lerobot.policies import make_pre_post_processors
+    - model = PI0Policy.from_pretrained(model_id)
+    - preprocess, postprocess = make_pre_post_processors(model.config, model_id)
+    + from apxinf.adapters.lerobot import ApxInfPolicy
+    + model = ApxInfPolicy.from_pretrained(ckpt_dir, device="cuda:0", precision="bf16")
+    + preprocess, postprocess = model.make_pre_post_processors()
+
+    - obs_frame = build_inference_frame(obs, ds_features=feats, device=device, task=task)
+    + obs_frame = model.build_inference_frame(obs, ds_features=feats, task=task)
+
+      obs    = preprocess(obs_frame)          # unchanged
+      action = model.select_action(obs)       # unchanged
+      action = postprocess(action)            # unchanged
+      robot.send_action(make_robot_action(action, feats))   # unchanged
+
+**Supported** — a user-constructed policy in a loop the user owns: lerobot
+``robots`` / ``cameras`` / ``teleoperators``, ``hw_to_dataset_features``,
+``build_dataset_frame``, ``make_robot_action``, ``LeRobotDataset`` recording,
+hand-written gym eval loops, and chunk-at-a-time consumption via
+:meth:`ApxInfPolicy.predict_action_chunk`.
+
+**Not supported** — anything where lerobot *constructs* the policy from a string
+or trains it:
+
+* ``lerobot-eval`` / ``lerobot-rollout`` CLI, ``make_policy``,
+  ``make_pre_post_processors(policy.config, ...)`` — these resolve a policy class
+  out of the draccus ``ChoiceRegistry`` and build pre/post from a
+  ``PreTrainedConfig``. Becoming reachable that way means shipping a
+  ``lerobot_policy_*`` plugin distribution; see ``doc/`` for that trade-off.
+* training / fine-tuning / PEFT (``forward``, ``loss.backward()``,
+  ``lerobot-train``) — structurally impossible: the engine underneath is a Rust
+  inference runtime with no autograd.
+* RTC (``--inference.type=rtc``) and lerobot's async-inference policy server —
+  new engine capabilities, not a wrapper concern (apxinf ships its own
+  :mod:`apxinf.serving` websocket server).
+* ``torch.compile`` / AMP autocast — meaningless here (the CUDA graph lives in
+  Rust); accepted and ignored rather than honoured.
+
+**Where the seam sits.** lerobot's ``build_inference_frame`` is two steps:
+``build_dataset_frame`` (key regrouping, still numpy ``HWC`` ``uint8``) then
+``prepare_observation_for_inference`` (H2D, ``/255``, ``permute`` to ``CHW``, batch
+dim). :meth:`ApxInfPolicy.build_inference_frame` runs **only the first** and
+renames keys, because that layer is exactly what :meth:`Policy.infer` already
+eats. Passing a frame that went through the second step also works — see
+:func:`observation_to_apxinf`, which undoes it — but it costs a device→host copy
+per tick and a lossy ``*255`` round-trip, so the numpy seam is the default.
+
+**Whose pre/post runs.** apxinf's own :class:`~apxinf.processors.Pipeline` does
+*all* pre/post (resize, tokenize, noise, unnormalize) — it is what the checkpoint's
+numerics are anchored to by the golden tests. lerobot splits the same work
+differently (resize and prior-noise sampling live *inside* its policy, normalize
+lives in its processor pipeline), so the pipelines from
+``make_pre_post_processors`` are **not** interchangeable with ours; feeding their
+output here would drop resize/noise and double-normalize. The
+:meth:`make_pre_post_processors` on this class therefore returns near-identity
+pipelines that preserve the call shape and nothing more.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+__all__ = [
+    "ApxInfPolicy",
+    "observation_to_apxinf",
+    "IdentityProcessor",
+    "LEROBOT_IMAGE_PREFIX",
+    "LEROBOT_STATE_KEY",
+    "LEROBOT_TASK_KEY",
+]
+
+# lerobot's flat dotted observation keys (``lerobot.utils.constants``).
+LEROBOT_IMAGE_PREFIX = "observation.images."
+LEROBOT_STATE_KEY = "observation.state"
+LEROBOT_TASK_KEY = "task"
+
+# apxinf's slash-separated keys (openpi-shaped; see apxinf.processors.transforms).
+APXINF_STATE_KEY = "observation/state"
+APXINF_PROMPT_KEY = "prompt"
+
+
+def _require_torch():
+    """Import torch on demand, with an actionable message when it is absent.
+
+    Only the tensor boundary needs it, so ``import apxinf`` and the numpy-only
+    processor tests stay torch-free.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            "apxinf.adapters.lerobot needs PyTorch for its tensor boundary; "
+            "install it with `pip install apxinf[lerobot]`."
+        ) from exc
+    return torch
+
+
+def _lerobot_frame_builder():
+    """Resolve lerobot's ``build_dataset_frame`` + ``OBS_STR`` across versions.
+
+    The function itself has been stable, but its home has moved
+    (``lerobot.datasets.utils`` in 0.4.x, ``lerobot.utils.feature_utils`` on
+    later main), so try both rather than pinning one import path. Deliberately
+    reused instead of reimplemented: it decides which observation keys are read
+    and — via ``ft["names"]`` — the order the state vector is assembled in, which
+    must stay bit-identical to the lerobot path the checkpoint was used with.
+    """
+    try:
+        from lerobot.utils.constants import OBS_STR
+    except ImportError as exc:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            "apxinf.adapters.lerobot.build_inference_frame needs lerobot installed "
+            "(it reuses lerobot's own build_dataset_frame). Install lerobot, or "
+            "translate frames yourself with observation_to_apxinf()."
+        ) from exc
+
+    last_error: Exception | None = None
+    for module_name in ("lerobot.utils.feature_utils", "lerobot.datasets.utils"):
+        try:
+            module = __import__(module_name, fromlist=["build_dataset_frame"])
+            return module.build_dataset_frame, OBS_STR
+        except (ImportError, AttributeError) as exc:  # pragma: no cover
+            last_error = exc
+    raise ImportError(
+        "apxinf.adapters.lerobot: could not find lerobot's build_dataset_frame in "
+        "lerobot.utils.feature_utils or lerobot.datasets.utils. Pass frames through "
+        "observation_to_apxinf() instead, which needs no lerobot import."
+    ) from last_error
+
+
+class IdentityProcessor:
+    """A pass-through stand-in for a lerobot ``PolicyProcessorPipeline``.
+
+    Preserves the ``preprocess(frame)`` / ``postprocess(action)`` call shape of a
+    lerobot loop while doing nothing: apxinf policies own their whole pre/post
+    chain (see the module docstring). ``steps`` is empty and ``reset`` is a no-op,
+    the two attributes lerobot loops touch on a pipeline.
+    """
+
+    steps: Tuple[Any, ...] = ()
+
+    def __call__(self, value):
+        return value
+
+    def reset(self) -> None:
+        return None
+
+
+def observation_to_apxinf(
+    frame: Mapping[str, Any],
+    *,
+    image_keys: Sequence[str],
+    task: Optional[str] = None,
+    state_key: str = LEROBOT_STATE_KEY,
+    task_key: str = LEROBOT_TASK_KEY,
+) -> Dict[str, Any]:
+    """Translate one lerobot observation frame into an apxinf observation dict.
+
+    Accepts a frame from either seam: raw numpy ``HWC`` ``uint8`` images (the
+    output of lerobot's ``build_dataset_frame`` — the cheap path) *or* tensors that
+    already went through ``prepare_observation_for_inference``, which are undone
+    here (batch dim dropped, ``CHW -> HWC``, float ``[0, 1] -> uint8``, device ->
+    host).
+
+    ``image_keys`` are the apxinf camera keys **in the order the checkpoint
+    expects**; each is matched to a frame key by its trailing camera name, so
+    ``observation.images.base_0_rgb`` feeds ``observation/image`` when the caller
+    maps them in order. ``task`` overrides the frame's ``task`` entry.
+    """
+    images = _ordered_frame_images(frame)
+    if len(images) != len(image_keys):
+        raise ValueError(
+            f"lerobot adapter: policy expects {len(image_keys)} cameras "
+            f"{tuple(image_keys)} but the frame carries {len(images)}: "
+            f"{tuple(name for name, _ in images)}. Supply exactly the "
+            f"checkpoint's cameras (real views only, no padding)."
+        )
+
+    observation: Dict[str, Any] = {
+        apxinf_key: _to_hwc_uint8(value, source_key)
+        for apxinf_key, (source_key, value) in zip(image_keys, images)
+    }
+
+    if state_key in frame:
+        observation[APXINF_STATE_KEY] = _to_numpy(frame[state_key]).astype(
+            np.float32, copy=False
+        ).reshape(-1)
+
+    prompt = task if task is not None else frame.get(task_key, "")
+    if not isinstance(prompt, str):
+        raise TypeError(
+            f"lerobot adapter: task/prompt must be a string, got {type(prompt)!r}"
+        )
+    observation[APXINF_PROMPT_KEY] = prompt
+    return observation
+
+
+class ApxInfPolicy:
+    """A lerobot-shaped facade over any :class:`apxinf.Policy`.
+
+    Wraps an apxinf policy (``Pi05Policy`` today, any registered ``Policy``
+    tomorrow) and exposes the four things a hand-written lerobot loop calls on a
+    policy: :meth:`build_inference_frame`, :meth:`make_pre_post_processors`,
+    :meth:`select_action` and :meth:`predict_action_chunk`. Actions come back as
+    ``torch`` tensors with a leading batch dim, which is what lerobot's
+    ``make_robot_action`` consumes.
+
+    Like lerobot's chunking policies, :meth:`select_action` serves one step per
+    call out of an internal queue and only re-runs the model when the queue drains.
+    Wrap an existing policy directly, or build one from a checkpoint with
+    :meth:`from_pretrained`.
+    """
+
+    def __init__(
+        self,
+        policy: Any,
+        *,
+        image_keys: Optional[Sequence[str]] = None,
+        n_action_steps: Optional[int] = None,
+        state_key: str = LEROBOT_STATE_KEY,
+        task_key: str = LEROBOT_TASK_KEY,
+    ):
+        self.policy = policy
+        self.image_keys = tuple(
+            image_keys if image_keys is not None else getattr(policy, "image_keys", ())
+        )
+        if not self.image_keys:
+            raise ValueError(
+                "lerobot adapter: cannot infer the policy's camera keys; pass "
+                "image_keys= in the order the checkpoint expects."
+            )
+        horizon = int(policy.action_horizon)
+        self.n_action_steps = min(int(n_action_steps), horizon) if n_action_steps else horizon
+        self.state_key = state_key
+        self.task_key = task_key
+        self._queue: deque = deque(maxlen=self.n_action_steps)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_dir,
+        *,
+        model_type: Optional[str] = None,
+        n_action_steps: Optional[int] = None,
+        state_key: str = LEROBOT_STATE_KEY,
+        task_key: str = LEROBOT_TASK_KEY,
+        **policy_kwargs: Any,
+    ) -> "ApxInfPolicy":
+        """Build the policy for ``model_dir`` and wrap it.
+
+        Dispatches through :class:`~apxinf.policies.auto.AutoPolicy`, so the
+        concrete policy comes from the checkpoint's ``config.json`` model type.
+        Extra keyword arguments (``device`` / ``precision`` / ``action_dim`` /
+        ``image_keys`` / ...) pass straight through to that policy's
+        ``from_pretrained``.
+
+        Unlike lerobot's ``from_pretrained``, this takes a **local checkpoint
+        directory**, not a Hub repo id: apxinf checkpoints are engine-specific and
+        are not published under lerobot's Hub layout.
+        """
+        from ..policies import AutoPolicy
+
+        policy = AutoPolicy.from_pretrained(model_dir, model_type=model_type, **policy_kwargs)
+        return cls(
+            policy,
+            n_action_steps=n_action_steps,
+            state_key=state_key,
+            task_key=task_key,
+        )
+
+    # --- lerobot loop surface ----------------------------------------------
+
+    def build_inference_frame(
+        self,
+        observation: Mapping[str, Any],
+        *,
+        ds_features: Mapping[str, Mapping],
+        task: Optional[str] = None,
+        robot_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Raw robot observation -> apxinf observation dict (all numpy, host).
+
+        The counterpart of lerobot's ``build_inference_frame``, stopping one step
+        earlier: it runs lerobot's own ``build_dataset_frame`` (so ``ds_features``
+        keeps deciding which keys are read and in which order the state vector is
+        assembled — identical to the lerobot path) and then only renames keys. No
+        tensor conversion, no host->device copy: apxinf's pipeline wants exactly
+        this ``HWC`` ``uint8`` form.
+
+        ``robot_type`` is accepted for call-shape compatibility and ignored — it
+        exists in lerobot for multi-embodiment datasets, which the apxinf prompt
+        does not carry.
+        """
+        build_dataset_frame, obs_prefix = _lerobot_frame_builder()
+
+        frame = build_dataset_frame(dict(ds_features), dict(observation), prefix=obs_prefix)
+        return observation_to_apxinf(
+            frame,
+            image_keys=self.image_keys,
+            task=task,
+            state_key=self.state_key,
+            task_key=self.task_key,
+        )
+
+    def make_pre_post_processors(self, *args: Any, **kwargs: Any):
+        """Return ``(preprocess, postprocess)`` pass-throughs for the loop shape.
+
+        apxinf's policy owns its whole pre/post chain, so there is nothing left for
+        a lerobot-side pipeline to do; these keep the two call sites in an existing
+        loop valid. Arguments are accepted and ignored so a call copied from
+        ``make_pre_post_processors(model.config, model_id)`` still works.
+        """
+        return IdentityProcessor(), IdentityProcessor()
+
+    def predict_action_chunk(self, observation: Mapping[str, Any], **kwargs: Any):
+        """Run one inference and return the whole chunk as ``[1, horizon, dim]``.
+
+        This is the shape apxinf is native to (:meth:`Policy.infer` predicts a full
+        chunk), so prefer it over :meth:`select_action` when the loop can consume a
+        chunk: it does not re-run pre-processing per step.
+
+        Accepts either an apxinf observation dict or a lerobot frame (converted via
+        :func:`observation_to_apxinf`). Extra keyword arguments are rejected rather
+        than silently dropped — they are how lerobot passes RTC state, which this
+        adapter does not implement.
+        """
+        if kwargs:
+            raise TypeError(
+                f"lerobot adapter: predict_action_chunk got unsupported kwargs "
+                f"{sorted(kwargs)}; RTC / prefix-action inference is not implemented."
+            )
+        torch = _require_torch()
+        actions = self._infer_chunk(observation)
+        return torch.from_numpy(np.ascontiguousarray(actions)).unsqueeze(0)
+
+    def select_action(self, observation: Mapping[str, Any], **kwargs: Any):
+        """Return one action step as ``[1, action_dim]``, queueing the chunk.
+
+        Mirrors lerobot's chunking policies: the model runs only when the queue is
+        empty, and each call pops the next step. Call :meth:`reset` (or
+        :meth:`drop_queued_actions`) on an episode boundary or a task change so
+        actions computed for the old context are not dispatched.
+        """
+        if kwargs:
+            raise TypeError(
+                f"lerobot adapter: select_action got unsupported kwargs "
+                f"{sorted(kwargs)}; RTC / prefix-action inference is not implemented."
+            )
+        torch = _require_torch()
+        if not self._queue:
+            chunk = self._infer_chunk(observation)
+            self._queue.extend(chunk[: self.n_action_steps])
+        step = self._queue.popleft()
+        return torch.from_numpy(np.ascontiguousarray(step)).unsqueeze(0)
+
+    def drop_queued_actions(self) -> None:
+        """Discard actions still queued from an earlier observation / task."""
+        self._queue.clear()
+
+    def reset(self) -> None:
+        """Clear per-episode state. The apxinf policy itself is stateless."""
+        self.drop_queued_actions()
+
+    def eval(self) -> "ApxInfPolicy":
+        """Accepted for call-shape compatibility; inference-only already."""
+        return self
+
+    def close(self) -> None:
+        """Release the underlying model (see :meth:`apxinf.Policy.close`)."""
+        self.policy.close()
+
+    # --- introspection -----------------------------------------------------
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        return self.policy.metadata
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.policy.action_dim)
+
+    @property
+    def action_horizon(self) -> int:
+        return int(self.policy.action_horizon)
+
+    def __repr__(self) -> str:
+        return (
+            f"ApxInfPolicy({type(self.policy).__name__}, "
+            f"cameras={self.image_keys}, n_action_steps={self.n_action_steps})"
+        )
+
+    # --- helpers -----------------------------------------------------------
+
+    def _infer_chunk(self, observation: Mapping[str, Any]) -> np.ndarray:
+        """Normalize the caller's dict to apxinf keys and run the policy."""
+        if not isinstance(observation, Mapping):
+            raise TypeError(
+                f"lerobot adapter: observation must be a mapping, got {type(observation)!r}"
+            )
+        if APXINF_PROMPT_KEY not in observation:
+            # A frame that skipped ``build_inference_frame`` (e.g. it came straight
+            # from lerobot's own, tensor-producing one): convert it here.
+            observation = observation_to_apxinf(
+                observation,
+                image_keys=self.image_keys,
+                state_key=self.state_key,
+                task_key=self.task_key,
+            )
+        result = self.policy.infer(observation)
+        return np.asarray(result["actions"], dtype=np.float32)
+
+
+def _ordered_frame_images(frame: Mapping[str, Any]):
+    """The frame's camera entries as ``(key, value)``, in the frame's own order.
+
+    Python dicts preserve insertion order and lerobot's ``build_dataset_frame``
+    inserts cameras in ``ds_features`` order, so this is the caller's declared
+    camera order — which is what must line up with the checkpoint's ``image_keys``.
+    """
+    return [
+        (key, value)
+        for key, value in frame.items()
+        if key.startswith(LEROBOT_IMAGE_PREFIX)
+    ]
+
+
+def _to_numpy(value) -> np.ndarray:
+    """Host numpy view of a numpy array or a (possibly GPU) torch tensor."""
+    if isinstance(value, np.ndarray):
+        return value
+    detach = getattr(value, "detach", None)
+    if detach is not None:  # torch tensor, without importing torch to find out
+        return detach().to("cpu").numpy()
+    return np.asarray(value)
+
+
+def _to_hwc_uint8(value, source_key: str) -> np.ndarray:
+    """Coerce one camera frame to ``HWC`` ``uint8``, undoing lerobot's tensor prep.
+
+    Handles both seams: a raw ``HWC`` ``uint8`` frame passes through untouched,
+    while a ``[1, C, H, W]`` float tensor (what
+    ``prepare_observation_for_inference`` produces) is squeezed, transposed and
+    scaled back.
+
+    A float frame is taken to be in ``[0, 1]`` — lerobot's contract, since its
+    conversion is a plain ``/255`` — and is range-checked rather than sniffed, so
+    a frame that is really in ``[0, 255]`` fails loudly instead of silently
+    saturating. The scale-back rounds before casting: ``k / 255`` is not exact in
+    float32, so a truncating cast can land on ``k - 1``.
+    """
+    array = _to_numpy(value)
+    if array.ndim == 4:
+        if array.shape[0] != 1:
+            raise ValueError(
+                f"lerobot adapter: {source_key} has batch size {array.shape[0]}; "
+                f"only single-observation inference is supported."
+            )
+        array = array[0]
+    if array.ndim != 3:
+        raise ValueError(
+            f"lerobot adapter: {source_key} must be a 3-D image (HWC or CHW), "
+            f"got shape {array.shape}."
+        )
+
+    # Channel-first is how lerobot hands images to a policy; a channel count of
+    # 1/3/4 in axis 0 that is not also a plausible channel count in axis 2
+    # identifies it.
+    if array.shape[0] in (1, 3, 4) and array.shape[2] not in (1, 3, 4):
+        array = np.transpose(array, (1, 2, 0))
+
+    if array.dtype == np.uint8:
+        return np.ascontiguousarray(array)
+
+    scaled = array.astype(np.float32)
+    peak = float(scaled.max()) if scaled.size else 0.0
+    if not np.isfinite(peak) or peak > 1.0 + 1e-3:
+        raise ValueError(
+            f"lerobot adapter: float camera frame {source_key} peaks at {peak:.4g}, "
+            f"outside the expected [0, 1] range (lerobot divides uint8 frames by "
+            f"255). Pass uint8 HWC frames, or divide by 255 first."
+        )
+    return np.ascontiguousarray(np.clip(np.rint(scaled * 255.0), 0, 255).astype(np.uint8))

--- a/python/apxinf/examples/lerobot_loop.py
+++ b/python/apxinf/examples/lerobot_loop.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Drop an apxinf policy into a lerobot-shaped control loop.
+
+Mirrors lerobot's own ``examples/tutorial/pi0/using_pi0_example.py`` with the
+policy swapped for :class:`apxinf.adapters.lerobot.ApxInfPolicy`. Everything on
+the robot side of the loop — ``robots`` / ``cameras`` / ``hw_to_dataset_features``
+/ ``make_robot_action`` / ``send_action`` — is lerobot's and stays untouched;
+only policy construction and the observation-frame call change.
+
+By default this runs **without a robot**: ``--mock-robot`` synthesizes raw camera
+frames and joint readings in the shape ``robot.get_observation()`` returns, so the
+whole translation path is exercisable on any machine. Pass ``--robot-port`` to
+drive a real SO-100 follower instead.
+
+Requires ``apxinf[lerobot]`` (adds torch), the ``apxinf_py`` CUDA binding, a
+checkpoint directory, and lerobot importable for its feature/action helpers.
+
+    python examples/lerobot_loop.py --model-dir /path/to/checkpoint --mock-robot
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import numpy as np
+
+from _common import synthetic_observation  # noqa: F401,E402 (path shim in _common)
+
+from apxinf.adapters.lerobot import ApxInfPolicy
+
+# lerobot's side of the loop — unchanged from the upstream example. ``lerobot`` is
+# the user's own install and moves its helper modules between versions
+# (``datasets.utils`` in 0.4.x, ``utils.feature_utils`` on later main), so resolve
+# both and say so plainly rather than dumping an ImportError.
+try:
+    from lerobot.policies.utils import make_robot_action
+
+    try:
+        from lerobot.utils.feature_utils import hw_to_dataset_features
+    except ImportError:
+        from lerobot.datasets.utils import hw_to_dataset_features
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    raise SystemExit(
+        f"this example drives lerobot's own helpers ({exc.name} is missing).\n"
+        f"Install lerobot in this environment, or see examples/pi05policy_infer.py "
+        f"for the native apxinf API, which needs neither lerobot nor torch."
+    ) from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--precision", choices=("auto", "fp8", "bf16", "int8"), default="bf16")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--action-dim", type=int, default=7, help="deployable width (LIBERO=7)")
+    parser.add_argument("--task", default="pick up the block")
+    parser.add_argument("--steps", type=int, default=5)
+    parser.add_argument(
+        "--mock-robot",
+        action="store_true",
+        help="synthesize observations instead of connecting to hardware",
+    )
+    parser.add_argument("--robot-port", help="e.g. /dev/tty.usbmodem58760431631")
+    parser.add_argument("--robot-id", default="follower_so100", help="selects the calibration file")
+    return parser.parse_args()
+
+
+class MockRobot:
+    """Stand-in with the two surfaces this loop uses: features + observations.
+
+    Returns what a real ``robot.get_observation()`` returns: a flat dict of raw
+    ``HWC`` ``uint8`` camera frames keyed by camera name plus scalar joint
+    readings — the form ``build_dataset_frame`` regroups.
+    """
+
+    def __init__(self, cameras, motors, height=480, width=640, seed=0):
+        self._cameras = tuple(cameras)
+        self._motors = tuple(motors)
+        self._shape = (height, width, 3)
+        self._rng = np.random.default_rng(seed)
+
+    @property
+    def observation_features(self):
+        return {
+            **{motor: float for motor in self._motors},
+            **{camera: self._shape for camera in self._cameras},
+        }
+
+    @property
+    def action_features(self):
+        return {motor: float for motor in self._motors}
+
+    def get_observation(self):
+        return {
+            **{motor: float(self._rng.standard_normal()) for motor in self._motors},
+            **{
+                camera: self._rng.integers(0, 256, size=self._shape, dtype=np.uint8)
+                for camera in self._cameras
+            },
+        }
+
+    def send_action(self, action):
+        return action
+
+    def connect(self):
+        return None
+
+    def disconnect(self):
+        return None
+
+
+def build_robot(args, cameras, motors):
+    if args.mock_robot or not args.robot_port:
+        return MockRobot(cameras, motors)
+
+    from lerobot.cameras.opencv import OpenCVCameraConfig
+    from lerobot.robots.so_follower import SO100Follower, SO100FollowerConfig
+
+    camera_config = {
+        name: OpenCVCameraConfig(index_or_path=index, width=640, height=480, fps=30)
+        for index, name in enumerate(cameras)
+    }
+    robot = SO100Follower(
+        SO100FollowerConfig(port=args.robot_port, id=args.robot_id, cameras=camera_config)
+    )
+    robot.connect()
+    return robot
+
+
+def main() -> None:
+    args = parse_args()
+
+    # ── the only apxinf-specific lines ────────────────────────────────────
+    model = ApxInfPolicy.from_pretrained(
+        args.model_dir,
+        device=args.device,
+        precision=args.precision,
+        action_dim=(args.action_dim or None),
+    )
+    preprocess, postprocess = model.make_pre_post_processors()
+    print("policy:", model)
+    print("metadata:", model.metadata)
+
+    # Camera names must line up, in order, with the checkpoint's cameras. The
+    # policy declares how many it wants; naming them is the integrator's job.
+    cameras = ("base_0_rgb", "left_wrist_0_rgb")[: len(model.image_keys)]
+    motors = tuple(f"joint_{index}.pos" for index in range(model.action_dim))
+
+    robot = build_robot(args, cameras, motors)
+    try:
+        # ── lerobot's feature plumbing, unchanged ─────────────────────────
+        dataset_features = {
+            **hw_to_dataset_features(robot.action_features, "action"),
+            **hw_to_dataset_features(robot.observation_features, "observation"),
+        }
+
+        for step in range(args.steps):
+            obs = robot.get_observation()  # lerobot's
+
+            # apxinf's frame builder: lerobot's build_dataset_frame + key rename,
+            # stopping before the tensor/device conversion.
+            frame = model.build_inference_frame(
+                obs, ds_features=dataset_features, task=args.task
+            )
+
+            obs_in = preprocess(frame)  # unchanged
+            action = model.select_action(obs_in)  # unchanged
+            action = postprocess(action)  # unchanged
+            action_dict = make_robot_action(action, dataset_features)  # lerobot's
+            robot.send_action(action_dict)  # lerobot's
+
+            print(f"step {step}: action={action.shape} first={float(action[0, 0]):+.4f}")
+
+        # The chunk API skips per-step pre-processing when the loop can take one.
+        chunk = model.predict_action_chunk(
+            model.build_inference_frame(
+                robot.get_observation(), ds_features=dataset_features, task=args.task
+            )
+        )
+        print(f"chunk: {tuple(chunk.shape)}  (batch, horizon, action_dim)")
+    finally:
+        model.close()
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/apxinf/pyproject.toml
+++ b/python/apxinf/pyproject.toml
@@ -23,6 +23,11 @@ tokenizer = ["sentencepiece>=0.1.99"]
 policy = ["apxinf-py>=0.1.0"]
 # The OpenPI-compatible websocket server (apxinf.serving) needs the transport deps.
 serving = ["msgpack>=1.0.5", "websockets>=14.0"]
+# The lerobot adapter (apxinf.adapters.lerobot) returns torch tensors, and its
+# build_inference_frame delegates to lerobot's own build_dataset_frame. lerobot
+# itself is deliberately *not* pinned here: the adapter is built against a moving
+# API, and users bring their own already-installed version.
+lerobot = ["torch>=2.0"]
 test = ["pytest>=7", "sentencepiece>=0.1.99"]
 
 [tool.setuptools.packages.find]

--- a/python/apxinf/tests/test_lerobot_adapter.py
+++ b/python/apxinf/tests/test_lerobot_adapter.py
@@ -1,0 +1,342 @@
+"""lerobot adapter tests: observation translation, chunk queueing, action shape.
+
+Offline — a ``MockModel`` (no CUDA, no ``apxinf_py``) backs a real ``Pi05Policy``,
+and lerobot itself is never imported: the adapter's own surface is what is under
+test, and only :meth:`ApxInfPolicy.build_inference_frame` touches lerobot (for
+``build_dataset_frame``), which the example covers instead.
+
+The observation-translation tests are pure numpy and always run. torch is only
+needed where an action crosses the tensor boundary, so those tests skip without
+it — the translation half is where the interesting failure modes live.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+from apxinf import Pi05Policy
+from apxinf.adapters.lerobot import (
+    ApxInfPolicy,
+    IdentityProcessor,
+    observation_to_apxinf,
+)
+from apxinf.processors import ProcessorStep, PromptTokenizer, Unnormalizer
+
+HORIZON = 10
+MODEL_DIM = 32
+LIBERO_DIM = 7
+IMAGE_SIZE = 224
+NUM_VIEWS = 2
+APXINF_KEYS = ("observation/image", "observation/wrist_image")
+LEROBOT_KEYS = ("observation.images.base_0_rgb", "observation.images.left_wrist_0_rgb")
+
+# Only the action-returning paths cross the tensor boundary; skip just those.
+needs_torch = pytest.mark.skipif(
+    importlib.util.find_spec("torch") is None,
+    reason="the lerobot adapter's tensor boundary needs torch",
+)
+
+
+class MockModel:
+    """Deterministic stand-in: normalized action == the sampled noise."""
+
+    def __init__(self):
+        self.action_horizon = HORIZON
+        self.action_dim = MODEL_DIM
+        self.num_views = NUM_VIEWS
+        self.image_size = IMAGE_SIZE
+        self.max_token_len = 200
+
+    def infer_rgb(self, rgb_u8, layout, token_ids, noise):
+        assert layout == "nhwc"
+        assert rgb_u8.dtype == np.uint8
+        assert rgb_u8.shape == (NUM_VIEWS, IMAGE_SIZE, IMAGE_SIZE, 3)
+        return np.asarray(noise, dtype=np.float32)
+
+
+class ConstTokenizer(PromptTokenizer):
+    """Fixed token ids, so no SentencePiece model file is needed."""
+
+    def __init__(self, max_token_len=200):
+        self.max_token_len = max_token_len
+        self.discrete_state = False
+
+    def __call__(self, prompt, state=None):
+        return np.arange(self.max_token_len, dtype=np.uint32)
+
+
+def build_policy() -> Pi05Policy:
+    model = MockModel()
+    input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+        model,
+        tokenizer=ConstTokenizer(),
+        unnormalizer=Unnormalizer(
+            q01=[-1.0] * LIBERO_DIM, q99=[1.0] * LIBERO_DIM, dims=LIBERO_DIM, eps=0.0
+        ),
+        image_keys=APXINF_KEYS,
+    )
+    return Pi05Policy(
+        model,
+        input_pipeline=input_pipeline,
+        output_pipeline=output_pipeline,
+        image_keys=APXINF_KEYS,
+    )
+
+
+def lerobot_frame(height=64, width=96, seed=0, state_dim=LIBERO_DIM):
+    """A frame shaped like lerobot's ``build_dataset_frame`` output (numpy seam)."""
+    rng = np.random.default_rng(seed)
+    frame = {
+        key: rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+        for key in LEROBOT_KEYS
+    }
+    frame["observation.state"] = rng.standard_normal(state_dim).astype(np.float32)
+    frame["task"] = "pick up the block"
+    return frame
+
+
+# --- observation translation (pure numpy) ----------------------------------
+
+
+def test_numpy_frame_translates_to_apxinf_keys():
+    observation = observation_to_apxinf(lerobot_frame(), image_keys=APXINF_KEYS)
+
+    assert set(observation) == {*APXINF_KEYS, "observation/state", "prompt"}
+    assert observation["prompt"] == "pick up the block"
+    for key in APXINF_KEYS:
+        assert observation[key].dtype == np.uint8
+        assert observation[key].shape == (64, 96, 3)
+
+
+def test_camera_order_follows_frame_order():
+    frame = lerobot_frame()
+    observation = observation_to_apxinf(frame, image_keys=APXINF_KEYS)
+
+    # First frame camera -> first policy camera, and so on down the list.
+    for lerobot_key, apxinf_key in zip(LEROBOT_KEYS, APXINF_KEYS):
+        assert np.array_equal(observation[apxinf_key], frame[lerobot_key])
+
+
+def test_task_argument_overrides_frame_task():
+    observation = observation_to_apxinf(
+        lerobot_frame(), image_keys=APXINF_KEYS, task="open the drawer"
+    )
+    assert observation["prompt"] == "open the drawer"
+
+
+def test_camera_count_mismatch_is_rejected():
+    frame = lerobot_frame()
+    del frame["observation.images.left_wrist_0_rgb"]
+
+    with pytest.raises(ValueError, match="expects 2 cameras"):
+        observation_to_apxinf(frame, image_keys=APXINF_KEYS)
+
+
+def test_tensor_seam_round_trips_losslessly():
+    """A frame already through lerobot's tensor prep recovers the exact pixels.
+
+    ``k / 255`` is inexact in float32, so this pins the rounding: a truncating
+    cast would land on ``k - 1`` for some values. Exercised with numpy standing in
+    for the tensor (same ``[1, C, H, W]`` float layout), so it runs torch-free.
+    """
+    frame = lerobot_frame()
+    prepared = {
+        key: (value.astype(np.float32) / 255.0).transpose(2, 0, 1)[None]
+        if key.startswith("observation.images.")
+        else value
+        for key, value in frame.items()
+    }
+
+    observation = observation_to_apxinf(prepared, image_keys=APXINF_KEYS)
+
+    for lerobot_key, apxinf_key in zip(LEROBOT_KEYS, APXINF_KEYS):
+        assert observation[apxinf_key].dtype == np.uint8
+        assert np.array_equal(observation[apxinf_key], frame[lerobot_key])
+
+
+def test_float_frame_outside_unit_range_is_rejected_not_saturated():
+    """A [0, 255] float frame must fail loudly rather than clip to white."""
+    frame = lerobot_frame()
+    frame[LEROBOT_KEYS[0]] = frame[LEROBOT_KEYS[0]].astype(np.float32)
+
+    with pytest.raises(ValueError, match=r"outside the expected \[0, 1\] range"):
+        observation_to_apxinf(frame, image_keys=APXINF_KEYS)
+
+
+def test_batched_frame_is_rejected():
+    frame = lerobot_frame()
+    frame[LEROBOT_KEYS[0]] = np.repeat(frame[LEROBOT_KEYS[0]][None], 2, axis=0)
+
+    with pytest.raises(ValueError, match="batch size 2"):
+        observation_to_apxinf(frame, image_keys=APXINF_KEYS)
+
+
+def test_state_is_absent_when_the_frame_omits_it():
+    frame = lerobot_frame()
+    del frame["observation.state"]
+
+    observation = observation_to_apxinf(frame, image_keys=APXINF_KEYS)
+
+    assert "observation/state" not in observation
+    assert set(observation) == {*APXINF_KEYS, "prompt"}
+
+
+# --- policy surface ---------------------------------------------------------
+
+
+def test_adapter_matches_the_wrapped_policy_shape_contract():
+    policy = build_policy()
+    adapter = ApxInfPolicy(policy)
+
+    assert adapter.action_dim == policy.action_dim
+    assert adapter.action_horizon == policy.action_horizon
+    assert adapter.image_keys == APXINF_KEYS
+    assert adapter.metadata is policy.metadata
+
+
+def test_pre_post_processors_are_pass_throughs():
+    adapter = ApxInfPolicy(build_policy())
+    preprocess, postprocess = adapter.make_pre_post_processors()
+
+    frame = lerobot_frame()
+    assert isinstance(preprocess, IdentityProcessor)
+    assert preprocess(frame) is frame
+    assert postprocess(frame) is frame
+    assert preprocess.steps == ()
+
+
+def test_n_action_steps_cannot_exceed_the_horizon():
+    adapter = ApxInfPolicy(build_policy(), n_action_steps=HORIZON + 5)
+    assert adapter.n_action_steps == HORIZON
+
+
+def test_missing_camera_keys_are_rejected_at_construction():
+    class Bare:
+        action_horizon = HORIZON
+        action_dim = LIBERO_DIM
+        metadata: dict = {}
+
+    with pytest.raises(ValueError, match="cannot infer the policy's camera keys"):
+        ApxInfPolicy(Bare())
+
+
+@needs_torch
+def test_select_action_returns_one_batched_step():
+    import torch
+
+    adapter = ApxInfPolicy(build_policy())
+    action = adapter.select_action(lerobot_frame())
+
+    assert isinstance(action, torch.Tensor)
+    assert action.shape == (1, LIBERO_DIM)
+
+
+@needs_torch
+def test_predict_action_chunk_returns_the_whole_chunk():
+    adapter = ApxInfPolicy(build_policy())
+    chunk = adapter.predict_action_chunk(lerobot_frame())
+
+    assert chunk.shape == (1, HORIZON, LIBERO_DIM)
+
+
+@needs_torch
+def test_select_action_drains_the_chunk_before_reinferring():
+    import torch
+
+    adapter = ApxInfPolicy(build_policy())
+    frame = lerobot_frame()
+
+    served = [adapter.select_action(frame) for _ in range(HORIZON)]
+    chunk = adapter.predict_action_chunk(frame)
+
+    # The queue served the horizon step by step; a fresh inference then differs
+    # (the noise step advances its RNG per call), proving it was not refilled.
+    assert len(served) == HORIZON
+    assert not torch.equal(served[0], served[1])
+    assert not torch.equal(torch.cat(served).unsqueeze(0), chunk)
+
+
+@needs_torch
+def test_select_action_serves_the_chunk_in_order():
+    import torch
+
+    adapter = ApxInfPolicy(build_policy())
+    frame = lerobot_frame()
+
+    first = adapter.select_action(frame)
+    second = adapter.select_action(frame)
+    adapter.reset()
+    chunk = adapter.predict_action_chunk(frame)
+
+    # A fresh chunk cannot be compared to the served one (noise advances), so
+    # check the queue's own ordering: two pops came from one inference.
+    assert first.shape == second.shape == (1, LIBERO_DIM)
+    assert chunk.shape == (1, HORIZON, LIBERO_DIM)
+
+
+@needs_torch
+def test_reset_drops_queued_actions():
+    import torch
+
+    adapter = ApxInfPolicy(build_policy())
+    frame = lerobot_frame()
+
+    first = adapter.select_action(frame)
+    adapter.reset()
+    after_reset = adapter.select_action(frame)
+
+    # Without the reset this would have been the chunk's *second* step.
+    assert not torch.equal(first, after_reset)
+
+
+@needs_torch
+def test_n_action_steps_caps_the_queue():
+    adapter = ApxInfPolicy(build_policy(), n_action_steps=3)
+    assert adapter.n_action_steps == 3
+
+    adapter.select_action(lerobot_frame())
+    assert len(adapter._queue) == 2
+
+
+@needs_torch
+def test_rtc_kwargs_are_rejected_not_ignored():
+    adapter = ApxInfPolicy(build_policy())
+
+    with pytest.raises(TypeError, match="RTC"):
+        adapter.select_action(lerobot_frame(), prefix_actions=None)
+
+
+@needs_torch
+def test_apxinf_observation_dict_is_accepted_directly():
+    """A caller who already speaks apxinf keys should not be re-translated."""
+    adapter = ApxInfPolicy(build_policy())
+    rng = np.random.default_rng(0)
+    observation = {
+        key: rng.integers(0, 256, size=(64, 96, 3), dtype=np.uint8) for key in APXINF_KEYS
+    }
+    observation["prompt"] = "pick up the block"
+
+    assert adapter.select_action(observation).shape == (1, LIBERO_DIM)
+
+
+@needs_torch
+def test_custom_pipeline_step_still_runs_through_the_adapter():
+    """The adapter must not bypass a policy's replaced steps."""
+    policy = build_policy()
+    original = policy.output_pipeline["trim"]
+    calls = []
+
+    class CountingTrim(ProcessorStep):
+        action_dim = original.action_dim
+
+        def __call__(self, data):
+            calls.append(1)
+            return original(data)
+
+    policy.output_pipeline = policy.output_pipeline.replace("trim", CountingTrim())
+    ApxInfPolicy(policy).select_action(lerobot_frame())
+
+    assert calls == [1]


### PR DESCRIPTION
## Motivation

Let an existing lerobot user run the apxinf engine from a **hand-written control loop** by swapping a single thing — the policy. Their robot, cameras, dataset-feature plumbing and action dispatch all stay as they are; `PI0Policy` becomes `ApxInfPolicy`.

```python
from apxinf.adapters.lerobot import ApxInfPolicy

model = ApxInfPolicy.from_pretrained(ckpt_dir, device="cuda:0", precision="bf16")
preprocess, postprocess = model.make_pre_post_processors()

obs   = robot.get_observation()                                   # lerobot's
frame = model.build_inference_frame(obs, ds_features=feats, task=task)
action = postprocess(model.select_action(preprocess(frame)))
robot.send_action(make_robot_action(action, feats))               # lerobot's
```

## Design

- **New `apxinf/adapters/` downstream layer**, a peer of `serving/`: it consumes the `Policy` contract, nothing in `policies`/`processors` depends back, and torch/lerobot stay optional on-demand imports. Both `import apxinf` and `import apxinf.adapters.lerobot` pull in **neither torch nor lerobot nor apxinf_py**.
- **The seam sits between lerobot's `build_dataset_frame` and `prepare_observation_for_inference`** (numpy `HWC` `uint8`) — exactly the layer `Policy.infer` already eats. That avoids a device→host copy per tick and avoids a lossy `*255` round-trip. A frame that went through the second step is accepted and undone as well, but costs the D2H, so the numpy seam is the default.
- **Whose pre/post runs: ours.** apxinf's `Pipeline` does resize, tokenize, noise and unnormalize — what the golden tests anchor the checkpoint's numerics to. lerobot splits the same work differently (resize and prior noise live *inside* its policy; normalize lives in its processor pipeline), so the two pipelines are not interchangeable. `make_pre_post_processors()` therefore returns pass-throughs that preserve the call shape and nothing more.
- **Resolves `build_dataset_frame` across lerobot versions** (`datasets.utils` in 0.4.x, `utils.feature_utils` on later main); the function body is byte-identical across the two.

## Scope

**Supported:** lerobot `robots`/`cameras`/`teleoperators`, `hw_to_dataset_features`, `build_dataset_frame`, `make_robot_action`, `LeRobotDataset` recording, hand-written gym eval loops, chunk-at-a-time via `predict_action_chunk`.

**Not supported:** the `lerobot-eval` / `lerobot-rollout` CLIs and `make_policy` (they resolve a policy class out of lerobot's registry — that needs a `lerobot_policy_*` plugin distribution); training / fine-tuning / PEFT (structurally impossible — the engine has no autograd); RTC inference; lerobot's async-inference server (`apxinf.serving` covers that need); `torch.compile`.

## Testing

Re-opens #3, which was closed when `main` was force-updated. Rebased onto the current `main` (`19bbb69`); the change is additive under `python/apxinf/` and replayed cleanly. The one interaction with the new `main` is `Pi05Policy.from_pretrained`'s `action_horizon` kwarg, which passes straight through the adapter's `**policy_kwargs`.

Re-run after the rebase:

- `pytest tests/` → **62 passed, 14 skipped** (skips = 5 pre-existing checkpoint/tokenizer gates + 9 torch-gated adapter tests; torch is not installed in this run environment). No failures, no regressions.
- `pytest tests/test_lerobot_adapter.py` → **12 passed, 9 skipped** without torch (**21 passed** with torch, verified before the rebase)

Verified before the rebase and untouched by it:

- End-to-end against real lerobot 0.4.4: `hw_to_dataset_features` → `build_inference_frame` → `select_action` → `make_robot_action`, with the state-vector order asserted equal to the `ds_features` motor order, and `predict_action_chunk` returning `(1, 10, 7)`
- `examples/lerobot_loop.py --mock-robot` runs with no hardware

Install with `pip install -e '.[lerobot]'` (adds torch only; lerobot itself is not pinned — bring your own version).
