### PR TITLE
Make the served embodiment an explicit launch flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,15 @@ subprocess), so activate the environment built in
 source .venv/bin/activate
 ```
 
+`--robot` selects the **embodiment** — the camera wire keys, the state routing,
+and the deployable action width — the way OpenPI's `serve_policy.py
+--policy.config <TrainConfig>` does. It defaults to `franka_libero`; a checkpoint
+fine-tuned for another robot must name its own preset, because a mismatch
+degrades silently rather than failing. `--help` lists every registered preset
+with its slot→key mapping. See
+[Adding an embodiment](doc/adding-an-embodiment.md) for the full launch guide and
+for how to register a new robot.
+
 Start FP8 on port 8000:
 
 ```bash

--- a/crates/apxinf-py/apxinf_py.pyi
+++ b/crates/apxinf-py/apxinf_py.pyi
@@ -18,15 +18,20 @@ class Model:
         precision: str = ...,
         calibration: str | None = ...,
         tactics: str | None = ...,
+        action_horizon: int | None = ...,
         num_views: int | None = ...,
+        sampling_seed: int = ...,
     ) -> "Model":
         """Load a checkpoint through the unified ``AutoModel`` frontend.
 
         ``device`` is ``cuda:N`` (default) or ``cpu``.
         ``precision`` is ``auto`` (default), ``fp8``, ``bf16``, or ``int8``.
+        ``action_horizon`` overrides the checkpoint's chunk length (a sequence
+        length, not a weight dimension).
         ``num_views`` serves fewer cameras than the checkpoint declares (1..=its
         own count), which is numerically equivalent to openpi padding + masking
         the absent views but skips their patch tokens.
+        ``sampling_seed`` seeds the implicit device-side noise stream.
         """
         ...
 

--- a/crates/apxinf-py/apxinf_py.pyi
+++ b/crates/apxinf-py/apxinf_py.pyi
@@ -18,11 +18,15 @@ class Model:
         precision: str = ...,
         calibration: str | None = ...,
         tactics: str | None = ...,
