### PR TITLE
docs: strengthen model port execution workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ nsys/
 .DS_Store
 __pycache__/
 *.py[cod]
+
+# Local model-port worktrees
+experiment/

--- a/doc/adding-a-new-model.md
+++ b/doc/adding-a-new-model.md
@@ -3,8 +3,9 @@
 Use this guide after the reference model runs and its semantics are understood.
 Follow [the porting workflow](porting-workflow.md) for evidence and acceptance,
 [the model-layer architecture](model-layer-architecture.md) for ownership and
-dependencies, and [the kernel guide](adding-new-kernels.md) for genuine backend
-gaps.
+dependencies, [Model Execution Wiring](model-execution-wiring.md) for composing
+the maintained device path, and [the kernel guide](adding-new-kernels.md) for
+genuine backend gaps.
 
 ## Start with a separate model directory
 
@@ -110,12 +111,25 @@ specialized fast path may recover a concrete backend for capabilities that do
 not belong on the portable trait. Trait is the floor; concrete types are the
 ceiling.
 
+Do not begin coverage discovery from `dyn Backend` alone. First inspect the
+closest maintained executor at the requested precision and the safe interfaces
+under `apxinf_cuda::kernels`, especially fused normalization/residual,
+QKV/RoPE/cache, attention, activation, and GEMM paths. Complete the execution
+ledger from [Model Execution Wiring](model-execution-wiring.md) before treating
+an operation as missing.
+
 ### Execution and preparation
 
 Separate reusable mathematics from execution state. A runtime may own device
 weights, caches, workspaces, CUDA graphs, and shape-specific preparation. A
 prepared object must bind every shape or condition that changes allocation,
 dispatch, or captured execution.
+
+Preparation runs the real fixed-shape executor once, installs required native
+plans, and proves workspace capacity before capture. Configuration validation
+alone is not preparation. Keep a CPU implementation inside a layer only as a
+named correctness scaffold; it is not the preferred target path and must be
+reported as performance debt.
 
 For VLA models, include state shape, image/grid structure, masks, action horizon,
 action width, embodiment/category selection, and stochastic input shape where
@@ -162,8 +176,9 @@ otherwise.
 
 ## Kernel decisions
 
-Try existing operators and reshapes first. A missing dtype, layout, shape, mask,
-or semantic variant may require backend work, but the new API must be
+Match repeated model sequences to existing fused safe interfaces first, then
+compose device primitives and layouts. A missing dtype, layout, shape, mask, or
+semantic variant may require backend work, but the new API must be
 model-neutral. Follow [Adding New Kernels](adding-new-kernels.md) and return to
 the original model references for operator replay.
 
@@ -188,5 +203,9 @@ the port is complete.
 
 The model has its own directory, uses the correct runtime contract, respects the
 model/backend boundary, loads through the maintained registry, passes declared
-numerical tolerances through the public path, reports unsupported cases
-clearly, and introduces no speculative shared abstraction.
+numerical tolerances through the public path, has no unintended hot-path host
+escapes or reports them as measured performance debt, audits applicable
+prepared/static/captured execution, reports functional and optimization status
+separately, reports unsupported cases clearly, and introduces no speculative
+shared abstraction. Explicit performance release gates remain mandatory;
+otherwise optimization is best effort.

--- a/doc/adding-a-new-model.md
+++ b/doc/adding-a-new-model.md
@@ -128,8 +128,10 @@ dispatch, or captured execution.
 Preparation runs the real fixed-shape executor once, installs required native
 plans, and proves workspace capacity before capture. Configuration validation
 alone is not preparation. Keep a CPU implementation inside a layer only as a
-named correctness scaffold; it is not the preferred target path and must be
-reported as performance debt.
+named correctness scaffold with an exit criterion. For an accelerator target,
+replace it through an existing safe device path or `adding-new-kernels.md`
+before completion; a repeated host escape is unfinished implementation rather
+than ordinary best-effort optimization debt.
 
 For VLA models, include state shape, image/grid structure, masks, action horizon,
 action width, embodiment/category selection, and stochastic input shape where
@@ -203,8 +205,8 @@ the port is complete.
 
 The model has its own directory, uses the correct runtime contract, respects the
 model/backend boundary, loads through the maintained registry, passes declared
-numerical tolerances through the public path, has no unintended hot-path host
-escapes or reports them as measured performance debt, audits applicable
+numerical tolerances through the public path, has no accelerator hot-path host
+escapes unless a concrete operator blocker is recorded, audits applicable
 prepared/static/captured execution, reports functional and optimization status
 separately, reports unsupported cases clearly, and introduces no speculative
 shared abstraction. Explicit performance release gates remain mandatory;

--- a/doc/adding-new-kernels.md
+++ b/doc/adding-new-kernels.md
@@ -1,5 +1,12 @@
 # Workflow for Adding New Hardware, Models, and Missing Operators to ApxInf
 
+This guide covers the vertical path for a genuinely missing operator. Before
+adding one for a model port, use
+[Model Execution Wiring](model-execution-wiring.md) to check maintained fused
+interfaces, device compositions, and runtime lifetime requirements. Absence
+from the portable backend trait alone is not evidence that a CUDA capability is
+missing.
+
 This document is intended for an agent responsible for porting a working PyTorch reference model to ApxInf. It assumes that the model already runs on the target hardware and that an initial scan has identified operators, data types, shapes, or hardware implementations missing from ApxInf.
 
 The goal is not to translate the PyTorch graph node by node. The goal is to:
@@ -725,4 +732,3 @@ Final acceptance criteria:
 - Individual operator and complete model outputs agree with the PyTorch reference within the appropriate precision tolerance.
 - CUDA Graph paths perform no illegal resource creation, synchronization, or dynamic allocation.
 - Performance optimizations are supported by profiling data collected on the target hardware.
-

--- a/doc/adding-new-kernels.md
+++ b/doc/adding-new-kernels.md
@@ -26,6 +26,15 @@ The goal is not to translate the PyTorch graph node by node. The goal is to:
 - Organize Custom CUDA sources by physical operation, not by model, executor, inference stage, or precision.
 - Prefer existing operators, reshapes, and vendor libraries. Do not add a kernel for every PyTorch expression.
 - The first implementation should be correct, verifiable, and have a safe fallback. Perform fusion and tuning only after profiling.
+- A CPU fallback may serve as a temporary correctness oracle while a target
+  accelerator path is under development. After replay proves the semantics,
+  continue through safe Rust API, FFI, adapter, CUDA implementation, workspace,
+  dispatch, and target-hardware replay. Repeated model-layer D2H/H2D is not a
+  completed accelerator implementation and must not be reclassified as generic
+  performance debt merely because end-to-end values pass.
+- CUDA compilation cost affects iteration strategy, not the required execution
+  path. Batch related kernel changes, use focused compile checks where the build
+  permits, and pay the full target build when validation requires it.
 - When no matching tactic exists, an operator must use its explicitly defined safe default or return a clear unsupported error. A model-level precision policy may explicitly require calibration or tuning artifacts.
 - Kernel launchers must not call `cudaStreamSynchronize`; doing so breaks asynchronous execution and CUDA Graph capture.
 - Unsupported hardware, dtype, shape, or alignment must use a correct fallback or return a clear error. It must never silently produce an incorrect result.