+        num_views: int | None = ...,
     ) -> "Model":
         """Load a checkpoint through the unified ``AutoModel`` frontend.
 
         ``device`` is ``cuda:N`` (default) or ``cpu``.
         ``precision`` is ``auto`` (default), ``fp8``, ``bf16``, or ``int8``.
+        ``num_views`` serves fewer cameras than the checkpoint declares (1..=its
+        own count), which is numerically equivalent to openpi padding + masking
+        the absent views but skips their patch tokens.
         """
         ...
 

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -245,8 +245,17 @@ impl Model {
     ///   (default) runs the native `config.json` value; an explicit value wins
     ///   over it. The horizon is a sequence length, not a weight dimension, so
     ///   the same weights load and run at the requested chunk length.
+    /// * `num_views` — serve fewer cameras than the checkpoint declares.
+    ///
+    /// `num_views` exists because a deployment often has fewer cameras than the
+    /// checkpoint was trained with. Dropping the trailing views is numerically
+    /// equivalent to openpi zero-padding and masking them — a masked view is
+    /// excluded from attention and consumes no RoPE position, and the vision
+    /// tower has no per-slot parameters — while saving one view's worth of patch
+    /// tokens per step. Nothing weight-shaped depends on the count; it only sizes
+    /// the prefix, so this is a load-time constant, not a per-request one.
     #[staticmethod]
-    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, action_horizon=None, sampling_seed=0))]
+    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, action_horizon=None, num_views=None, sampling_seed=0))]
     fn load(
         model: &str,
         path: PathBuf,
@@ -255,6 +264,7 @@ impl Model {
         calibration: Option<PathBuf>,
         tactics: Option<PathBuf>,
         action_horizon: Option<usize>,
+        num_views: Option<usize>,
         sampling_seed: u64,
     ) -> PyResult<Self> {
         let device = parse_device(device)?;
@@ -262,14 +272,28 @@ impl Model {
         // Only hand the loader an explicit config when the caller actually
         // overrode something; otherwise it reads `config.json` itself, exactly
         // as before.
-        let overridden = match action_horizon {
-            Some(horizon) => {
-                config.action_horizon = horizon;
-                config.validate().map_err(runtime_err)?;
-                true
+        let mut overridden = false;
+        if let Some(horizon) = action_horizon {
+            config.action_horizon = horizon;
+            overridden = true;
+        }
+        if let Some(views) = num_views {
+            if views == 0 || views > config.num_views {
+                return Err(PyValueError::new_err(format!(
+                    "apxinf_py.load: num_views={views} must be in 1..={} (the \
+                     checkpoint's view count); a checkpoint cannot serve more \
+                     cameras than it was trained on",
+                    config.num_views
+                )));
             }
-            None => false,
-        };
+            config.num_views = views;
+            overridden = true;
+        }
+        // Validate once, after every override, so a combination that is
+        // individually valid but jointly is not still fails here.
+        if overridden {
+            config.validate().map_err(runtime_err)?;
+        }
         let options = LoadOptions {
             model_name: Some(model.to_owned()),
             precision: parse_precision(precision)?,

--- a/doc/adding-a-new-model.md
+++ b/doc/adding-a-new-model.md
@@ -4,7 +4,10 @@ Use this guide after the reference model runs and its semantics are understood.
 Follow [the porting workflow](porting-workflow.md) for evidence and acceptance,
 [the model-layer architecture](model-layer-architecture.md) for ownership and
 dependencies, and [the kernel guide](adding-new-kernels.md) for genuine backend
-gaps.
+gaps. For a VLA, [adding an embodiment](adding-an-embodiment.md) covers the
+Python-side serving contract this guide leaves to the policy layer: which
+observation keys a client sends, how state is routed, and how to register a new
+robot.
 
 ## Start with a separate model directory
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -1,0 +1,378 @@
+# Adding an Embodiment to ApxInf
+
+A guide for serving a new robot through the OpenPI-compatible websocket API, and
+for launching a server against an embodiment that already exists. Written after
+the Unitree G1 port; every claim here is grounded in code that runs.
+
+The companion doc for the *model* side is
+[`doc/adding-a-new-model.md`](adding-a-new-model.md). That one is about weights
+and kernels. This one is about the **wire contract**: which keys the client
+sends, how state is routed, and what the action vector means when it comes back.
+
+## Why this is a table and not a default
+
+A pi05 checkpoint does not carry its wire contract. The weights fix the view
+count and the action width; they say nothing about whether the base camera
+arrives as `observation/image` or as `obs["images"]["cam_high"]`, whether the
+state vector is discretized into the prompt or dropped, or whether the 32-wide
+model output should be truncated to 7 or to 16.
+
+Before presets, `Pi05Policy`'s LIBERO defaults applied to *every* checkpoint. A
+G1 checkpoint served with no extra arguments ran LIBERO's keys, dropped state,
+and skipped the G1 delta→absolute and 32→16 steps. Nothing failed. Nothing
+logged. It looked exactly like a "model accuracy problem."
+
+So the embodiment is a named, explicit launch flag on both sides — the same shape
+OpenPI uses, so the two line up one-to-one:
+
+```
+openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
+apxinf:  pi05_openpi_websocket_server.py --robot unitree_g1
+```
+
+## Three namespaces, kept separate
+
+Most confusion in this area comes from collapsing these. They are different
+things and they never need to be equal.
+
+| | what it is | where it lives | on the wire? |
+|---|---|---|---|
+| **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `robots/presets.py` | never — the *order* is baked into the weights |
+| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `slots` | yes — this is what the client sends |
+| **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
+
+A preset pairs each view slot with the wire key that fills it. `image_keys` is
+order-significant: entry *i* is stacked into model view slot *i*. A tuple written
+in the wrong order still stacks, still has the right shape, and silently feeds
+the wrong camera to each slot — pairing every key with its slot makes that
+reviewable instead of positional.
+
+## Launching a server for an existing embodiment
+
+`--robot` is the only flag that has to be right. It selects the wire keys, the
+state routing, the action width, and the robot pre/post steps together.
+
+```bash
+# Franka Panda under LIBERO's key convention (the default)
+python3 scripts/pi05_openpi_websocket_server.py \
+  --model-dir "$APXINF_MODEL_DIR" \
+  --robot franka_libero \
+  --precision bf16 --host 0.0.0.0 --port 8000
+
+# Unitree G1: 3 cameras, nested keys, state discretized into the prompt
+python3 scripts/pi05_openpi_websocket_server.py \
+  --model-dir "$G1_MODEL_DIR" \
+  --robot unitree_g1 \
+  --precision bf16 --host 0.0.0.0 --port 8000
+```
+
+`--robot` defaults to `franka_libero`, so an existing LIBERO launch command needs
+no change. `python3 scripts/pi05_openpi_websocket_server.py --help` prints every
+registered preset with its slot→key mapping.
+
+### Confirm the contract before trusting the numbers
+
+The server logs what it ended up serving and publishes the same thing in its
+connect-time metadata. Read one of them **before** concluding anything about
+accuracy:
+
+```
+INFO serving robot=unitree_g1 H=50 x D=32
+     image_keys=['images/cam_high', 'images/cam_left_wrist', 'images/cam_right_wrist']
+     state=state discrete_state=False
+```
+
+From a client:
+
+```python
+from openpi_client import websocket_client_policy as wcp
+c = wcp.WebsocketClientPolicy(host="127.0.0.1", port=8000)
+meta = c.get_server_metadata()
+assert meta["robot"] == "unitree_g1"
+assert meta["image_keys"] == [...]      # the keys you are actually sending
+assert meta["discrete_state"] is True   # a joint-space robot needs this on
+```
+
+Published keys: `robot`, `robot_slots`, `model_type`, `image_keys`, `state_key`,
+`prompt_key`, `discrete_state`, `state_normalized`, `action_horizon`,
+`action_dim`, `model_action_dim`, `num_views`, `image_size`, `input_pipeline`,
+`output_pipeline`. A key mismatch is invisible on the wire but obvious here.
+
+### Per-field overrides
+
+A deployed client may already speak a fixed dialect that does not match any
+preset. Override the individual field rather than editing the preset:
+
+```bash
+python3 scripts/pi05_openpi_websocket_server.py \
+  --model-dir "$APXINF_MODEL_DIR" --robot franka_libero \
+  --image-keys 'observation/exterior_image_1_left,observation/wrist_image_left' \
+  --state-key 'observation/joint_position'
+```
+
+Nested layouts are written as a slash path: `--image-keys
+'images/cam_high,images/cam_left_wrist'`. `--discrete-state` /
+`--no-discrete-state` and `--action-dim` override the remaining fields.
+
+If you find yourself passing the same overrides twice, that is the signal to add
+a preset.
+
+### Serving fewer cameras than the checkpoint declares
+
+```bash
+python3 scripts/pi05_openpi_websocket_server.py \
+  --model-dir "$APXINF_MODEL_DIR" --robot franka_libero \
+  --image-keys 'observation/image' --num-views 1 \
+  --precision bf16 --port 8000
+```
+
+This drops the trailing view slots at **load** time. It is numerically equivalent
+to what OpenPI does by zero-padding the absent views and masking them out —
+masked tokens consume no RoPE position (`positions = cumsum(input_mask) - 1`),
+are excluded from attention (`valid_mask = mask[:, None, :] * mask[:, :, None]`),
+and `embed_prefix` runs the same `PaliGemma.img` encoder per view with no
+per-slot learned embedding. `num_views` only sizes the prefix; nothing
+weight-shaped depends on it. The difference is that we skip the ~256 patch tokens
+per absent view instead of computing and discarding them (measured 1.38× on a
+2-view LIBERO checkpoint served with one camera, on Orin).
+
+**`--num-views` is deliberately required to be explicit.** A short `--image-keys`
+list on its own is an error, not an inference. Forgetting a camera key should
+fail at startup, not quietly cost accuracy — which is the exact failure mode this
+whole mechanism exists to prevent. It is a server-side launch flag, not part of
+the wire protocol, so an unmodified openpi client is unaffected.
+
+## Adding a new embodiment
+
+### Step 0 — write down the contract
+
+Before any code, get these seven facts from the OpenPI `TrainConfig` the
+checkpoint was fine-tuned under (its `data_transforms` pair is the source of
+truth):
+
+1. camera wire keys, **in view-slot order**, and whether they are flat or nested;
+2. the state wire key;
+3. whether state is discretized into the prompt or dropped;
+4. state width and layout;
+5. model action width vs. deployable action width;
+6. whether actions are deltas needing the current state to resolve;
+7. any robot-space convention (joint sign flips, gripper mapping).
+
+Facts 1–5 are just a table row. Facts 6–7 are the only ones that need code.
+
+### Step 1 — decide whether you need robot steps at all
+
+| the checkpoint… | what to write |
+|---|---|
+| emits absolute actions in robot space, at the deployable width | **nothing** — a preset row is the whole port |
+| needs a fixed truncation only | a preset row with `action_dim=N` |
+| emits deltas, or needs a sign/gripper convention | processing steps + an adapter (Steps 2–3) |
+
+Take the cheap path when it is available. `franka_libero` is a table row and
+nothing else.
+
+### Step 2 — robot processing steps
+
+`python/apxinf/apxinf/processors/robots/<robot>.py`. Each step is a
+`ProcessorStep`: `dict -> dict` over the shared data dict, with a name. These
+must be **model-agnostic** — they reference no policy symbols and vary only with
+the robot body.
+
+The data-dict contract:
+
+* input chain reads `observation` / `prompt`, writes `rgb` (uint8 NHWC),
+  `token_ids` (uint32), `noise`;
+* output chain reads `normalized_actions`, writes `trimmed` then `actions`
+  (unnormalized float32). `observation` is threaded through so an output step can
+  read state.
+
+Resolve every wire key through `lookup_key` / `has_key` / `set_key` from
+`processors/transforms.py` rather than indexing the observation directly. They
+resolve **flat first, then as a nested path**, so one flat key string addresses
+either layout: `"observation/image"` hits `data["observation/image"]` if that key
+literally exists, and `"images/cam_high"` walks
+`data["images"]["cam_high"]` when it does not. `set_key` returns a copy — the
+client's dict is never mutated.
+
+Write each step as a no-op when its input is absent. `UnitreeG1DecodeState`
+returns `data` unchanged when there is no state, so state-off serving degrades to
+"this step does nothing" instead of raising deep in the pipeline.
+
+### Step 3 — the adapter
+
+`python/apxinf/apxinf/robots/<robot>.py`. One factory that loads the checkpoint
+through the generic `Pi05Policy.from_pretrained` and then splices the robot steps
+into the default pipelines:
+
+```python
+def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **kwargs):
+    base = Pi05Policy.from_pretrained(
+        model_dir,
+        image_keys=tuple(image_keys),
+        action_dim=None,      # keep full model width; the encode step truncates
+        state_key=state_key,
+        **kwargs,
+    )
+    input_pipeline = base.input_pipeline.insert_before(
+        "tokenize", ("<robot>_decode_state", <Robot>DecodeState(state_key))
+    )
+    output_pipeline = Pipeline([
+        ("unnormalize", base.output_pipeline["unnormalize"]),
+        ("<robot>_absolute", <Robot>AbsoluteActions(state_key)),
+        ("<robot>_encode", <Robot>EncodeActions()),
+    ])
+    return Pi05Policy(base.model, input_pipeline=..., output_pipeline=..., ...)
+```
+
+Two orderings matter and are easy to get wrong:
+
+* the decode-state step goes **before** `tokenize`, so discretized state (when
+  on) and the delta→absolute output step both see the decoded state;
+* unnormalize runs at **full model width**, before any truncation, so
+  delta→absolute sees the whole action. Pass `action_dim=None` into
+  `from_pretrained` and let the encode step truncate.
+
+### Step 4 — register the preset
+
+One entry in `python/apxinf/apxinf/robots/presets.py`. This is the whole
+registration step — OpenPI's `training/config.py` equivalent.
+
+```python
+MY_ROBOT = RobotPreset(
+    name="myarm_mydataset",
+    slots=(
+        ("base_0_rgb", "observation/image"),
+        ("left_wrist_0_rgb", "observation/wrist_image"),
+    ),
+    state_key="observation/state",
+    action_dim=7,               # None keeps full width when an encode step truncates
+    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
+    builder=build_my_robot_policy,   # omit for the stock policy
+    summary="MyArm, MyDataset keys: 2 cameras, 7-dim action",
+    builder_kwargs={},          # constants the builder always receives
+)
+
+ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
+```
+
+`__post_init__` rejects a `slots` tuple that is not an in-order prefix of
+`VIEW_SLOTS`, and rejects duplicate wire keys. A checkpoint fills view slots from
+0 up, so there is no way to spell "wrist camera only" other than putting it in
+slot 0.
+
+Add an entry to `ROBOT_ALIASES` if a deployment already says something else in
+its launch scripts; a rename should not break a running system.
+
+### Naming: `<arm>_<key convention>`
+
+The arm alone does not determine the contract. LIBERO and DROID are both Franka
+Panda, yet LIBERO sends `observation/image` with a 7-dim EEF-delta action while
+DROID sends `observation/exterior_image_1_left` with a different action space. So
+a preset is named for the arm **and** the dataset convention whose keys it
+implements: `franka_libero`, not `libero` (a benchmark, not a robot) and not
+`franka` (ambiguous). A single-embodiment robot that owns its convention needs no
+suffix — `unitree_g1`.
+
+### Step 5 — tests
+
+Add to `tests/test_robot_presets.py`. Four things are worth asserting, and they
+run on CPU with a mock model — no GPU, no checkpoint:
+
+1. **the preset matches the openpi transform it mirrors** — keys, order, widths,
+   `discrete_state`, spelled out literally rather than derived;
+2. **an unmodified openpi client round-trips** — `UnitreeG1ServingTest` starts
+   the real `WebsocketPolicyServer` on a mock model and sends the observation the
+   integrator's client actually sends;
+3. **the wrong dialect fails loudly** — a LIBERO-shaped observation against your
+   server must raise, naming the served `image_keys`;
+4. **slot order is load-bearing** — reordering `image_keys` reorders the stacked
+   views (`ImageSlotOrderTest` asserts this against the tensor, not the metadata).
+
+```bash
+python3 tests/test_robot_presets.py          # no GPU needed
+```
+
+## Verification recipe
+
+Offline first, then one GPU pass. In order, because each step localizes a
+different class of bug:
+
+```bash
+# 1. contract + plumbing, CPU only, mock model
+python3 tests/test_robot_presets.py
+
+# 2. real checkpoint, native contract
+python3 scripts/pi05_openpi_websocket_server.py \
+  --model-dir "$CKPT" --robot <preset> --precision bf16 --port 8000
+#    -> read the "serving robot=..." line; assert every field
+
+# 3. real transport, unmodified openpi client
+#    -> assert actions.shape == (meta["action_horizon"], meta["action_dim"])
+#    -> assert np.isfinite(actions).all()
+
+# 4. wrong-dialect rejection: send another preset's keys; it must raise
+```
+
+Step 3's shape assertion should read the shape **off the metadata**, not off a
+constant. A hard-coded expected shape tests your memory of the checkpoint rather
+than the server.
+
+For a transport-only check with no weights on disk, `--random-weights --robot
+<preset>` serves the preset's key layout on synthetic weights. Its actions are
+numerically meaningless, and it cannot honour `discrete_state=True` (the
+synthetic tokenizer never reads state) — it warns at startup when you ask it to.
+
+## Gotchas we hit
+
+1. **`discrete_state=False` drops state; it does not pass it through raw.**
+   There is no third state. A joint-space robot served with `discrete_state=False`
+   loses its proprioception silently, which also makes any delta→absolute step a
+   no-op (a delta cannot be resolved without current joint positions).
+2. **`image_keys` order is the view slot order.** Wrong order → right shape,
+   wrong cameras, no error. This is why presets pair keys with slot names.
+3. **Truncate after unnormalize, not before.** Unnormalize at full model width so
+   the delta→absolute step sees the whole action; let the robot encode step do
+   the 32→16.
+4. **`action_dim` in a preset is the *deployable* width, not the model's.**
+   `None` is correct when a robot output step does the truncation itself —
+   metadata still reports both (`action_dim` and `model_action_dim`).
+5. **Nested keys need `lookup_key`, not `obs[k]`.** Both wire shapes exist in the
+   wild and arrive as one string. Indexing directly works for LIBERO and raises
+   for G1.
+6. **A preset's `num_views` must equal the checkpoint's**, unless you pass
+   `--num-views` to load fewer. `Pi05Policy.default_pipelines` rejects a mismatch
+   and names the fix in the message.
+7. **`--random-weights` cannot preview a `discrete_state=True` contract.** Its
+   synthetic tokenizer ignores state, so the published metadata says
+   `discrete_state=False` — truthful about that server, misleading as a preview.
+   It warns; use a checkpoint for a real contract check.
+8. **Metadata is the contract; assert it from the client.** Every silent failure
+   in this area is visible in the connect-time metadata one line before it
+   becomes an "accuracy problem."
+
+## Rules
+
+1. **The embodiment is explicit, never inferred.** No preset is guessed from the
+   checkpoint, and `--num-views` is not inferred from `len(image_keys)`. An
+   omission should fail at startup.
+2. **Robot steps are model-agnostic; adapters are where they meet a policy.**
+   `processors/robots/` imports no policy symbols; `robots/` does the assembly.
+3. **Fail loudly with the served contract in the message.** Every error in this
+   layer names what the server is actually serving, because the person reading it
+   is comparing two dialects.
+4. **A preset row is the cheapest port; prefer it.** Only write steps for a
+   convention the model output genuinely does not satisfy.
+5. **Overrides exist for deployed clients, not for new robots.** If the same
+   `--image-keys` shows up twice, add a preset.
+
+## Concrete example
+
+The Unitree G1 port is the reference implementation — it exercises every step,
+including the ones `franka_libero` skips:
+
+- `python/apxinf/apxinf/robots/presets.py` — the registry and both presets
+- `python/apxinf/apxinf/processors/robots/unitree_g1.py` — decode-state,
+  delta→absolute, 32→16 encode
+- `python/apxinf/apxinf/robots/unitree_g1.py` — the adapter that splices them in
+- `python/apxinf/apxinf/processors/transforms.py` — `lookup_key`/`has_key`/`set_key`
+- `tests/test_robot_presets.py` — contract, serving, and slot-order tests

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -35,7 +35,14 @@ from __future__ import annotations
 
 from . import processors
 from .policies import AutoPolicy, Pi05Policy, Policy
-from .robots import build_unitree_g1_policy
+from .robots import (
+    ROBOT_PRESETS,
+    RobotPreset,
+    available_robots,
+    build_robot_policy,
+    build_unitree_g1_policy,
+    get_robot_preset,
+)
 from .processors import (
     GaussianNoise,
     Normalizer,
@@ -56,6 +63,12 @@ __all__ = [
     "AutoPolicy",
     # robot adapters
     "build_unitree_g1_policy",
+    # robot presets (embodiment -> wire keys + pipelines), openpi's TrainConfig analogue
+    "RobotPreset",
+    "ROBOT_PRESETS",
+    "available_robots",
+    "get_robot_preset",
+    "build_robot_policy",
     # bindings (lazy)
     "Model",
     # processor steps

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -143,17 +143,30 @@ class Pi05Policy:
     ) -> Tuple[Pipeline, Pipeline]:
         """Assemble the default ``(input_pipeline, output_pipeline)`` from parts.
 
-        pi05 runs the exact camera set the checkpoint declares (``model.num_views``,
-        parsed from the config's ``input_features``). The task's ``image_keys`` must
-        name precisely those cameras — no more, no fewer. Absent cameras are never
-        sent, so there is no padding: the model runs the real view shape directly.
+        pi05 runs the exact camera set the model was loaded for
+        (``model.num_views``, parsed from the config's ``input_features``). The
+        task's ``image_keys`` must name precisely those cameras — no more, no
+        fewer. Absent cameras are never sent, so there is no padding: the model
+        runs the real view shape directly.
+
+        A deployment with *fewer* cameras than the checkpoint declares is served
+        by loading with ``num_views=`` (``--num-views`` on the server), which
+        drops the trailing view slots at load time rather than zero-filling them
+        per request.
         """
         image_keys = tuple(image_keys)
         if len(image_keys) != model.num_views:
+            fix = (
+                f"load with num_views={len(image_keys)} to serve fewer cameras "
+                "than the checkpoint declares"
+                if len(image_keys) < model.num_views
+                else "a checkpoint cannot serve more cameras than it was trained on"
+            )
             raise ValueError(
                 f"Pi05Policy: model expects {model.num_views} camera views but "
                 f"{len(image_keys)} image_keys were given: {image_keys}. Supply "
-                f"exactly the checkpoint's cameras (real views only, no padding)."
+                f"exactly the loaded model's cameras (real views only, no "
+                f"padding), or {fix}."
             )
         image_pipeline = image_pipeline or Pipeline(
             [("parse", ParseImage()), ("resize", ResizeWithPad(model.image_size))]
@@ -199,6 +212,7 @@ class Pi05Policy:
         image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
         prompt_key: str = _PROMPT_KEY,
         state_key: str = _STATE_KEY,
+        num_views: Optional[int] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "Pi05Policy":
         """Build the **default** policy from a checkpoint directory.
@@ -221,6 +235,13 @@ class Pi05Policy:
         ``norm_stats[state_norm_key]`` to map raw state to ``[-1, 1]`` before it is
         discretized into the prompt.
 
+        ``num_views`` loads the checkpoint for fewer cameras than it declares, for
+        a deployment that has fewer. It must equal ``len(image_keys)``. This drops
+        the trailing view slots at load time instead of zero-filling them per
+        request, which is numerically equivalent to openpi's padding + masking
+        (a masked view is excluded from attention, occupies no RoPE position, and
+        the vision tower has no per-slot parameters) and skips their patch tokens.
+
         For a **fully custom** pre/post chain, do not funnel it through here:
         build the parts yourself and use :meth:`default_pipelines` +
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
@@ -238,6 +259,7 @@ class Pi05Policy:
                 **({"calibration": str(calibration)} if calibration else {}),
                 **({"tactics": str(tactics)} if tactics else {}),
                 **({"action_horizon": int(action_horizon)} if action_horizon else {}),
+                **({"num_views": int(num_views)} if num_views is not None else {}),
                 sampling_seed=int(seed),
             )
         elif action_horizon is not None and int(action_horizon) != int(model.action_horizon):
@@ -247,6 +269,14 @@ class Pi05Policy:
                 f"Pi05Policy.from_pretrained: action_horizon={action_horizon} conflicts "
                 f"with the supplied model's horizon {model.action_horizon}; pass the "
                 f"override to the model constructor instead"
+            )
+        elif num_views is not None and num_views != model.num_views:
+            # An already-loaded handle has its view count baked in; silently
+            # ignoring the argument would serve a different shape than requested.
+            raise ValueError(
+                f"Pi05Policy.from_pretrained: num_views={num_views} but the model "
+                f"passed in was loaded with {model.num_views}; pass num_views to "
+                "the load call instead"
             )
 
         tokenizer = PromptTokenizer(

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -64,6 +64,8 @@ from ...processors.transforms import (
     RGB,
     TOKEN_IDS,
     Unnormalize,
+    has_key,
+    lookup_key,
 )
 from ..registry import register_policy
 
@@ -115,6 +117,8 @@ class Pi05Policy:
             "num_views": model.num_views,
             "image_size": [model.image_size, model.image_size],
             "image_keys": list(self.image_keys),
+            "state_key": self.state_key,
+            "prompt_key": self.prompt_key,
             "discrete_state": self.discrete_state,
             "state_normalized": state_normalized,
             "input_pipeline": input_pipeline.names,
@@ -364,7 +368,7 @@ class Pi05Policy:
             raise TypeError(f"observation must be a mapping, got {type(observation)!r}")
         self._require_keys(observation)
 
-        prompt = observation[self.prompt_key]
+        prompt = lookup_key(observation, self.prompt_key)
         if not isinstance(prompt, str):
             raise TypeError(f"{self.prompt_key} must be a string, got {type(prompt)!r}")
 
@@ -439,13 +443,29 @@ class Pi05Policy:
     # --- helpers -----------------------------------------------------------
 
     def _require_keys(self, observation: Mapping[str, Any]) -> None:
+        """Reject an observation the configured pipeline cannot read.
+
+        Only the *configured* keys are required; any extra key the client sends
+        is ignored (openpi behaves the same). Each is resolved through
+        :func:`~apxinf.processors.transforms.lookup_key`, so a nested
+        ``{"images": {"cam_high": ...}}`` layout satisfies ``"images/cam_high"``.
+        The error names the served keys, because a key mismatch is the single
+        most common integration failure and the client cannot see our config
+        except through ``metadata``.
+        """
         required = list(self.image_keys) + [self.prompt_key]
         if self.discrete_state:
             # State is only mandatory when it is actually injected into the prompt.
             required.append(self.state_key)
-        missing = [key for key in required if key not in observation]
+        missing = [key for key in required if not has_key(observation, key)]
         if missing:
-            raise KeyError(f"Pi05Policy.infer: missing observation keys: {missing}")
+            raise KeyError(
+                f"Pi05Policy.infer: missing observation keys: {missing}. "
+                f"This policy serves image_keys={list(self.image_keys)}, "
+                f"prompt_key={self.prompt_key!r}"
+                + (f", state_key={self.state_key!r}" if self.discrete_state else "")
+                + f"; the observation has {sorted(observation)}."
+            )
 
     @staticmethod
     def _find_step(pipeline: Pipeline, name: str):

--- a/python/apxinf/apxinf/processors/__init__.py
+++ b/python/apxinf/apxinf/processors/__init__.py
@@ -12,7 +12,7 @@ from .noise import GaussianNoise
 from .normalize import Normalizer, Unnormalizer, load_norm_stats
 from .resize import ParseImage, ResizeWithPad
 from .tokenize import PromptTokenizer, SyntheticTokenizer, build_prompt, discretize_state
-from .transforms import ImageStack, SampleNoise, Tokenize, Trim
+from .transforms import ImageStack, SampleNoise, Tokenize, Trim, has_key, lookup_key, set_key
 from .transforms import Unnormalize as UnnormalizeStep
 
 __all__ = [
@@ -31,6 +31,9 @@ __all__ = [
     # dict->dict steps for a policy's pre/post pipeline
     "ImageStack",
     "Tokenize",
+    "lookup_key",
+    "has_key",
+    "set_key",
     "SampleNoise",
     "Trim",
     "UnnormalizeStep",

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -38,20 +38,28 @@ from typing import Any, MutableMapping
 import numpy as np
 
 from ..base import ProcessorStep
-from ..transforms import ACTIONS, OBSERVATION
+from ..transforms import ACTIONS, OBSERVATION, lookup_key, set_key
 
 __all__ = [
     "UnitreeG1DecodeState",
     "UnitreeG1AbsoluteActions",
     "UnitreeG1EncodeActions",
     "G1_CAMERAS",
+    "G1_STATE_KEY",
     "G1_ROBOT_DIM",
     "G1_DELTA_MASK",
 ]
 
-#: G1 camera keys, ordered base / left-wrist / right-wrist to match the model's
-#: view slots (openpi ``base_0_rgb`` / ``left_wrist_0_rgb`` / ``right_wrist_0_rgb``).
-G1_CAMERAS = ("cam_high", "cam_left_wrist", "cam_right_wrist")
+#: G1 camera **wire keys**, ordered base / left-wrist / right-wrist to match the
+#: model's view slots (openpi ``base_0_rgb`` / ``left_wrist_0_rgb`` /
+#: ``right_wrist_0_rgb``). These are the keys an unmodified openpi G1 client
+#: sends, i.e. the nested ``obs["images"]["cam_high"]`` layout, spelled as a path
+#: for :func:`~apxinf.processors.transforms.lookup_key`.
+G1_CAMERAS = ("images/cam_high", "images/cam_left_wrist", "images/cam_right_wrist")
+
+#: G1 state wire key. openpi's G1 client sends a flat top-level ``"state"``, not
+#: LIBERO's ``"observation/state"``.
+G1_STATE_KEY = "state"
 
 #: G1 state/action layout: [L-arm 7, L-gripper 1, R-arm 7, R-gripper 1].
 G1_ROBOT_DIM = 16
@@ -103,20 +111,21 @@ class UnitreeG1DecodeState(ProcessorStep):
     no-op when no state is present (state-off serving).
     """
 
-    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 
     def __call__(self, data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         observation = data.get(self.observation_key)
-        if observation is None or self.state_key not in observation:
+        if observation is None:
             return data
-        state = np.asarray(observation[self.state_key], dtype=np.float32) * _joint_flip_mask()
+        raw = lookup_key(observation, self.state_key, None)
+        if raw is None:
+            return data
+        state = np.asarray(raw, dtype=np.float32) * _joint_flip_mask()
         idx = list(_GRIPPER_INDICES)
         state[idx] = _gripper_to_angular(state[idx])
-        decoded = dict(observation)
-        decoded[self.state_key] = state
-        data[self.observation_key] = decoded
+        data[self.observation_key] = set_key(observation, self.state_key, state)
         return data
 
 
@@ -129,13 +138,13 @@ class UnitreeG1AbsoluteActions(ProcessorStep):
     ``Pi05Policy.infer``. A no-op when state is absent (delta cannot be resolved).
     """
 
-    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 
     def __call__(self, data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         observation = data.get(self.observation_key) or {}
-        state = observation.get(self.state_key)
+        state = lookup_key(observation, self.state_key, None)
         if state is None:
             return data
         actions = np.asarray(data[ACTIONS], dtype=np.float32).copy()

--- a/python/apxinf/apxinf/processors/transforms.py
+++ b/python/apxinf/apxinf/processors/transforms.py
@@ -32,7 +32,16 @@ import numpy as np
 
 from .base import ProcessorStep
 
-__all__ = ["ImageStack", "Tokenize", "SampleNoise", "Trim", "Unnormalize"]
+__all__ = [
+    "ImageStack",
+    "Tokenize",
+    "SampleNoise",
+    "Trim",
+    "Unnormalize",
+    "lookup_key",
+    "has_key",
+    "set_key",
+]
 
 # Canonical data-dict keys (the inter-step contract).
 OBSERVATION = "observation"
@@ -54,6 +63,66 @@ def _require(data: Mapping[str, Any], key: str, step: str) -> Any:
         ) from None
 
 
+_ABSENT = object()
+_NO_DEFAULT = object()
+
+
+def lookup_key(observation: Mapping[str, Any], key: str, default: Any = _NO_DEFAULT) -> Any:
+    """Resolve one **wire key** against a raw observation: flat first, then nested.
+
+    OpenPI embodiments spell their wire keys two different ways, and both arrive
+    here as one string:
+
+    * **flat**, with the slash part of the name itself — ``data["observation/image"]``
+      (LIBERO, DROID);
+    * **nested** one level — ``data["images"]["cam_high"]`` (ALOHA, Unitree G1).
+
+    A flat hit always wins, so a key that literally exists in the observation
+    keeps its exact meaning; only an absent key is split on ``/`` and walked as a
+    path. That makes ``"images/cam_high"`` a valid spelling of the nested form
+    without changing what ``"observation/image"`` means, so one flat
+    ``image_keys`` tuple can address either layout.
+
+    Raises :class:`KeyError` when the key resolves to nothing and no ``default``
+    is given.
+    """
+    if key in observation:
+        return observation[key]
+    if "/" in key:
+        node: Any = observation
+        for part in key.split("/"):
+            if not isinstance(node, Mapping) or part not in node:
+                break
+            node = node[part]
+        else:
+            return node
+    if default is _NO_DEFAULT:
+        raise KeyError(key)
+    return default
+
+
+def has_key(observation: Mapping[str, Any], key: str) -> bool:
+    """Whether :func:`lookup_key` can resolve ``key`` (flat or nested)."""
+    return lookup_key(observation, key, _ABSENT) is not _ABSENT
+
+
+def set_key(observation: Mapping[str, Any], key: str, value: Any) -> dict:
+    """Return a copy of ``observation`` with ``key`` set, mirroring :func:`lookup_key`.
+
+    Writes flat when the key already exists flat (or has no ``/``); otherwise
+    walks the nested path, shallow-copying only the mappings along it. The
+    caller's dict is never mutated — input steps hand the decoded observation
+    downstream while the client's original stays untouched.
+    """
+    if key in observation or "/" not in key:
+        return {**observation, key: value}
+    head, *rest = key.split("/")
+    node = observation.get(head)
+    if isinstance(node, Mapping):
+        return {**observation, head: set_key(node, "/".join(rest), value)}
+    return {**observation, key: value}
+
+
 class ImageStack(ProcessorStep):
     """Stack per-view images into one uint8 NHWC array under ``rgb``.
 
@@ -62,6 +131,15 @@ class ImageStack(ProcessorStep):
     in order. No slot padding: the model runs the exact shape it is handed, so
     the caller must supply precisely the cameras the checkpoint expects (absent
     cameras are simply not sent, never zero-filled).
+
+    ``image_keys`` order is what binds a camera to a model view slot: entry ``i``
+    becomes ``rgb[i]``, which the checkpoint trained as its slot ``i`` (openpi's
+    ``base_0_rgb`` / ``left_wrist_0_rgb`` / ``right_wrist_0_rgb``). A wrong order
+    stacks cleanly and silently feeds the wrong camera to each slot, so build the
+    tuple from a slot-named preset (:mod:`apxinf.robots.presets`) rather than by
+    hand. Each key is resolved by :func:`lookup_key`, so flat
+    (``"observation/image"``) and nested (``"images/cam_high"``) wire layouts both
+    work.
     """
 
     def __init__(
@@ -79,7 +157,17 @@ class ImageStack(ProcessorStep):
 
     def __call__(self, data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         observation = _require(data, self.observation_key, "ImageStack")
-        views = [self.image_pipeline(observation[key]) for key in self.image_keys]
+        views = []
+        for key in self.image_keys:
+            try:
+                image = lookup_key(observation, key)
+            except KeyError:
+                raise KeyError(
+                    f"ImageStack: observation has no camera {key!r}; configured "
+                    f"image_keys={list(self.image_keys)}, observation keys="
+                    f"{sorted(observation)}"
+                ) from None
+            views.append(self.image_pipeline(image))
         data[RGB] = np.ascontiguousarray(np.stack(views), dtype=np.uint8)
         return data
 
@@ -111,7 +199,7 @@ class Tokenize(ProcessorStep):
         prompt = _require(data, self.prompt_key, "Tokenize")
         if getattr(self.tokenizer, "discrete_state", False):
             observation = _require(data, self.observation_key, "Tokenize")
-            state = observation.get(self.state_key)
+            state = lookup_key(observation, self.state_key, None)
             if self.state_normalizer is not None and state is not None:
                 state = self.state_normalizer(np.asarray(state, dtype=np.float32))
             data[TOKEN_IDS] = self.tokenizer(prompt, state=state)

--- a/python/apxinf/apxinf/robots/__init__.py
+++ b/python/apxinf/apxinf/robots/__init__.py
@@ -10,11 +10,28 @@ This is the top assembly layer: it depends *downward* on both
 :mod:`apxinf.policies` (the model) and :mod:`apxinf.processors` (the steps).
 Neither depends back on it, so adding a robot never touches the policy or
 processor packages — you write steps under ``processors/robots/`` and a
-``build_*`` factory here.
+``build_*`` factory here, then register both in :mod:`apxinf.robots.presets` so
+they are reachable as ``--robot <name>`` at serving time.
 """
 
 from __future__ import annotations
 
+from .presets import (
+    ROBOT_PRESETS,
+    VIEW_SLOTS,
+    RobotPreset,
+    available_robots,
+    build_robot_policy,
+    get_robot_preset,
+)
 from .unitree_g1 import build_unitree_g1_policy
 
-__all__ = ["build_unitree_g1_policy"]
+__all__ = [
+    "build_unitree_g1_policy",
+    "RobotPreset",
+    "ROBOT_PRESETS",
+    "VIEW_SLOTS",
+    "available_robots",
+    "get_robot_preset",
+    "build_robot_policy",
+]

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -1,0 +1,228 @@
+"""Robot presets: the wire contract of one embodiment, as a named table entry.
+
+OpenPI keeps this information in a Python registry of ``TrainConfig``s: which
+``DataTransformFn`` pair runs, and therefore which **wire keys** the client must
+send. ``serve_policy.py --policy.config pi05_UnitreeG1_...`` selects an entry;
+the client cannot negotiate it and must match by hand.
+
+This module is the same idea with the same shape, so switching embodiments is a
+launch flag on both sides rather than a code edit on ours:
+
+    openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
+    apxinf:  pi05_openpi_websocket_server.py --robot unitree_g1
+
+**Why a table and not a default.** ``Pi05Policy``'s ``_DEFAULT_IMAGE_KEYS`` is
+LIBERO's wire contract. As *the* default it silently applied to every checkpoint,
+so a G1 checkpoint served without extra arguments ran LIBERO's keys, dropped
+state, and skipped the G1 delta→absolute and 32→16 steps — every symptom of a
+"model accuracy problem" with nothing in the logs. A preset makes the embodiment
+an explicit, named choice.
+
+**Why slot names.** ``image_keys`` is order-significant: entry ``i`` is stacked
+into model view slot ``i``, which the checkpoint trained as openpi's
+``base_0_rgb`` / ``left_wrist_0_rgb`` / ``right_wrist_0_rgb``. A tuple written in
+the wrong order still stacks, still has the right shape, and silently feeds the
+wrong camera to each slot. Pairing every wire key with the slot it fills makes
+that order reviewable instead of positional.
+
+**Naming rule: ``<arm>_<convention>``.** The arm alone does not determine the
+contract — LIBERO and DROID are both Franka Panda, yet LIBERO sends
+``observation/image`` with a 7-dim EEF-delta action while DROID sends
+``observation/exterior_image_1_left`` with a different action space. So a preset
+is named for the arm *and* the dataset convention whose keys it implements:
+``franka_libero``, not ``libero`` (a benchmark, not a robot) and not ``franka``
+(ambiguous). Single-embodiment robots that own their convention need no suffix —
+``unitree_g1``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+from ..policies.auto import AutoPolicy
+from ..policies.base import Policy
+from ..processors.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY
+from .unitree_g1 import build_unitree_g1_policy
+
+__all__ = [
+    "VIEW_SLOTS",
+    "RobotPreset",
+    "ROBOT_PRESETS",
+    "ROBOT_ALIASES",
+    "available_robots",
+    "get_robot_preset",
+    "build_robot_policy",
+]
+
+#: pi05 model view slots in order, as named by openpi's ``model.IMAGE_KEYS``.
+#: A checkpoint's ``num_views`` is how many of these its weights were trained on;
+#: the names are openpi's convention, the *order* is baked into the weights.
+VIEW_SLOTS = ("base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb")
+
+
+def _build_generic(model_dir, **kwargs) -> Policy:
+    """Default builder: the stock policy, no robot-specific pre/post steps."""
+    return AutoPolicy.from_pretrained(model_dir, **kwargs)
+
+
+@dataclass(frozen=True)
+class RobotPreset:
+    """One embodiment's serving contract: wire keys + action width + builder."""
+
+    #: Registry name, used as ``--robot <name>``.
+    name: str
+    #: ``(view slot, wire key)`` pairs in model slot order. The slot name is
+    #: documentation and validation; only the wire key goes on the network.
+    slots: Tuple[Tuple[str, str], ...]
+    #: Wire key of the proprioceptive state vector.
+    state_key: str
+    #: Wire key of the task instruction.
+    prompt_key: str = "prompt"
+    #: Deployable action width. ``None`` keeps the model's full vector — correct
+    #: when a robot output step does the truncation itself (G1's 32→16 encode).
+    action_dim: Optional[int] = None
+    #: Whether state is discretized into the prompt. Off means state is *dropped*.
+    discrete_state: bool = False
+    #: Factory that loads the checkpoint and wires this robot's pre/post steps.
+    builder: Callable[..., Policy] = _build_generic
+    #: One-line description for ``--help`` and the served metadata.
+    summary: str = ""
+    #: Extra keyword arguments the builder always receives.
+    builder_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.slots:
+            raise ValueError(f"RobotPreset {self.name!r}: at least one camera slot is required")
+        if len(self.slots) > len(VIEW_SLOTS):
+            raise ValueError(
+                f"RobotPreset {self.name!r}: {len(self.slots)} slots exceeds pi05's "
+                f"{len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
+            )
+        expected = VIEW_SLOTS[: len(self.slots)]
+        declared = tuple(slot for slot, _ in self.slots)
+        if declared != expected:
+            raise ValueError(
+                f"RobotPreset {self.name!r}: slots must be a prefix of {VIEW_SLOTS} in "
+                f"order (a checkpoint fills view slots from 0 up), got {declared}"
+            )
+        wire = [key for _, key in self.slots]
+        if len(set(wire)) != len(wire):
+            raise ValueError(f"RobotPreset {self.name!r}: duplicate camera wire keys {wire}")
+
+    @property
+    def image_keys(self) -> Tuple[str, ...]:
+        """Camera wire keys in model slot order — what ``ImageStack`` consumes."""
+        return tuple(key for _, key in self.slots)
+
+    @property
+    def num_views(self) -> int:
+        """Cameras this preset sends; must equal the checkpoint's ``num_views``."""
+        return len(self.slots)
+
+    def describe(self) -> str:
+        """Human-readable slot→wire-key mapping, for ``--help`` and startup logs."""
+        rendered = ", ".join(f"{slot}={key}" for slot, key in self.slots)
+        return f"{self.name}: {rendered}; state={self.state_key}"
+
+
+#: Franka Panda under LIBERO's key convention (the 7-DoF sim benchmark):
+#: 2 cameras, 7-dim action. Mirrors openpi ``LiberoInputs``. State is dropped by
+#: default, matching the numerics of the existing serving link.
+FRANKA_LIBERO = RobotPreset(
+    name="franka_libero",
+    slots=(
+        ("base_0_rgb", "observation/image"),
+        ("left_wrist_0_rgb", "observation/wrist_image"),
+    ),
+    state_key="observation/state",
+    action_dim=7,
+    discrete_state=False,
+    summary="Franka Panda, LIBERO keys: 2 cameras, 7-dim action (6 EEF deltas + gripper)",
+)
+
+#: Unitree G1 (humanoid, dual-arm + 2 dexterous hands): 3 cameras, 16-dim action.
+#: Mirrors the ``pi05_UnitreeG1`` fine-tune's ``unitreeG1Inputs``/``Outputs``: the
+#: client sends the nested ``obs["images"][...]`` layout and a flat ``"state"``.
+#: ``action_dim`` stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16
+#: truncation after delta→absolute has seen the full-width action.
+UNITREE_G1 = RobotPreset(
+    name="unitree_g1",
+    slots=tuple(zip(VIEW_SLOTS, G1_CAMERAS)),
+    state_key=G1_STATE_KEY,
+    action_dim=None,
+    discrete_state=True,
+    builder=build_unitree_g1_policy,
+    summary="Unitree G1: 3 cameras, 16-DoF state, delta joint actions, 32->16 encode",
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+#: Name -> preset. Add an embodiment here once its steps and factory exist; that
+#: is the whole registration step (openpi's ``training/config.py`` equivalent).
+ROBOT_PRESETS: Dict[str, RobotPreset] = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1)}
+
+#: Accepted spellings that are not canonical names. ``libero`` names a benchmark
+#: rather than a robot, but it is what the deployed launch commands and docs say,
+#: so it keeps resolving instead of failing a running deployment on a rename.
+ROBOT_ALIASES: Dict[str, str] = {"libero": "franka_libero"}
+
+
+def available_robots(*, include_aliases: bool = False) -> Tuple[str, ...]:
+    """Registered preset names, for ``--robot`` choices and error messages."""
+    names = tuple(ROBOT_PRESETS)
+    return names + tuple(ROBOT_ALIASES) if include_aliases else names
+
+
+def get_robot_preset(name: str) -> RobotPreset:
+    """Look up a preset by canonical name or alias, with a listing in the error."""
+    canonical = ROBOT_ALIASES.get(name, name)
+    try:
+        return ROBOT_PRESETS[canonical]
+    except KeyError:
+        raise KeyError(
+            f"unknown robot preset {name!r}; known: {list(available_robots())}"
+            f" (aliases: {list(ROBOT_ALIASES)})"
+        ) from None
+
+
+def build_robot_policy(
+    robot: str,
+    model_dir,
+    *,
+    image_keys: Optional[Sequence[str]] = None,
+    state_key: Optional[str] = None,
+    action_dim: Optional[int] = None,
+    discrete_state: Optional[bool] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+    **kwargs: Any,
+) -> Policy:
+    """Load ``model_dir`` under the named preset, with per-argument overrides.
+
+    Each override defaults to the preset's value; passing one replaces just that
+    field. ``image_keys`` and ``state_key`` exist because a deployed client may
+    already speak a fixed dialect — they let a server match an installed robot
+    stack without editing the preset (and without touching the client).
+
+    The resulting wire contract is published in the policy ``metadata``
+    (``robot`` / ``image_keys`` / ``state_key`` / ``discrete_state``), which the
+    server pushes on connect, so a client can assert it rather than guess.
+    """
+    preset = get_robot_preset(robot)
+    keys = tuple(image_keys) if image_keys is not None else preset.image_keys
+    state = state_key if state_key is not None else preset.state_key
+    discrete = preset.discrete_state if discrete_state is None else bool(discrete_state)
+    width = preset.action_dim if action_dim is None else action_dim
+
+    return preset.builder(
+        model_dir,
+        image_keys=keys,
+        state_key=state,
+        discrete_state=discrete,
+        action_dim=width,
+        metadata={
+            "robot": preset.name,
+            "robot_slots": [list(pair) for pair in zip(VIEW_SLOTS, keys)],
+            **(dict(metadata) if metadata else {}),
+        },
+        **{**dict(preset.builder_kwargs), **kwargs},
+    )

--- a/python/apxinf/apxinf/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/robots/unitree_g1.py
@@ -25,6 +25,7 @@ from ..processors import Pipeline
 from ..processors.robots.unitree_g1 import (
     G1_CAMERAS,
     G1_ROBOT_DIM,
+    G1_STATE_KEY,
     UnitreeG1AbsoluteActions,
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
@@ -39,9 +40,10 @@ def build_unitree_g1_policy(
     *,
     use_delta_joint_actions: bool = True,
     adapt_to_pi: bool = True,
-    state_key: str = "observation/state",
+    state_key: str = G1_STATE_KEY,
     image_keys: Sequence[str] = G1_CAMERAS,
-    discrete_state: bool = False,
+    discrete_state: bool = True,
+    action_dim: Optional[int] = None,
     unnormalizer: Optional[Unnormalize] = None,
     metadata: Optional[dict] = None,
     **from_pretrained_kwargs: Any,
@@ -58,10 +60,19 @@ def build_unitree_g1_policy(
 
     ``adapt_to_pi=False`` drops the decode/encode conventions (raw robot space);
     ``use_delta_joint_actions=False`` drops the delta->absolute step (the model
-    already emits absolute actions). By default the unnormalizer comes from the
-    checkpoint's ``norm_stats["actions"]``, so a real deployment needs G1
-    norm_stats at least ``16`` wide; pass ``unnormalizer=`` to inject one (e.g. a
-    full-width identity for a shape/plumbing test on a stand-in checkpoint).
+    already emits absolute actions). ``action_dim`` is the **deployable** width
+    reported to clients and defaults to :data:`G1_ROBOT_DIM` — the model always
+    runs at full width internally, and ``UnitreeG1EncodeActions`` performs the
+    truncation. By default the unnormalizer comes from the checkpoint's
+    ``norm_stats["actions"]``, so a real deployment needs G1 norm_stats at least
+    ``16`` wide; pass ``unnormalizer=`` to inject one (e.g. a full-width identity
+    for a shape/plumbing test on a stand-in checkpoint).
+
+    Defaults match what an unmodified openpi G1 client sends: the nested
+    ``obs["images"][...]`` cameras, a flat ``"state"``, and state discretized into
+    the prompt. Serving with ``discrete_state=False`` silently drops state, which
+    also makes ``use_delta_joint_actions`` a no-op (a delta cannot be resolved
+    without the current joint positions).
     """
     base = Pi05Policy.from_pretrained(
         model_dir,
@@ -93,6 +104,6 @@ def build_unitree_g1_policy(
         output_pipeline=output_pipeline,
         image_keys=tuple(image_keys),
         state_key=state_key,
-        action_dim=G1_ROBOT_DIM,
+        action_dim=G1_ROBOT_DIM if action_dim is None else int(action_dim),
         metadata={"robot": "unitree_g1", **(metadata or {})},
     )

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -39,18 +39,37 @@ python -c "import apxinf_py; print(apxinf_py.Model.load('pi05','<ckpt>/model.saf
 ```bash
 python scripts/pi05_openpi_websocket_server.py \
     --model-dir <ckpt> \
+    --robot franka_libero \  # embodiment preset: wire keys + pre/post steps + action width
     --precision bf16 \
     --device cuda:0 \
-    --action-dim 7 \        # deployment width; 0 keeps the full 32 dims
     --host 0.0.0.0 --port 8000
 ```
 
+- `--robot` is the one flag that decides **which keys the client must send**. It
+  is openpi's `serve_policy.py --policy.config <TrainConfig>` equivalent: the
+  embodiment is fixed at startup and the client cannot negotiate it. A checkpoint
+  fine-tuned for another robot **must** name it — the wire keys, the state
+  routing, and the action encoding all differ, and a mismatch degrades silently
+  (plausible-looking actions from the wrong cameras) rather than failing.
+  `--robot` also sets `--action-dim` and `--discrete-state`; pass those flags only
+  to override the preset. `python scripts/pi05_openpi_websocket_server.py --help`
+  lists every preset with its slot→key mapping.
+- Presets are named `<arm>_<key convention>`, because the arm alone does not fix
+  the contract: LIBERO and DROID are both Franka Panda with different keys and
+  action spaces. `--robot libero` still resolves to `franka_libero`.
+- `--image-keys` / `--state-key` override individual keys, for a deployed client
+  that already speaks a fixed dialect. `--image-keys` order is significant: key
+  *i* fills model view slot *i* (`base_0_rgb`, `left_wrist_0_rgb`,
+  `right_wrist_0_rgb`).
 - `--host 0.0.0.0` accepts remote clients (split deployment); `127.0.0.1` for a
   local-only test.
-- `--action-dim 7` — LIBERO uses the first 7 dims (last is the gripper).
 - Health check: `curl http://<host>:8000/healthz` → `OK`.
-- On connect the server pushes its metadata (`num_views` / `action_horizon` /
-  `precision` / ...).
+- The startup log prints the served contract; the same fields are pushed to every
+  client on connect (see §3):
+
+  ```
+  serving robot=franka_libero H=10 x D=7 image_keys=['observation/image', 'observation/wrist_image'] state=observation/state discrete_state=False
+  ```
 
 ## 3. Call it (stock `openpi_client`, unmodified)
 
@@ -58,17 +77,32 @@ python scripts/pi05_openpi_websocket_server.py \
 from openpi_client import websocket_client_policy
 
 client = websocket_client_policy.WebsocketClientPolicy("<host>", 8000)
-print(client.get_server_metadata())          # {'num_views':3,'action_horizon':50,'precision':'bf16',...}
+meta = client.get_server_metadata()
+# {'robot': 'franka_libero', 'image_keys': ['observation/image', 'observation/wrist_image'],
+#  'state_key': 'observation/state', 'discrete_state': False, 'prompt_key': 'prompt',
+#  'num_views': 2, 'action_horizon': 10, 'action_dim': 7, 'precision': 'bf16', ...}
 
 result = client.infer({
-    "observation/image":       base_rgb_uint8,    # HWC uint8; the server resizes
+    "observation/image":       base_rgb_uint8,     # HWC uint8 RGB; the server resizes
     "observation/wrist_image": wrist_rgb_uint8,
-    "observation/state":       state_f32,          # dropped on the LIBERO path; see §5 for a robot
+    "observation/state":       state_f32,          # dropped unless discrete_state; see §5
     "prompt":                  "put both moka pots on the stove",
 })
-result["actions"]         # float32 [H, 7]; H is the checkpoint's native horizon
+result["actions"]         # float32 [H, action_dim]; H is the checkpoint's native horizon
 result["policy_timing"]   # {'infer_ms': bare model, 'policy_ms': full policy}
 ```
+
+The metadata **is** the wire contract — assert against `meta["image_keys"]` /
+`meta["state_key"]` instead of hardcoding keys, so a server/client mismatch shows
+up as a failed assertion at startup rather than as degraded accuracy in the
+field. Sending a key the server does not serve raises a `KeyError` naming both
+sides; sending an *extra* key is silently ignored (matching openpi).
+
+**Images are RGB.** Neither this server nor openpi converts colour: an `H×W×3`
+uint8 array is taken as RGB as-is. A client reading frames with OpenCV must
+`cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)` first — BGR frames run fine and score
+badly. Resizing *is* done server-side (aspect-preserving pad to the model's
+edge), so any input resolution is fine.
 
 Reference client: [python/apxinf/examples/openpi_client.py](../../examples/openpi_client.py).
 
@@ -134,8 +168,9 @@ fields:
 ```
 
 > LIBERO is a **Franka Panda 7-DoF** benchmark (7-dim action = 6 EEF deltas + 1
-> gripper), so eval runs the Panda/libero path with `--action-dim 7`. It is a
-> different embodiment from the robots in §5 (e.g. G1) and unrelated to them.
+> gripper), so eval runs the default `--robot franka_libero` preset, which
+> already sets the 2 camera keys and the 7-dim action width. It is a different
+> embodiment from the robots in §5 (e.g. G1) and unrelated to them.
 
 ## 5. Port an OpenPI config + processors into apxinf (for your own robot)
 
@@ -262,12 +297,60 @@ The delta→absolute output step needs to see the **input state**.
 pipeline; the stock `trim`/`unnormalize` ignore it, so existing numbers are
 unchanged (matching OpenPI's "output transforms can see input state" semantics).
 
-### 5.6 Use and verify
+### 5.6 Register a preset (the last step — do not skip it)
+
+A factory alone is not deployable: whoever launches the server still has to know
+your robot's wire keys, action width, and state routing, and getting any of them
+wrong is silent. Add one entry to
+[`python/apxinf/apxinf/robots/presets.py`](../robots/presets.py) and the whole
+contract becomes `--robot <name>`:
+
+```python
+MY_ROBOT = RobotPreset(
+    name="my_robot",                              # <arm>_<key convention> if the arm is shared
+    slots=(                                       # (model view slot, wire key), in slot order
+        ("base_0_rgb",        "images/cam_high"),
+        ("left_wrist_0_rgb",  "images/cam_left_wrist"),
+    ),
+    state_key="state",
+    action_dim=None,                              # None: the encode step trims
+    discrete_state=True,                          # False *drops* state entirely
+    builder=build_my_robot_policy,
+    summary="My robot: 2 cameras, 14-DoF state, delta joint actions",
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
+```
+
+Naming each wire key with the **model view slot** it fills is the point: the
+tuple is order-significant (entry *i* becomes model view slot *i*), and a wrong
+order still stacks, still has the right shape, and silently feeds the wrong
+camera to each slot. The pairing is validated — slots must be a prefix of
+`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb` in order, with no duplicate
+wire keys.
+
+Wire keys may be written **flat** (`"observation/image"` — the slash is part of
+the name, as LIBERO and DROID send it) or as a **nested path**
+(`"images/cam_high"` → `obs["images"]["cam_high"]`, as ALOHA and G1 send it). A
+flat hit always wins, so both layouts work from one tuple and an unmodified
+upstream client needs no changes.
+
+The preset's contract is published in the served metadata (§3) and printed at
+startup, so a client can assert it.
+
+### 5.7 Use and verify
 
 ```python
 from apxinf import build_unitree_g1_policy          # shipped G1 example
 policy = build_unitree_g1_policy("<g1-ckpt>", use_delta_joint_actions=True, adapt_to_pi=True)
 actions = policy.infer(obs)["actions"]               # [H, 16]
+```
+
+Served the same way, once §5.6 is done:
+
+```bash
+python scripts/pi05_openpi_websocket_server.py --model-dir <g1-ckpt> --robot unitree_g1
 ```
 
 Smoke test (plumbing/shape): [scripts/g1_adapter_smoke.py](../../../../scripts/g1_adapter_smoke.py)

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -61,6 +61,14 @@ python scripts/pi05_openpi_websocket_server.py \
   that already speaks a fixed dialect. `--image-keys` order is significant: key
   *i* fills model view slot *i* (`base_0_rgb`, `left_wrist_0_rgb`,
   `right_wrist_0_rgb`).
+- `--num-views` serves a checkpoint with **fewer cameras than it declares** — a
+  3-view checkpoint on a 2-camera robot. The trailing view slots are dropped at
+  load time, which is numerically identical to what openpi does (it zero-pads the
+  absent view and masks it; a masked view is excluded from attention, occupies no
+  RoPE position, and the vision tower has no per-slot parameters) while skipping
+  that view's 256 patch tokens every step. It must equal the number of image
+  keys, and it is deliberately required rather than inferred, so a *forgotten*
+  camera key is an error instead of a quiet accuracy loss.
 - `--host 0.0.0.0` accepts remote clients (split deployment); `127.0.0.1` for a
   local-only test.
 - Health check: `curl http://<host>:8000/healthz` → `OK`.

--- a/scripts/g1_adapter_smoke.py
+++ b/scripts/g1_adapter_smoke.py
@@ -31,9 +31,7 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 from apxinf import build_unitree_g1_policy  # noqa: E402
 from apxinf.processors import Unnormalizer  # noqa: E402
 from apxinf.processors.transforms import Unnormalize  # noqa: E402
-from apxinf.robots.unitree_g1 import G1_CAMERAS  # noqa: E402
-
-STATE_KEY = "observation/state"
+from apxinf.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY  # noqa: E402
 
 
 def parse_args():
@@ -70,7 +68,7 @@ def main():
         model=model,  # reuse the already-loaded handle
         use_delta_joint_actions=True,
         adapt_to_pi=True,
-        state_key=STATE_KEY,
+        state_key=G1_STATE_KEY,
         unnormalizer=identity,
         precision=args.precision,
         device=args.device,
@@ -88,8 +86,16 @@ def main():
     else:
         cam = lambda: rng.integers(0, 256, (S, S, 3), dtype=np.uint8)  # noqa: E731
 
-    observation = {name: cam() for name in G1_CAMERAS}
-    observation[STATE_KEY] = rng.standard_normal(16).astype(np.float32)
+    # The exact layout an unmodified openpi G1 client sends: cameras nested one
+    # level under "images", state flat. The policy's image_keys are the paths
+    # ("images/cam_high"), which lookup_key walks into this dict.
+    groups: dict = {}
+    for key in G1_CAMERAS:
+        group, _, camera = key.partition("/")
+        assert camera, f"expected a nested camera path, got {key!r}"
+        groups.setdefault(group, {})[camera] = cam()
+    observation = dict(groups)
+    observation[G1_STATE_KEY] = rng.standard_normal(16).astype(np.float32)
     observation["prompt"] = args.prompt
 
     out = policy.infer(observation)

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -148,9 +148,19 @@ def parse_args() -> argparse.Namespace:
         "or 50 with --random-weights. An explicit value outranks the checkpoint "
         "(the horizon is a sequence length, not a weight dimension).",
     )
+    parser.add_argument(
+        "--num-views",
+        type=int,
+        default=None,
+        help="serve fewer cameras than the checkpoint declares (must equal the "
+        "number of image keys). Drops the trailing view slots at load time — "
+        "equivalent to openpi zero-padding and masking them, minus their patch "
+        "tokens. Required to be explicit: a short image_keys list on its own is "
+        "an error, so a forgotten camera fails instead of degrading. Also sets "
+        "the synthetic view count under --random-weights.",
+    )
     # Synthetic-shape knobs, used only with --random-weights (a checkpoint runs its
     # native config). They mirror apxinf_py.Model.random.
-    parser.add_argument("--num-views", type=int, default=None, help="random: camera views")
     parser.add_argument("--image-size", type=int, default=224, help="random: image edge")
     parser.add_argument("--num-flow-steps", type=int, default=10, help="random: flow steps")
     parser.add_argument("--max-token-len", type=int, default=200, help="random: max prompt tokens")
@@ -192,6 +202,12 @@ def main() -> None:
     image_keys = args.image_keys if args.image_keys is not None else preset.image_keys
     state_key = args.state_key if args.state_key is not None else preset.state_key
     discrete_state = preset.discrete_state if args.discrete_state is None else args.discrete_state
+    if args.num_views is not None and args.num_views != len(image_keys):
+        raise ValueError(
+            f"--num-views {args.num_views} disagrees with the {len(image_keys)} "
+            f"camera keys being served ({list(image_keys)}); they name the same "
+            "cameras, so they must match"
+        )
 
     metadata = {
         "protocol": "openpi.websocket_policy",
@@ -259,6 +275,7 @@ def main() -> None:
             state_key=state_key,
             discrete_state=discrete_state,
             action_dim=args.action_dim,
+            num_views=args.num_views,
             model_type=args.model_type,
             checkpoint=args.checkpoint,
             device=args.device,

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -2,17 +2,32 @@
 """Thin CLI launcher for the OpenPI-compatible π0.5 websocket service.
 
 All reusable logic lives in the library: the transport shell in
-:mod:`apxinf.serving` and the policy in :mod:`apxinf` (``AutoPolicy`` /
-``Pi05Policy``). This file is only argument parsing + wiring — load an
-**in-process** policy through the ``apxinf_py`` PyO3 binding and serve it.
+:mod:`apxinf.serving`, the policy in :mod:`apxinf` (``AutoPolicy`` /
+``Pi05Policy``), and the per-embodiment wire contract in
+:mod:`apxinf.robots.presets`. This file is only argument parsing + wiring — load
+an **in-process** policy through the ``apxinf_py`` PyO3 binding and serve it.
 
 The old subprocess + stdio hop (``ApxInfStdioEngine`` + ``pi05_libero_server``)
 is gone; so are the script's private resize/tokenize/unnormalize copies.
 
-**State gap:** ``observation/state`` is dropped by default so numerics match the
-prior serving link. ``--discrete-state`` opts in and wires ``apxinf``'s
-``state_normalizer`` (normalize raw state to [-1, 1] from ``norm_stats``) +
-prompt discretization — see :mod:`apxinf.policies.impls.pi05`.
+**Embodiment:** ``--robot`` selects the wire keys and the robot pre/post steps,
+the way openpi's ``serve_policy.py --policy.config <TrainConfig>`` does. It
+defaults to ``franka_libero``; a checkpoint fine-tuned for another robot **must**
+name it, because the wire keys, the state routing, and the action encoding all
+differ and a mismatch degrades silently rather than failing. ``--image-keys`` /
+``--state-key`` override individual fields for a client that already speaks a
+fixed dialect.
+
+**State:** each preset decides whether ``state`` is injected (discretized into
+the prompt, normalized to [-1, 1] from ``norm_stats``) or dropped —
+``--discrete-state`` / ``--no-discrete-state`` override it. ``franka_libero``
+drops state to match the numerics of the prior serving link; a joint-space robot
+needs it.
+
+**Images are RGB.** Neither this server nor openpi converts colour: an
+``H×W×3`` uint8 array is taken as RGB as-is. A client reading frames with
+OpenCV must ``cv2.cvtColor(img, cv2.COLOR_BGR2RGB)`` first. Resizing *is* done
+here (aspect-preserving pad to the model's edge), so any resolution is fine.
 """
 
 from __future__ import annotations
@@ -31,18 +46,57 @@ _APXINF_PKG = _REPO_ROOT / "python" / "apxinf"
 if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
-from apxinf import AutoPolicy, Pi05Policy  # noqa: E402
+from apxinf import Pi05Policy  # noqa: E402
+from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_PRESETS,
+    available_robots,
+    build_robot_policy,
+    get_robot_preset,
+)
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
 
-DEFAULT_LIBERO_ACTION_DIM = 7
+DEFAULT_ROBOT = "franka_libero"
+
+
+def _split_keys(value: str) -> tuple:
+    keys = tuple(part.strip() for part in value.split(",") if part.strip())
+    if not keys:
+        raise argparse.ArgumentTypeError("--image-keys needs at least one camera key")
+    return keys
 
 
 def parse_args() -> argparse.Namespace:
+    robot_help = "\n".join(f"  {p.describe()}" for p in ROBOT_PRESETS.values())
     parser = argparse.ArgumentParser(
         description="Serve a ApxInf PI0.5 policy through OpenPI's websocket API "
-        "(in-process; no subprocess)"
+        "(in-process; no subprocess)",
+        epilog=f"robot presets (--robot):\n{robot_help}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--model-dir", type=pathlib.Path, help="checkpoint directory")
+    parser.add_argument(
+        "--robot",
+        choices=available_robots(include_aliases=True),
+        default=DEFAULT_ROBOT,
+        help="embodiment preset: wire keys + robot pre/post steps + action width "
+        f"(default: {DEFAULT_ROBOT}). openpi's --policy.config equivalent; a "
+        "checkpoint fine-tuned for another robot must name it. Presets are named "
+        "<arm>_<key convention>, since the arm alone does not fix the contract.",
+    )
+    parser.add_argument(
+        "--image-keys",
+        type=_split_keys,
+        default=None,
+        help="comma-separated camera wire keys, overriding the preset. Order is "
+        "significant: key i fills model view slot i (base, left wrist, right "
+        "wrist). Nested client layouts are written as a path, e.g. "
+        "'images/cam_high,images/cam_left_wrist'.",
+    )
+    parser.add_argument(
+        "--state-key",
+        default=None,
+        help="observation key holding the state vector, overriding the preset",
+    )
     parser.add_argument(
         "--random-weights",
         action="store_true",
@@ -81,8 +135,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--action-dim",
         type=int,
-        default=DEFAULT_LIBERO_ACTION_DIM,
-        help="deployable action width to trim to (LIBERO=7; 0 keeps full vector)",
+        default=None,
+        help="deployable action width to trim to, overriding the preset "
+        "(LIBERO=7; 0 keeps the full vector)",
     )
     parser.add_argument("--norm-key", default="actions")
     parser.add_argument(
@@ -95,16 +150,25 @@ def parse_args() -> argparse.Namespace:
     )
     # Synthetic-shape knobs, used only with --random-weights (a checkpoint runs its
     # native config). They mirror apxinf_py.Model.random.
-    parser.add_argument("--num-views", type=int, default=2, help="random: camera views")
+    parser.add_argument("--num-views", type=int, default=None, help="random: camera views")
     parser.add_argument("--image-size", type=int, default=224, help="random: image edge")
     parser.add_argument("--num-flow-steps", type=int, default=10, help="random: flow steps")
     parser.add_argument("--max-token-len", type=int, default=200, help="random: max prompt tokens")
     parser.add_argument("--token-count", type=int, default=10, help="random: synthetic prompt length")
     parser.add_argument(
         "--discrete-state",
+        dest="discrete_state",
         action="store_true",
+        default=None,
         help="inject discretized state into the prompt (state normalized to "
-        "[-1, 1] from norm_stats). OFF by default to match current numerics.",
+        "[-1, 1] from norm_stats), overriding the preset. Without it state is "
+        "silently dropped — a joint-space robot needs this on.",
+    )
+    parser.add_argument(
+        "--no-discrete-state",
+        dest="discrete_state",
+        action="store_false",
+        help="drop state even if the preset injects it",
     )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
@@ -124,10 +188,15 @@ def main() -> None:
     if args.random_weights and args.model_dir is not None:
         raise ValueError("--random-weights is checkpoint-free; do not also pass --model-dir")
 
+    preset = get_robot_preset(args.robot)
+    image_keys = args.image_keys if args.image_keys is not None else preset.image_keys
+    state_key = args.state_key if args.state_key is not None else preset.state_key
+    discrete_state = preset.discrete_state if args.discrete_state is None else args.discrete_state
+
     metadata = {
         "protocol": "openpi.websocket_policy",
         "precision": args.precision,
-        "policy": "libero",
+        "policy": preset.name,
     }
 
     if args.random_weights:
@@ -139,11 +208,14 @@ def main() -> None:
         if args.precision == "fp8":
             calibration = str(args.calibration) if args.calibration is not None else "uniform:1.0"
         action_horizon = args.action_horizon if args.action_horizon is not None else 50
+        # The preset's cameras define the synthetic view count unless --num-views is
+        # given explicitly, so --robot alone yields a servable synthetic engine.
+        num_views = args.num_views if args.num_views is not None else len(image_keys)
         logging.info(
             "serving checkpoint-free %s random-weights engine (views=%d, H=%d, T=%d) "
             "— actions are latency-only",
             args.precision,
-            args.num_views,
+            num_views,
             action_horizon,
             args.token_count,
         )
@@ -151,7 +223,7 @@ def main() -> None:
             model=(args.model_type or "pi05"),
             device=args.device,
             precision=args.precision,
-            num_views=args.num_views,
+            num_views=num_views,
             image_size=args.image_size,
             action_horizon=action_horizon,
             action_dim=(args.action_dim or 32),
@@ -166,15 +238,27 @@ def main() -> None:
             token_count=args.token_count,
             action_dim=(args.action_dim or None),
             seed=args.seed,
-            metadata=metadata,
+            image_keys=image_keys[:num_views],
+            state_key=state_key,
+            metadata={**metadata, "robot": preset.name},
         )
     else:
         if args.precision == "fp8" and (args.calibration is None or args.tactics is None):
             raise ValueError("--calibration and --tactics are required for FP8")
 
-        logging.info("loading %s policy in-process from %s", args.precision, args.model_dir)
-        policy = AutoPolicy.from_pretrained(
+        logging.info(
+            "loading %s policy in-process from %s as robot=%s",
+            args.precision,
             args.model_dir,
+            preset.describe(),
+        )
+        policy = build_robot_policy(
+            preset.name,
+            args.model_dir,
+            image_keys=image_keys,
+            state_key=state_key,
+            discrete_state=discrete_state,
+            action_dim=args.action_dim,
             model_type=args.model_type,
             checkpoint=args.checkpoint,
             device=args.device,
@@ -183,15 +267,20 @@ def main() -> None:
             tactics=args.tactics,
             tokenizer_path=args.tokenizer,
             norm_key=args.norm_key,
-            action_dim=(args.action_dim or None),
             action_horizon=args.action_horizon,
             seed=args.seed,
-            discrete_state=args.discrete_state,
             metadata=metadata,
         )
-    # Clients read the served shape off this metadata rather than assuming one.
+    # Clients read the served wire contract off this metadata rather than assuming
+    # one: a key mismatch is silent on the wire but visible here.
     logging.info(
-        "serving H=%d x D=%d", policy.metadata["action_horizon"], policy.metadata["action_dim"]
+        "serving robot=%s H=%d x D=%d image_keys=%s state=%s discrete_state=%s",
+        policy.metadata.get("robot", preset.name),
+        policy.metadata["action_horizon"],
+        policy.metadata["action_dim"],
+        policy.metadata["image_keys"],
+        policy.metadata["state_key"],
+        policy.metadata["discrete_state"],
     )
     server = WebsocketPolicyServer(policy, args.host, args.port)
     try:

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -227,6 +227,19 @@ def main() -> None:
         # The preset's cameras define the synthetic view count unless --num-views is
         # given explicitly, so --robot alone yields a servable synthetic engine.
         num_views = args.num_views if args.num_views is not None else len(image_keys)
+        # The synthetic tokenizer emits a fixed token stream and never reads state,
+        # so this server cannot reproduce a discrete-state preset. Say so: the
+        # published metadata is the wire contract, and silently serving
+        # discrete_state=False for a preset that declares True is precisely the
+        # mismatch --robot exists to prevent.
+        if discrete_state:
+            logging.warning(
+                "--random-weights cannot honour %s's discrete_state=True: the "
+                "synthetic tokenizer ignores state, so the served metadata will "
+                "say discrete_state=False. Use a checkpoint to preview the real "
+                "contract.",
+                preset.name,
+            )
         logging.info(
             "serving checkpoint-free %s random-weights engine (views=%d, H=%d, T=%d) "
             "— actions are latency-only",

--- a/tests/test_pi05_openpi_websocket.py
+++ b/tests/test_pi05_openpi_websocket.py
@@ -179,7 +179,7 @@ class WebsocketServerCompatibilityTest(unittest.TestCase):
         self.assertNotIn("prev_total_ms", first["server_timing"])
         self.assertIn("prev_total_ms", second["server_timing"])
 
-        # The in-process model saw two NHWC calls, stacked + padded to num_views.
+        # The in-process model saw two NHWC calls, one row per configured camera.
         self.assertEqual(len(self.policy.model.images), 2)
         self.assertEqual(self.policy.model.images[0].shape, (NUM_VIEWS, 224, 224, 3))
         self.assertEqual(self.policy.model.images[0].dtype, np.dtype("uint8"))

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -1,0 +1,419 @@
+"""Robot presets, wire-key resolution, and the G1 serving path end-to-end.
+
+Covers the layer that decides *which keys a client must send*, which is where a
+deployment silently degrades rather than fails: a checkpoint served under the
+wrong embodiment still returns well-shaped actions.
+
+Three groups:
+
+* :class:`KeyResolutionTest` — ``lookup_key`` / ``has_key`` / ``set_key``, the
+  flat-vs-nested wire layouts (``"observation/image"`` vs
+  ``obs["images"]["cam_high"]``).
+* :class:`RobotPresetTest` — the preset table's invariants and overrides.
+* :class:`UnitreeG1ServingTest` — an **unmodified openpi G1 observation** driven
+  through the real websocket transport into a G1-wired policy, asserting camera
+  →slot binding, state routing, and the delta→absolute / 32→16 output chain.
+
+Runs offline against a mock model; no CUDA, no checkpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import sys
+import threading
+import unittest
+
+import numpy as np
+from openpi_client import websocket_client_policy
+import websockets.asyncio.server as websocket_server
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / "python" / "apxinf"))
+os.environ["NO_PROXY"] = "127.0.0.1,localhost"
+os.environ["no_proxy"] = "127.0.0.1,localhost"
+
+from apxinf import Pi05Policy  # noqa: E402
+from apxinf.processors import Pipeline, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
+    G1_CAMERAS,
+    G1_ROBOT_DIM,
+    G1_STATE_KEY,
+    UnitreeG1AbsoluteActions,
+    UnitreeG1DecodeState,
+    UnitreeG1EncodeActions,
+)
+from apxinf.processors.transforms import (  # noqa: E402
+    Unnormalize,
+    has_key,
+    lookup_key,
+    set_key,
+)
+from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_PRESETS,
+    VIEW_SLOTS,
+    RobotPreset,
+    available_robots,
+    get_robot_preset,
+)
+from apxinf.serving import WebsocketPolicyServer  # noqa: E402
+from apxinf.serving.websocket import health_check  # noqa: E402
+
+HORIZON = 4
+MODEL_DIM = 32
+IMAGE_SIZE = 224
+
+
+class KeyResolutionTest(unittest.TestCase):
+    """A wire key must resolve the same way everywhere it is used."""
+
+    OBSERVATION = {
+        "observation/image": "flat-base",
+        "images": {"cam_high": "nested-base", "cam_left_wrist": "nested-left"},
+        "state": np.zeros(4, dtype=np.float32),
+        "explicitly_none": None,
+    }
+
+    def test_flat_key_containing_a_slash_is_not_split(self) -> None:
+        # LIBERO/DROID names are flat even though they contain "/". Splitting
+        # them would silently look in the wrong place.
+        self.assertEqual(lookup_key(self.OBSERVATION, "observation/image"), "flat-base")
+
+    def test_nested_key_is_walked_as_a_path(self) -> None:
+        # ALOHA/G1 clients send obs["images"]["cam_high"].
+        self.assertEqual(lookup_key(self.OBSERVATION, "images/cam_high"), "nested-base")
+
+    def test_flat_hit_wins_over_a_nested_path(self) -> None:
+        observation = {"a/b": "flat", "a": {"b": "nested"}}
+        self.assertEqual(lookup_key(observation, "a/b"), "flat")
+
+    def test_missing_key_raises_without_a_default(self) -> None:
+        with self.assertRaises(KeyError):
+            lookup_key(self.OBSERVATION, "images/cam_right_wrist")
+        self.assertIsNone(lookup_key(self.OBSERVATION, "images/cam_right_wrist", None))
+
+    def test_has_key_distinguishes_absent_from_a_none_value(self) -> None:
+        # A present-but-None state must not be reported as missing, or the
+        # required-key check would reject a valid observation.
+        self.assertTrue(has_key(self.OBSERVATION, "explicitly_none"))
+        self.assertFalse(has_key(self.OBSERVATION, "images/cam_right_wrist"))
+
+    def test_set_key_writes_nested_without_mutating_the_caller(self) -> None:
+        updated = set_key(self.OBSERVATION, "images/cam_high", "decoded")
+        self.assertEqual(updated["images"]["cam_high"], "decoded")
+        self.assertEqual(updated["images"]["cam_left_wrist"], "nested-left")
+        self.assertEqual(self.OBSERVATION["images"]["cam_high"], "nested-base")
+
+    def test_set_key_writes_flat_for_a_flat_key(self) -> None:
+        updated = set_key(self.OBSERVATION, "state", np.ones(4, dtype=np.float32))
+        self.assertTrue(np.all(updated["state"] == 1))
+        self.assertTrue(np.all(self.OBSERVATION["state"] == 0))
+
+
+class RobotPresetTest(unittest.TestCase):
+    """The preset table is the only place a wire contract is declared."""
+
+    def test_shipped_presets_are_well_formed(self) -> None:
+        for name, preset in ROBOT_PRESETS.items():
+            self.assertEqual(name, preset.name)
+            self.assertEqual(preset.num_views, len(preset.image_keys))
+            self.assertLessEqual(preset.num_views, len(VIEW_SLOTS))
+
+    def test_franka_libero_matches_openpi_libero_inputs(self) -> None:
+        preset = get_robot_preset("franka_libero")
+        self.assertEqual(
+            preset.image_keys, ("observation/image", "observation/wrist_image")
+        )
+        self.assertEqual(preset.state_key, "observation/state")
+        self.assertEqual(preset.action_dim, 7)
+
+    def test_the_libero_alias_still_resolves(self) -> None:
+        # Deployed launch commands say --robot libero; a rename must not break a
+        # running install, so the old spelling keeps resolving to the same entry.
+        self.assertIs(get_robot_preset("libero"), get_robot_preset("franka_libero"))
+        self.assertNotIn("libero", available_robots())
+        self.assertIn("libero", available_robots(include_aliases=True))
+
+    def test_g1_matches_an_unmodified_openpi_g1_client(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+        self.assertEqual(preset.image_keys, G1_CAMERAS)
+        self.assertEqual(preset.state_key, G1_STATE_KEY)
+        # State must be routed, not dropped: without it delta->absolute is a no-op.
+        self.assertTrue(preset.discrete_state)
+        # Full model width; UnitreeG1EncodeActions does the 32->16 truncation.
+        self.assertIsNone(preset.action_dim)
+
+    def test_slots_must_be_a_prefix_of_the_model_view_slots(self) -> None:
+        # A checkpoint fills view slots from 0 up, so declaring "base + right
+        # wrist" is not expressible and must be rejected at table-definition
+        # time rather than mis-binding a camera at inference time.
+        with self.assertRaises(ValueError):
+            RobotPreset(
+                name="bad",
+                slots=(("base_0_rgb", "a"), ("right_wrist_0_rgb", "b")),
+                state_key="state",
+            )
+
+    def test_duplicate_camera_keys_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            RobotPreset(
+                name="bad",
+                slots=(("base_0_rgb", "a"), ("left_wrist_0_rgb", "a")),
+                state_key="state",
+            )
+
+    def test_unknown_robot_names_the_known_ones(self) -> None:
+        with self.assertRaises(KeyError) as caught:
+            get_robot_preset("g1")
+        for name in available_robots(include_aliases=True):
+            self.assertIn(name, str(caught.exception))
+
+
+class MockModel:
+    """In-process ``BareModel`` stand-in returning a constant normalized action."""
+
+    def __init__(self, num_views: int, value: float = 0.0) -> None:
+        self.action_horizon = HORIZON
+        self.action_dim = MODEL_DIM
+        self.num_views = num_views
+        self.image_size = IMAGE_SIZE
+        self.max_token_len = 200
+        self.images: list = []
+        self.states: list = []
+        self._value = value
+
+    def infer_rgb(self, rgb_u8, layout, token_ids, noise):
+        assert layout == "nhwc"
+        self.images.append(np.asarray(rgb_u8).copy())
+        return np.full((HORIZON, MODEL_DIM), self._value, dtype=np.float32)
+
+
+class RecordingTokenizer(PromptTokenizer):
+    """Discrete-state tokenizer that records the state it was handed."""
+
+    def __init__(self) -> None:
+        self.max_token_len = 200
+        self.discrete_state = True
+        self.seen_states: list = []
+
+    def __call__(self, prompt, state=None):
+        self.seen_states.append(None if state is None else np.asarray(state).copy())
+        return np.asarray([2, 108, 12], dtype=np.uint32)
+
+
+def build_g1_mock_policy() -> Pi05Policy:
+    """A G1-wired policy over a mock model: the real pipelines, no checkpoint.
+
+    Mirrors ``build_unitree_g1_policy`` but injects the model and an identity
+    unnormalizer, so the assertions isolate the adapter's arithmetic from
+    checkpoint norm_stats.
+    """
+    model = MockModel(num_views=len(G1_CAMERAS))
+    tokenizer = RecordingTokenizer()
+    identity = Unnormalizer(
+        q01=[-1.0] * MODEL_DIM, q99=[1.0] * MODEL_DIM, dims=MODEL_DIM, eps=0.0
+    )
+    input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+        model,
+        tokenizer=tokenizer,
+        unnormalizer=identity,
+        image_keys=G1_CAMERAS,
+        state_key=G1_STATE_KEY,
+    )
+    input_pipeline = input_pipeline.insert_before(
+        "tokenize", ("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))
+    )
+    output_pipeline = Pipeline(
+        [
+            ("unnormalize", Unnormalize(identity)),
+            ("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY)),
+            ("g1_encode", UnitreeG1EncodeActions()),
+        ]
+    )
+    policy = Pi05Policy(
+        model,
+        input_pipeline=input_pipeline,
+        output_pipeline=output_pipeline,
+        image_keys=G1_CAMERAS,
+        state_key=G1_STATE_KEY,
+        action_dim=G1_ROBOT_DIM,
+        metadata={"robot": "unitree_g1", "protocol": "openpi.websocket_policy"},
+    )
+    policy.tokenizer = tokenizer
+    return policy
+
+
+class RunningServer:
+    def __init__(self, policy) -> None:
+        self._policy_server = WebsocketPolicyServer(policy, "127.0.0.1", 0)
+        self._loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=10):
+            raise TimeoutError("websocket test server did not start")
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+
+        async def start() -> None:
+            self._server = await websocket_server.serve(
+                self._policy_server.handler,
+                "127.0.0.1",
+                0,
+                compression=None,
+                max_size=None,
+                process_request=health_check,
+            )
+            self.port = self._server.sockets[0].getsockname()[1]
+            self._ready.set()
+
+        self._loop.run_until_complete(start())
+        self._loop.run_forever()
+
+    def close(self) -> None:
+        async def stop() -> None:
+            self._server.close()
+            await self._server.wait_closed()
+
+        asyncio.run_coroutine_threadsafe(stop(), self._loop).result(timeout=10)
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=10)
+        self._loop.close()
+
+
+def g1_observation(state: np.ndarray, prompt: str = "pull down the black switch"):
+    """Exactly what an unmodified openpi G1 client sends."""
+    def cam(fill: int) -> np.ndarray:
+        return np.full((480, 640, 3), fill, dtype=np.uint8)
+
+    return {
+        "images": {
+            "cam_high": cam(10),
+            "cam_left_wrist": cam(20),
+            "cam_right_wrist": cam(30),
+        },
+        "state": state,
+        "prompt": prompt,
+    }
+
+
+class UnitreeG1ServingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = build_g1_mock_policy()
+        self.server = RunningServer(self.policy)
+
+    def tearDown(self) -> None:
+        self.server.close()
+
+    def test_unmodified_openpi_g1_observation_round_trips(self) -> None:
+        client = websocket_client_policy.WebsocketClientPolicy(
+            "127.0.0.1", self.server.port
+        )
+        metadata = client.get_server_metadata()
+        # The wire contract is published, so a client can assert it instead of
+        # discovering a mismatch as degraded behaviour.
+        self.assertEqual(metadata["robot"], "unitree_g1")
+        self.assertEqual(metadata["image_keys"], list(G1_CAMERAS))
+        self.assertEqual(metadata["state_key"], G1_STATE_KEY)
+        self.assertTrue(metadata["discrete_state"])
+        self.assertEqual(metadata["action_dim"], G1_ROBOT_DIM)
+
+        state = np.arange(G1_ROBOT_DIM, dtype=np.float32) / 100.0
+        try:
+            result = client.infer(g1_observation(state))
+        finally:
+            client._ws.close()
+
+        actions = result["actions"]
+        self.assertEqual(actions.shape, (HORIZON, G1_ROBOT_DIM))
+
+        # Cameras land in declared slot order, resized to the model edge.
+        stacked = self.policy.model.images[0]
+        self.assertEqual(stacked.shape, (3, IMAGE_SIZE, IMAGE_SIZE, 3))
+        for slot, fill in enumerate((10, 20, 30)):
+            self.assertEqual(int(stacked[slot].max()), fill, f"slot {slot}")
+
+        # State reached the tokenizer (dropped state is the silent failure mode).
+        seen = self.policy.tokenizer.seen_states[-1]
+        self.assertIsNotNone(seen)
+        np.testing.assert_allclose(seen[:7], state[:7], atol=1e-6)
+
+        # Model emitted normalized 0 -> identity-unnormalized 0, so every arm dim
+        # is exactly the current joint angle (delta 0 made absolute).
+        np.testing.assert_allclose(actions[0][:7], state[:7], atol=1e-6)
+        np.testing.assert_allclose(actions[0][8:15], state[8:15], atol=1e-6)
+        # Gripper dims are absolute already, and clipped into [0, 1].
+        self.assertTrue(np.all(actions[:, [7, 15]] >= 0.0))
+        self.assertTrue(np.all(actions[:, [7, 15]] <= 1.0))
+
+    def test_libero_keys_against_a_g1_server_fail_loudly(self) -> None:
+        # The delivered-Orin failure mode: a client sending LIBERO-shaped keys
+        # must be rejected with the served contract in the message, not served a
+        # plausible-looking action built from the wrong cameras.
+        client = websocket_client_policy.WebsocketClientPolicy(
+            "127.0.0.1", self.server.port
+        )
+        try:
+            with self.assertRaises(Exception) as caught:
+                client.infer(
+                    {
+                        "observation/image": np.zeros((224, 224, 3), dtype=np.uint8),
+                        "observation/wrist_image": np.zeros((224, 224, 3), dtype=np.uint8),
+                        "observation/state": np.zeros(G1_ROBOT_DIM, dtype=np.float32),
+                        "prompt": "pick up the cup",
+                    }
+                )
+        finally:
+            client._ws.close()
+        message = str(caught.exception)
+        self.assertIn("images/cam_high", message)
+        self.assertIn("missing observation keys", message)
+
+
+class ImageSlotOrderTest(unittest.TestCase):
+    """``image_keys`` order binds a camera to a model view slot."""
+
+    def test_reordering_image_keys_reorders_the_stacked_views(self) -> None:
+        model = MockModel(num_views=3)
+        reversed_keys = tuple(reversed(G1_CAMERAS))
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=Unnormalizer(
+                q01=[-1.0] * MODEL_DIM, q99=[1.0] * MODEL_DIM, dims=MODEL_DIM, eps=0.0
+            ),
+            image_keys=reversed_keys,
+            state_key=G1_STATE_KEY,
+        )
+        policy = Pi05Policy(
+            model,
+            input_pipeline=input_pipeline,
+            output_pipeline=output_pipeline,
+            image_keys=reversed_keys,
+            state_key=G1_STATE_KEY,
+            action_dim=MODEL_DIM,
+        )
+        policy.infer(g1_observation(np.zeros(G1_ROBOT_DIM, dtype=np.float32)))
+        # Same observation, reversed config -> reversed slots, and nothing warns.
+        # That silence is why presets pair each wire key with its slot name.
+        stacked = model.images[0]
+        for slot, fill in enumerate((30, 20, 10)):
+            self.assertEqual(int(stacked[slot].max()), fill, f"slot {slot}")
+
+    def test_view_count_must_match_the_checkpoint(self) -> None:
+        model = MockModel(num_views=3)
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy.default_pipelines(
+                model,
+                tokenizer=RecordingTokenizer(),
+                unnormalizer=Unnormalizer(q01=[-1.0], q99=[1.0], dims=1, eps=0.0),
+                image_keys=("observation/image", "observation/wrist_image"),
+            )
+        self.assertIn("3 camera views", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -412,7 +412,35 @@ class ImageSlotOrderTest(unittest.TestCase):
                 unnormalizer=Unnormalizer(q01=[-1.0], q99=[1.0], dims=1, eps=0.0),
                 image_keys=("observation/image", "observation/wrist_image"),
             )
-        self.assertIn("3 camera views", str(caught.exception))
+        message = str(caught.exception)
+        self.assertIn("3 camera views", message)
+        # Serving fewer cameras is legitimate; the error must name the way to do
+        # it rather than leaving the operator to pad with black frames.
+        self.assertIn("num_views=2", message)
+
+    def test_extra_image_keys_are_rejected_without_offering_a_fix(self) -> None:
+        # A checkpoint cannot grow a camera, so there is no num_views to suggest.
+        model = MockModel(num_views=1)
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy.default_pipelines(
+                model,
+                tokenizer=RecordingTokenizer(),
+                unnormalizer=Unnormalizer(q01=[-1.0], q99=[1.0], dims=1, eps=0.0),
+                image_keys=("observation/image", "observation/wrist_image"),
+            )
+        message = str(caught.exception)
+        self.assertNotIn("num_views=", message)
+        self.assertIn("cannot serve more cameras", message)
+
+
+    def test_num_views_disagreeing_with_a_passed_in_model_is_rejected(self) -> None:
+        # An already-loaded handle has its view count baked in, so honouring the
+        # argument is impossible; ignoring it would serve a shape nobody asked for.
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy.from_pretrained(
+                "/nonexistent", model=MockModel(num_views=3), num_views=2
+            )
+        self.assertIn("pass num_views to the load call", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes the served embodiment an explicit launch flag, so an openpi-compatible
client and this server agree on the wire contract instead of both assuming
LIBERO.

Today `scripts/pi05_openpi_websocket_server.py` hard-codes LIBERO's keys
(`observation/image`, `observation/wrist_image`, `observation/state`). A
checkpoint fine-tuned for another robot is served silently against the wrong
dialect: the keys miss, the state routing differs, the action width differs, and
the failure shows up as degraded actions rather than an error. openpi solves this
by fixing the embodiment at startup via `--policy.config <TrainConfig>`; this PR
adds the equivalent `--robot`.

## Changes

**`--robot <preset>`** — a preset carries the camera wire keys (order-significant:
key *i* fills model view slot *i*), the state key, whether state is discretized
into the prompt, and the deployable action width. Two presets ship:

| preset | keys | state | action_dim |
|---|---|---|---|
| `franka_libero` (default, alias `libero`) | `observation/image`, `observation/wrist_image` | dropped | 7 |
| `unitree_g1` | `images/cam_high`, `images/cam_left_wrist`, `images/cam_right_wrist` | discretized | 32 |

Presets are named `<arm>_<key convention>` on purpose: LIBERO and DROID are both
Franka Panda with different keys and action spaces, so `franka` alone would not
fix the contract, and `libero` names a benchmark rather than a robot.

**Nested observation keys** — `apxinf.processors.transforms` gains
`lookup_key`/`has_key`/`set_key`, resolving flat-with-slash first
(`"observation/image"`, LIBERO/DROID) and then walking a nested path
(`obs["images"]["cam_high"]`, ALOHA/Unitree G1). Both wire shapes exist in the
wild; this handles them without the caller knowing which it is.

**`--num-views N`** — serves a checkpoint with fewer cameras than it declares.
This is numerically equivalent to what openpi does by zero-padding the absent
views and masking them out, but it skips their ~256 patch tokens per view
instead of computing and discarding them (measured 1.38x on a 2-view LIBERO
checkpoint served with one camera). The equivalence holds because masked tokens
consume no RoPE position (`positions = cumsum(input_mask) - 1`), are excluded
from attention (`valid_mask = mask[:, None, :] * mask[:, :, None]`), and
`embed_prefix` runs the same `PaliGemma.img` encoder per view with no per-slot
learned embedding. `num_views` only sizes the prefix; nothing weight-shaped
depends on it, so the load-time override is sound.

The flag is **required to be explicit** — a short `--image-keys` list on its own
is an error. A forgotten camera key should fail at startup, not quietly cost
accuracy.

**Loud failures** — a missing camera key raises with the served contract in the
message; `--num-views` above the checkpoint's own count is rejected at load;
`--num-views` disagreeing with the number of image keys is rejected at parse;
and `--random-weights` now warns that its synthetic tokenizer cannot honour a
preset's `discrete_state=True`, rather than publishing a contract it is not
serving.

**`apxinf_py.pyi`** — the stub was missing `action_horizon` and `sampling_seed`;
restored to match the Rust signature, with `num_views` added.

## Compatibility

`--num-views` is a server-side launch flag, not part of the wire protocol —
an unmodified openpi client is unaffected. `--robot` defaults to
`franka_libero`, which is byte-for-byte the previous behaviour, so existing
launches are unchanged.

## Verification

On Jetson AGX Orin (sm87), against this branch rebased onto `main`:

- `cargo check` and `cargo build --release -p apxinf-py --features cuda,extension-module` — clean
- 20/20 unit tests in `tests/test_robot_presets.py` (key resolution, preset validation, G1 serving, image slot order)
- Real checkpoint `pi05_libero_base` under `--robot franka_libero`: actions `(50, 7)`, finite, 2962 ms
- Same checkpoint with `--num-views 1`: actions `(50, 7)`, finite, 2140 ms (1.38x)
- `--num-views 4` on a 2-view checkpoint: rejected at load with the view count in the message
- Missing wrist camera: `KeyError` naming the served `image_keys`
- `--robot unitree_g1` over real websocket transport with an **unmodified** `openpi_client`: nested-key round trip returns `(50, 32)`; a LIBERO-shaped observation is rejected rather than served

## Docs

`doc/adding-an-embodiment.md` is new: how to launch a server for an existing
embodiment (and how to read the served contract off the metadata before
concluding anything about accuracy), and the five-step recipe for registering a
new one — contract table, robot processing steps, adapter, preset row, tests.
Includes the naming rule, the three namespaces that are easy to collapse, and the
gotchas this port actually hit. `README.md` gains a `--robot` paragraph pointing
at it, and `doc/adding-a-new-model.md` a reciprocal link (that doc is the model
side; this one is the wire-contract side).