@@ -180,6 +189,11 @@ Reuse an existing ApxInf operator
 ```
 
 Record the selected backend, fallback, hardware constraints, and rationale in the gap table.
+
+When the selected path is a temporary host scaffold, also record its **exit
+criterion**: the safe device API that will replace it, the required workspace
+lifetime, and the operator replay that removes the scaffold. A passing model
+fixture starts that replacement work; it does not close the gap.
 
 ## 5. Define the Safe Rust Operator Contract First
 

--- a/doc/model-execution-wiring.md
+++ b/doc/model-execution-wiring.md
@@ -1,0 +1,141 @@
+# Model Execution Wiring
+
+Use this guide after model semantics are known and before writing the executor.
+It bridges the model equation and ApxInf's safe CUDA interfaces. The purpose is
+to design the maintained hot path, not merely to find an implementation that
+produces the right answer.
+
+## Start from an execution ledger
+
+Write one row for every repeated block and every boundary operation:
+
+| Reference computation | Tensor contract | Frequency | Preferred ApxInf call | Buffers and lifetime | Host traffic | Evidence |
+|---|---|---:|---|---|---|---|
+| semantic expression, including adjacent operations | shape, dtype, layout, broadcasting, rounding | per request, layer, or solver step | fused call, then primitive alternative | output, scratch, cache, stable address | expected transfer or `none` | replay fixture and tolerance |
+
+The ledger is a design artifact and may stay in the private port workspace. It
+must cover preprocessing-to-output, not only transformer blocks. Update it when
+the implementation differs from the plan.
+
+Search for an implementation in this order:
+
+1. the closest maintained optimized executor at the requested precision and
+   hardware, especially `crates/apxinf-model/src/pi05/*_executor.rs` and
+   `*_runtime.rs` for VLA execution;
+2. safe model-neutral interfaces under `crates/apxinf-cuda/src/kernels/`, with
+   particular attention to `fused.rs`, `attention.rs`, `rope.rs`, `norm.rs`,
+   `activation.rs`, `gemm/`, `cache.rs`, and `elementwise.rs`;
+3. the portable `Backend` trait when the operation belongs in a portable path;
+4. a new safe, model-neutral operator when required semantics really are absent.
+
+The portable trait is the capability floor, not a catalog of every optimized
+CUDA path. A missing `dyn Backend` method does not establish a kernel gap.
+Model code may recover the concrete CUDA seam described in
+[Adding a New Model](adding-a-new-model.md), but must not call raw FFI.
+
+## Select compositions before primitives
+
+Match sequences of semantics, not isolated framework nodes. Common candidates
+include projection plus bias/activation, residual plus normalization, QKV split
+plus positional encoding and cache write, gated MLP, adaptive normalization and
+residual gating, and solver updates. Prefer an existing fused safe call when its
+shape, layout, dtype, broadcast, mask, and intermediate-rounding contracts all
+match.
+
+Do not force a nearby fusion onto different semantics. Record why each repeated
+sequence uses a fused call, an unfused device composition, or requires a new
+operator. Validate a fused choice against the unfused/reference computation at
+the fusion boundary as well as at final output.
+
+Equivalent graph rewrites are encouraged. For example, separate Q, K, and V
+linear projections may be replaced by one packed QKV GEMM followed by an
+existing split, split-plus-RoPE, or split-plus-RoPE-plus-cache-write interface
+when the concatenated weight/bias order, head grouping, layout, dtype, and
+rounding are proven equivalent. In the current CUDA facade this commonly means
+one packed `gemm` call followed by `attention::split_qkv_bias_*` or
+`rope::split_qkv_apply_*`; it does not imply that GEMM and split are necessarily
+one CUDA launch. Record both the semantic fusion and the actual launch boundary.
+
+## Keep the hot path on the device
+
+After canonical inputs have been uploaded, intermediate tensors remain on the
+target device through the final model output. The steady-state ledger must have:
+
+- no intermediate device-to-host-to-device round trips;
+- no host implementation of activation, indexing, interpolation, scatter,
+  masking, positional encoding, or other layer mathematics;
+- no synchronization introduced only to inspect or transform an intermediate;
+- no per-layer or per-solver-step allocation that could have been prepared.
+
+Host work is appropriate for checkpoint loading, one-time weight conversion,
+canonical input preprocessing, explicit calibration, and final output transfer.
+A CPU implementation inside a layer may be used briefly to establish numerical
+evidence, but it is a **correctness scaffold**. Mark the affected ledger row,
+profile its cost, and report it as performance debt until it is replaced. It
+does not invalidate functional acceptance by itself, but it must never be an
+unreported consequence of an absent backend-trait method.
+
+## Plan tensor lifetime and reuse
+
+Classify each value by when it changes:
+
+- checkpoint lifetime: transformed weights, constant position tables;
+- prepared-profile lifetime: masks, index maps, shape metadata, graph workspace;
+- request lifetime: encoded images and language prefix, reusable cross-attention
+  keys and values;
+- solver-step lifetime: timestep embedding, noisy action state, step output;
+- layer lifetime: transient projections and normalization scratch.
+
+Compute or upload a value at the widest correct lifetime. In particular, audit
+iterative VLA paths for prefix/cross-attention KV, masks, position data, and
+timestep data that can be stored in fixed device buffers. A generic cache API
+is not proof that the model uses the right cache lifetime.
+
+## Prepare and capture fixed-shape execution
+
+For a fixed target profile, allocate outputs and scratch at stable addresses.
+Use `GraphWorkspace`, run the same inference body once through
+`prepare_with_workspace` to validate shapes and prepare native plans, then run
+it through `with_workspace` during CUDA Graph capture. Update captured input
+contents in place and replay the graph through the maintained runtime.
+
+Preparation must exercise the real executor. A method that only validates a
+configuration object is not execution preparation. If graph capture is
+unsupported for a required operation, record the exact operation and failure;
+an eager fallback is a known performance gap, not silent success. Compare eager
+and replayed outputs before relying on replay latency.
+
+## Wiring review
+
+Before reporting the port, provide evidence for all of the following:
+
+- every ledger row resolves to a safe device call, a named correctness
+  scaffold, or an explicit blocker;
+- every repeated adjacency has a documented fused-versus-unfused decision;
+- the steady-state host-transfer and synchronization list is empty except for
+  public input/output boundaries;
+- stable buffers and reusable KV/state are owned by the runtime at the correct
+  lifetime;
+- the fixed-shape path completes prepare, capture, input update, and replay, or
+  records the concrete capture gap as performance debt/blocker;
+- operator/layer replay, eager end-to-end, captured end-to-end, and public API
+  checks pass their declared tolerances;
+- wall-clock and graph-replay latency are reported separately, with any gap to
+  the stated target attributed to measured operations where possible.
+
+Report two independent outcomes:
+
+- **functional acceptance** requires the reference tolerance, maintained public
+  path, and clear unsupported-case behavior;
+- **optimization status** is `target met`, `best effort with performance debt`,
+  or `blocked`, with remaining host escapes, unfused hot sequences, missing
+  reusable state, capture gaps, and measured impact listed explicitly.
+
+Optimization is best effort unless the task explicitly defines it as a release
+gate. The agent must investigate and attempt the applicable existing paths, but
+an honest, measured performance gap does not erase a functionally correct port.
+
+Only after this review should a genuinely missing row be handed to
+[Adding New Kernels](adding-new-kernels.md). That guide explains how to add a
+kernel vertically; this guide decides which safe interface the model should
+call and how those calls form the execution path.

--- a/doc/model-execution-wiring.md
+++ b/doc/model-execution-wiring.md
@@ -71,9 +71,16 @@ Host work is appropriate for checkpoint loading, one-time weight conversion,
 canonical input preprocessing, explicit calibration, and final output transfer.
 A CPU implementation inside a layer may be used briefly to establish numerical
 evidence, but it is a **correctness scaffold**. Mark the affected ledger row,
-profile its cost, and report it as performance debt until it is replaced. It
-does not invalidate functional acceptance by itself, but it must never be an
-unreported consequence of an absent backend-trait method.
+profile its cost, and use it to validate the replacement boundary. Once the
+semantics are established, resolve the row through an existing safe device
+composition or the complete [Adding New Kernels](adding-new-kernels.md) path.
+For an accelerator target, a steady-state host scaffold is not deliverable
+optimization debt: it remains unfinished implementation unless a concrete
+operator blocker makes a correct device path impossible. Long CUDA build times,
+adapter rebuild scope, or the availability of a numerically correct host path
+do not satisfy that blocker. Ordinary optimization debt may cover an unfused
+device composition, untuned tactic, or documented capture gap after the hot
+computation itself remains on the device.
 
 ## Plan tensor lifetime and reuse
 
@@ -110,7 +117,7 @@ and replayed outputs before relying on replay latency.
 Before reporting the port, provide evidence for all of the following:
 
 - every ledger row resolves to a safe device call, a named correctness
-  scaffold, or an explicit blocker;
+  scaffold that is still being replaced, or an explicit blocker;
 - every repeated adjacency has a documented fused-versus-unfused decision;
 - the steady-state host-transfer and synchronization list is empty except for
   public input/output boundaries;
@@ -134,6 +141,8 @@ Report two independent outcomes:
 Optimization is best effort unless the task explicitly defines it as a release
 gate. The agent must investigate and attempt the applicable existing paths, but
 an honest, measured performance gap does not erase a functionally correct port.
+Best effort does not waive the device-residency rule for repeated accelerator
+model computation.
 
 Only after this review should a genuinely missing row be handed to
 [Adding New Kernels](adding-new-kernels.md). That guide explains how to add a

--- a/doc/model-layer-architecture.md
+++ b/doc/model-layer-architecture.md
@@ -87,6 +87,20 @@ Portable models use `dyn Backend`. Optimized runtimes may use concrete backend
 facilities for fusion, graph capture, or transfers that should not enlarge the
 portable trait. Trait is the floor; concrete types are the ceiling.
 
+ApxInf currently concentrates on CUDA backends, and the maintained model set
+does not yet provide enough repeated fusion cases to justify a stable abstract
+interface for every high-performance composition. Following YAGNI, broadly
+useful primitive operations may live on `Backend`, while optimized CUDA model
+paths call safe model-neutral fused functions through the model directory's
+CUDA seam. This direct safe call is intentional; raw FFI remains forbidden.
+
+Revisit that boundary when multiple maintained models or hardware backends need
+the same semantic fusion and lifecycle contract. At that point, extract the
+smallest common interface supported by those implementations instead of
+forecasting variants through optional flags today. Moving a proven fusion
+behind a trait later is an architectural evolution, not a prerequisite for its
+first correct optimized use.
+
 A fused mega-kernel still lives in the backend as a kernel implementation, but
 the model chooses when its semantics match. The backend does not import the
 model type.

--- a/doc/porting-workflow.md
+++ b/doc/porting-workflow.md
@@ -28,24 +28,51 @@ Before editing code, record outside the repository:
 - correctness tolerances and performance goals;
 - expected public API and deployment path.
 
-### Resolve missing inputs with the user
+### Discover missing inputs and ask early
+
+Treat the list above as a discovery contract, not as an assumption that the
+user has already supplied every value. Before implementation, inspect only the
+current task's allowed workspace and environment for evidence such as the
+reference checkout, checkpoint configuration, configured execution hosts, GPU
+capabilities, and CUDA toolchain. Do not infer a source revision, checkpoint
+variant, target precision, or hardware target from a similarly named branch or
+an unrelated previous experiment.
+
+If required facts remain unknown or ambiguous after that inspection, ask the
+user one concise, consolidated question. In particular, explicitly request the
+missing parts of:
+
+- reference source location and immutable revision;
+- checkpoint location and exact model variant;
+- target device or execution host, GPU/compute capability, and CUDA toolkit;
+- target inference dtype; and
+- mandatory correctness, latency, memory, or capture gates.
+
+Ask as ordinary requirements gathering and name what each missing value
+unlocks. Do not replace the question with a generic blocked-status message. A
+useful request is, for example: "To run the reference and design the CUDA path,
+please provide the reference source/revision, checkpoint, target GPU and CUDA
+environment, and inference dtype."
+
+This preflight is best effort rather than an all-or-nothing form:
+
+- continue independent repository inspection and design work while waiting
+  when it is safe and useful;
+- use an explicit user-provided value even when environment discovery suggests
+  a likely default;
+- when no performance target is supplied, pursue functional and numerical
+  acceptance first and report optimization as best effort;
+- do not require the user to repeat facts that are already available in the
+  current task or can be verified safely; and
+- report a blocker only when a specific missing fact prevents further useful
+  progress, after stating what was inspected, what operation is prevented, and
+  exactly what information or access would resolve it.
 
 The model variant, checkpoint, dtype, and target hardware are user choices, not
-implementation details. If any is missing, explicitly ask the user before
-implementation. First gather enough evidence to make the question useful:
-
-- inspect the model publisher's official GitHub repository and Hugging Face
-  organization for maintained variants, compatible checkpoints, licenses, and
-  reference precision;
-- inspect the available execution environment for GPU model, compute
-  capability, memory, CUDA toolkit, and existing official checkpoint caches;
-- compare those facts with ApxInf's currently supported devices and dtypes.
-
-Present one recommended default tuple and explain the tradeoff, plus alternatives
-when they materially change scope or feasibility. Recommendations are proposals:
-wait for the user to confirm or replace the model, checkpoint, dtype, and target
-hardware. Record the confirmed tuple before proceeding. Never infer consent from
-a convenient local cache or silently substitute a different model release.
+implementation details. Present one recommended tuple and explain material
+alternatives. Record the confirmed or explicitly authorized tuple before
+implementation; never infer consent from a convenient cache or silently
+substitute a different model release.
 
 Keep private paths and generated evidence under the private workspace described
 in `AGENTS.md`. Do not commit model weights, captured tensors, environment

--- a/doc/porting-workflow.md
+++ b/doc/porting-workflow.md
@@ -38,15 +38,43 @@ capabilities, and CUDA toolchain. Do not infer a source revision, checkpoint
 variant, target precision, or hardware target from a similarly named branch or
 an unrelated previous experiment.
 
-If required facts remain unknown or ambiguous after that inspection, ask the
-user one concise, consolidated question. In particular, explicitly request the
-missing parts of:
+At the first user-facing preflight, ask the user to choose an execution mode:
+
+- **hands-off (recommended):** continue through every workflow stage and stop
+  only at completion, a concrete blocker, or a required approval;
+- **hands-on:** pause at named review checkpoints and ask for direction, for
+  example before committing, choosing between materially different public
+  interfaces, or accepting measured optimization debt.
+
+If the user does not select a mode but has asked the agent to implement or
+complete the port, use hands-off. Record the selected mode in the private port
+notes. A progress summary is an update, not a stopping condition in hands-off
+mode. In hands-on mode, a checkpoint pause must ask a concrete question and
+state the default action; a bare progress report is not a checkpoint. Continue
+safe read-only discovery while waiting for the mode choice.
+
+If required facts remain unknown or ambiguous after inspection, combine them
+with the mode choice in one concise question. Explicitly request the missing
+parts of:
 
 - reference source location and immutable revision;
 - checkpoint location and exact model variant;
 - target device or execution host, GPU/compute capability, and CUDA toolkit;
 - target inference dtype; and
 - mandatory correctness, latency, memory, or capture gates.
+
+Offer discovered defaults rather than presenting every blank as homework:
+
+- when no source is supplied, search the model owner's official GitHub
+  repositories and propose an immutable revision;
+- when no checkpoint is supplied, search the model owner's official
+  Hugging Face repositories and propose the exact model/revision, without
+  treating a ref or partial cache as a complete local snapshot;
+- inspect the local machine first; if it is a Thor or Orin, propose the detected
+  GPU, compute capability, CUDA toolkit, and available execution path; otherwise
+  leave the target-hardware default blank; and
+- label every proposed value as discovered and unconfirmed until the user
+  accepts it or the task already authorizes that exact target.
 
 Ask as ordinary requirements gathering and name what each missing value
 unlocks. Do not replace the question with a generic blocked-status message. A
@@ -73,6 +101,11 @@ implementation details. Present one recommended tuple and explain material
 alternatives. Record the confirmed or explicitly authorized tuple before
 implementation; never infer consent from a convenient cache or silently
 substitute a different model release.
+
+In hands-off mode, continue after every intermediate validation, build result,
+or numerical checkpoint while required completion criteria remain. Do not end
+a turn with a list of remaining work unless the same message contains a
+specific blocker or approval request that prevents that work.
 
 Keep private paths and generated evidence under the private workspace described
 in `AGENTS.md`. Do not commit model weights, captured tensors, environment
@@ -150,7 +183,7 @@ facade before consulting only the portable backend trait.
 The design must identify fusion choices, tensor lifetimes, reusable KV/state,
 workspace ownership, host transfers, and CUDA Graph eligibility. Any CPU
 implementation inside the steady-state model graph is a temporary correctness
-scaffold and must be reported as performance debt.
+scaffold. Give it a device replacement and exit criterion in the ledger.
 
 ## 6. Check kernel coverage
 
@@ -167,8 +200,9 @@ classify it as:
 Layout adaptations and device fallbacks require operator-level replay against
 captured reference tensors. A declared fallback without replay evidence is a
 kernel gap, not a passed capability. A host fallback in the hot path may satisfy
-functional correctness, but remains visible performance debt even when its
-numerical replay passes.
+an intermediate functional checkpoint, but the accelerator port remains
+unfinished until the fallback is replaced or a concrete operator blocker is
+established.
 
 When a genuine gap is found, follow
 [`adding-new-kernels.md`](adding-new-kernels.md). Hand off the operation's full
@@ -268,6 +302,9 @@ A port is complete only when:
   Graph eligibility have been audited;
 - applicable existing optimized paths have been attempted and remaining
   performance debt is itemized;
+- every accelerator hot-path correctness scaffold has been replaced by a
+  device implementation, or a concrete operator blocker names the missing
+  semantics, attempted safe interfaces, and required resolution;
 - performance is measured with the declared metric and reported independently
   from functional acceptance;
 - the repository diff contains no private or one-off experiment artifacts.

--- a/doc/porting-workflow.md
+++ b/doc/porting-workflow.md
@@ -11,7 +11,9 @@ verification evidence agree.
 
 Before implementation, read [Adding a New Model](adding-a-new-model.md). Use
 [the model-layer architecture](model-layer-architecture.md) to decide ownership
-and refactoring boundaries. When coverage is missing, switch explicitly to
+and refactoring boundaries. Design the target device path with
+[Model Execution Wiring](model-execution-wiring.md). When coverage is missing,
+switch explicitly to
 [Adding New Kernels](adding-new-kernels.md) and return here after the kernel has
 been replayed against the original model evidence.
 
@@ -111,9 +113,22 @@ Do not approve a rewrite solely because shapes match or the final output looks
 plausible. If a supposedly canonical rewrite changes semantics, stop and report
 the gap.
 
-## 5. Check kernel coverage
+## 5. Design the target execution path
 
-For every computation required by the canonical model, classify it as:
+Before implementing the executor, build the execution ledger required by
+[Model Execution Wiring](model-execution-wiring.md). Resolve repeated semantic
+sequences against maintained optimized executors and the safe CUDA kernel
+facade before consulting only the portable backend trait.
+
+The design must identify fusion choices, tensor lifetimes, reusable KV/state,
+workspace ownership, host transfers, and CUDA Graph eligibility. Any CPU
+implementation inside the steady-state model graph is a temporary correctness
+scaffold and must be reported as performance debt.
+
+## 6. Check kernel coverage
+
+For every computation or repeated composition required by the canonical model,
+classify it as:
 
 - existing fused implementation;
 - existing primitive;
@@ -122,9 +137,11 @@ For every computation required by the canonical model, classify it as:
 - missing capability;
 - unsupported semantics.
 
-Layout adaptations and fallbacks require operator-level replay against captured
-reference tensors. A declared fallback without replay evidence is a kernel gap,
-not a passed capability.
+Layout adaptations and device fallbacks require operator-level replay against
+captured reference tensors. A declared fallback without replay evidence is a
+kernel gap, not a passed capability. A host fallback in the hot path may satisfy
+functional correctness, but remains visible performance debt even when its
+numerical replay passes.
 
 When a genuine gap is found, follow
 [`adding-new-kernels.md`](adding-new-kernels.md). Hand off the operation's full
@@ -135,7 +152,7 @@ After kernel work returns, replay it against the original model references and
 repeat coverage analysis. A returned implementation is not accepted merely
 because it builds or passes a synthetic unit test.
 
-## 6. Implement the model
+## 7. Implement the model
 
 Follow [Adding a New Model](adding-a-new-model.md), including its separate model
 directory, runtime-contract choice, and YAGNI rules. Consult
@@ -148,16 +165,16 @@ call raw CUDA, vendor libraries, or FFI directly.
 
 Prefer this order:
 
-1. reuse an existing runtime abstraction;
-2. reuse existing operators and layouts;
-3. add a model-neutral operator when semantics are genuinely missing;
-4. optimize only after correctness evidence exists.
+1. reuse the execution structure of a maintained optimized runtime;
+2. reuse matching fused safe interfaces;
+3. compose existing device primitives when fusion semantics do not match;
+4. add a model-neutral operator when semantics are genuinely missing.
 
 If implementation reveals that an earlier preflight assumption was wrong,
 return to semantic inventory or kernel coverage. Finding more work is progress,
 not completion.
 
-## 7. Verify independently
+## 8. Verify independently
 
 Verification must be runnable independently of the agent's reasoning notes.
 Use the repository's existing build, test, example, and benchmark mechanisms
@@ -171,12 +188,17 @@ Verify in increasing scope:
 3. complete deterministic inference against the reference;
 4. the public policy or serving API;
 5. requested target/precision tuples;
-6. latency and memory against stated goals.
+6. eager-versus-captured output parity;
+7. host-transfer and synchronization audit of the steady-state path;
+8. wall-clock and graph-replay latency plus memory against stated goals.
 
-Correctness gates are mandatory. Performance goals may remain explicitly
-unmet, but must not be reported as passed.
+Correctness gates are mandatory. Optimization is best effort unless the request
+explicitly declares a performance release gate. Report functional acceptance
+separately from optimization status. Unmet latency, host escapes, or capture
+gaps must include attempted reuse, measured impact where available, and the
+next concrete optimization; they must not be hidden behind a generic fallback.
 
-## 8. Prepare the review
+## 9. Prepare the review
 
 The reviewable change should contain only maintained product material:
 
@@ -215,5 +237,14 @@ A port is complete only when:
 - end-to-end output passes the declared tolerance;
 - the public deployment path has been exercised;
 - unsupported targets fail clearly;
-- performance is measured and reported honestly;
+- optimization opportunities, host escapes, static-buffer/KV reuse, and CUDA
+  Graph eligibility have been audited;
+- applicable existing optimized paths have been attempted and remaining
+  performance debt is itemized;
+- performance is measured with the declared metric and reported independently
+  from functional acceptance;
 - the repository diff contains no private or one-off experiment artifacts.
+
+When the task explicitly makes a latency, memory, or capture target a release
+gate, that target remains part of completion. Otherwise a functionally accepted
+port may finish with optimization status `best effort with performance debt`.

--- a/skills/model-port-workflow/SKILL.md
+++ b/skills/model-port-workflow/SKILL.md
@@ -25,14 +25,15 @@ background material.
 
 ## Workflow
 
-1. Fix the exact model variant and reference revision, checkpoint identity,
-   target hardware, precision, representative inputs, tolerances, performance
-   goals, and public API. When the user omits the model variant, checkpoint,
-   dtype, or hardware, inspect the official GitHub/Hugging Face sources and the
-   available execution environment, present recommended defaults with reasons,
-   and explicitly ask the user to confirm or replace them. Do not silently pick
-   these inputs. Completion: the user has confirmed every requested tuple and
-   acceptance threshold.
+1. During preflight, ask once for hands-off or hands-on execution and the
+   missing port inputs. Recommend hands-off and use it when an implementation
+   request does not choose a mode. Offer discovered official GitHub source and
+   Hugging Face checkpoint candidates; offer detected hardware defaults only
+   for local Thor or Orin. Then fix the reference revision, checkpoint
+   identity, target, precision, representative inputs, tolerances, performance
+   goals, and public API. Do not silently pick user choices: record the
+   confirmed or explicitly authorized tuple. Completion: every requested tuple
+   and acceptance threshold is explicit.
 2. Run the reference privately and capture deterministic inputs, outputs, and
    diagnostic tensors. Completion: the reference loads and repeated captures
    are attributable to the same source, environment, weights, and stochastic
@@ -43,12 +44,15 @@ background material.
    Inspect maintained optimized executors and fused interfaces before the
    portable backend trait. Account for tensor lifetime, reusable KV/state,
    workspace, host traffic, and graph eligibility. Completion: every hot-path
-   row has a device implementation, a named correctness scaffold, or a concrete
-   blocker.
+   row has a device implementation, a named correctness scaffold with a device
+   exit criterion, or a concrete blocker.
 5. Classify fused and primitive coverage. If a real gap exists, follow
    `adding-new-kernels.md`, then replay the returned implementation against the
-   original references. A CPU layer implementation is only a named correctness
-   scaffold and must be reported as performance debt.
+   original references. A CPU layer implementation is a named correctness
+   scaffold with an exit criterion. On an accelerator target, replace every
+   repeated hot-path scaffold with a safe device path; build cost and passing
+   end-to-end values do not turn host round trips into deliverable performance
+   debt.
 6. Create `crates/apxinf-model/src/<model>/`. Start with a self-contained
    implementation; copy a close model when useful and defer shared extraction
    until repeated maintained implementations prove the seam.
@@ -64,6 +68,12 @@ background material.
    temporary adapters, replay scripts, and agent state outside the repository.
 
 ## Stop conditions
+
+In hands-off mode, intermediate builds, numerical checkpoints, progress
+summaries, and uncommitted changes are continuation points. Stop only at the
+completion criteria, a concrete blocker, or an approval the agent cannot grant.
+In hands-on mode, pause at named checkpoints with a concrete question and a
+default next action, including whether to commit when that choice is useful.
 
 Stop with a concrete blocker when the reference cannot run, semantics remain
 unknown, canonical equivalence fails, a required kernel has no correct path, or

--- a/skills/model-port-workflow/SKILL.md
+++ b/skills/model-port-workflow/SKILL.md
@@ -15,7 +15,9 @@ Read these repository documents before changing code:
    or changing model-layer code. Follow its separate-directory and YAGNI rules.
 3. [`doc/model-layer-architecture.md`](../../doc/model-layer-architecture.md)
    when deciding ownership, dependencies, runtime seams, or refactoring.
-4. [`doc/adding-new-kernels.md`](../../doc/adding-new-kernels.md) whenever
+4. [`doc/model-execution-wiring.md`](../../doc/model-execution-wiring.md) before
+   implementing an executor or deciding that optimized coverage is missing.
+5. [`doc/adding-new-kernels.md`](../../doc/adding-new-kernels.md) whenever
    operator, dtype, layout, shape, or hardware coverage is missing.
 
 Read each selected document completely. Treat them as instructions, not
@@ -37,25 +39,37 @@ background material.
    inputs.
 3. Inventory semantics and weight transformations. Completion: every required
    computation is understood independently of its framework operator name.
-4. Classify kernel coverage. Reuse model-neutral operations first. If a real
-   gap exists, follow `adding-new-kernels.md`, then replay the returned
-   implementation against the original references.
-5. Create `crates/apxinf-model/src/<model>/`. Start with a self-contained
+4. Create an execution ledger from reference semantics through safe CUDA calls.
+   Inspect maintained optimized executors and fused interfaces before the
+   portable backend trait. Account for tensor lifetime, reusable KV/state,
+   workspace, host traffic, and graph eligibility. Completion: every hot-path
+   row has a device implementation, a named correctness scaffold, or a concrete
+   blocker.
+5. Classify fused and primitive coverage. If a real gap exists, follow
+   `adding-new-kernels.md`, then replay the returned implementation against the
+   original references. A CPU layer implementation is only a named correctness
+   scaffold and must be reported as performance debt.
+6. Create `crates/apxinf-model/src/<model>/`. Start with a self-contained
    implementation; copy a close model when useful and defer shared extraction
    until repeated maintained implementations prove the seam.
-6. Integrate through the appropriate maintained contract: `LlmTrait` for
+7. Integrate through the appropriate maintained contract: `LlmTrait` for
    LLM/VLM or `VlaRuntime` plus the Python policy layer for VLA.
-7. Verify operators, transformations, intermediate checkpoints, complete
-   inference, public serving/policy integration, and requested performance.
-8. Prepare a product-only diff. Keep checkpoints, captures, generated reports,
+8. Verify operators, transformations, intermediate checkpoints, eager and
+   captured inference, host-transfer audit, public serving/policy integration,
+   and requested performance. Report functional acceptance separately from
+   optimization status (`target met`, `best effort with performance debt`, or
+   `blocked`). Performance is best effort unless explicitly declared a release
+   gate, but applicable existing optimized paths must be investigated.
+9. Prepare a product-only diff. Keep checkpoints, captures, generated reports,
    temporary adapters, replay scripts, and agent state outside the repository.
 
 ## Stop conditions
 
 Stop with a concrete blocker when the reference cannot run, semantics remain
 unknown, canonical equivalence fails, a required kernel has no correct path, or
-the maintained public integration cannot be exercised. Report unmet
-performance goals separately from correctness.
+the maintained public integration cannot be exercised. A performance gap alone
+is not a stop condition unless performance is an explicit release gate; exhaust
+applicable existing paths, measure the gap, and report the remaining debt.
 
 A partial foundation is not a completion condition. While safe in-scope work
 remains, continue through the runtime, public integration, and end-to-end


### PR DESCRIPTION
## Summary
- add an execution-wiring guide that maps model semantics to maintained fused CUDA interfaces, workspaces, static state, and CUDA Graph capture
- add hands-off and hands-on interaction modes with actionable input discovery defaults
- require accelerator hot-path CPU scaffolds to exit through an existing device path or the complete kernel-integration workflow
- keep functional acceptance separate from device-resident optimization debt while preventing progress checkpoints from ending hands-off ports

## Validation
- rebased onto upstream/main at 28e8ad4
- git diff --check upstream/main...HEAD
- audited changed paths and confirmed the branch contains no GR00T implementation files or symbols