### PR TITLE
experiment: validate GR00T N1.7 GPU port workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ Reported latency is P50 over 30 samples after 10 warm-up iterations
 import numpy as np
 from apxinf import AutoPolicy
 
-policy = AutoPolicy.from_pretrained("<path-to-model>", precision="bf16", action_dim=7)
+# image_keys / state_key are the wire contract — the policy holds no dataset's
+# convention as a default, so state the ones your client actually sends. These
+# are LIBERO's; `--robot <preset>` on the server does this for you from a table.
+policy = AutoPolicy.from_pretrained(
+    "<path-to-model>",
+    precision="bf16",
+    action_dim=7,
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+)
 
 result = policy.infer({
     "observation/image":       np.zeros((256, 256, 3), np.uint8),

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ from apxinf import AutoPolicy
 
 # image_keys / state_key are the wire contract — the policy holds no dataset's
 # convention as a default, so state the ones your client actually sends. These
-# are LIBERO's; `--robot <preset>` on the server does this for you from a table.
+# are LIBERO's (`apxinf.conventions.LIBERO`); `--robot <preset>` on the server,
+# or `build_robot_policy(...)` in code, does this for you from a table.
 policy = AutoPolicy.from_pretrained(
     "<path-to-model>",
     precision="bf16",

--- a/crates/apxinf-cuda/adapters/custom_kernels.cu
+++ b/crates/apxinf-cuda/adapters/custom_kernels.cu
@@ -2,6 +2,7 @@
 // Stable C ABI and CUDA launch adapter for custom static-inference operators.
 
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
@@ -11,6 +12,27 @@
 #include <cstring>
 
 namespace {
+
+__global__ void cast_f32_bf16_kernel(const float* input, __nv_bfloat16* output,
+                                     int64_t count) {
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < count; i += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+    output[i] = __float2bfloat16(input[i]);
+  }
+}
+
+__global__ void scatter_rows_bf16_kernel(const __nv_bfloat16* source,
+                                         const uint32_t* positions,
+                                         __nv_bfloat16* destination,
+                                         int rows, int cols) {
+  int64_t count = static_cast<int64_t>(rows) * cols;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < count; i += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+    int row = static_cast<int>(i / cols);
+    int col = static_cast<int>(i - static_cast<int64_t>(row) * cols);
+    destination[static_cast<int64_t>(positions[row]) * cols + col] = source[i];
+  }
+}
 #include "../kernels/custom/math.cuh"
 #include "../kernels/custom/reduction.cuh"
 #include "../kernels/custom/quantization.cuh"
@@ -23,6 +45,30 @@ namespace {
 #include "../kernels/custom/fused.cuh"
 #include "../kernels/custom/cache.cuh"
 }  // namespace
+
+extern "C" cudaError_t apxinf_cast_f32_bf16(
+    const void* input, void* output, int64_t count, cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || count <= 0) return cudaErrorInvalidValue;
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 4096 ? 4096 : blocks;
+  cast_f32_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const float*>(input), static_cast<__nv_bfloat16*>(output), count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_scatter_rows_bf16(
+    const void* source, const uint32_t* positions, void* destination,
+    int rows, int cols, cudaStream_t stream) {
+  if (source == nullptr || positions == nullptr || destination == nullptr ||
+      rows <= 0 || cols <= 0) return cudaErrorInvalidValue;
+  int64_t count = static_cast<int64_t>(rows) * cols;
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 4096 ? 4096 : blocks;
+  scatter_rows_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(source), positions,
+      static_cast<__nv_bfloat16*>(destination), rows, cols);
+  return cudaGetLastError();
+}
 
 namespace {
 

--- a/crates/apxinf-cuda/adapters/tensorrt_adapter.cpp
+++ b/crates/apxinf-cuda/adapters/tensorrt_adapter.cpp
@@ -1,0 +1,168 @@
+#include <NvInfer.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+thread_local std::string last_error;
+
+class Logger final : public nvinfer1::ILogger {
+ public:
+  void log(Severity severity, char const* message) noexcept override {
+    if (severity <= Severity::kERROR) last_error = message ? message : "TensorRT error";
+  }
+};
+
+Logger logger;
+
+template <typename T>
+struct TrtDelete {
+  void operator()(T* value) const noexcept { delete value; }
+};
+
+struct Engine {
+  std::unique_ptr<nvinfer1::IRuntime, TrtDelete<nvinfer1::IRuntime>> runtime;
+  std::unique_ptr<nvinfer1::ICudaEngine, TrtDelete<nvinfer1::ICudaEngine>> engine;
+  std::unique_ptr<nvinfer1::IExecutionContext, TrtDelete<nvinfer1::IExecutionContext>> context;
+};
+
+void fail(char const* message) { last_error = message ? message : "TensorRT error"; }
+
+}  // namespace
+
+extern "C" {
+
+char const* apxinf_trt_last_error() { return last_error.c_str(); }
+
+void* apxinf_trt_load(char const* path) {
+  last_error.clear();
+  if (!path) {
+    fail("TensorRT engine path is null");
+    return nullptr;
+  }
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input) {
+    last_error = std::string("open TensorRT engine: ") + path;
+    return nullptr;
+  }
+  auto const size = input.tellg();
+  if (size <= 0) {
+    fail("TensorRT engine is empty");
+    return nullptr;
+  }
+  input.seekg(0, std::ios::beg);
+  std::vector<char> bytes(static_cast<size_t>(size));
+  if (!input.read(bytes.data(), size)) {
+    fail("read TensorRT engine");
+    return nullptr;
+  }
+
+  auto value = std::make_unique<Engine>();
+  value->runtime.reset(nvinfer1::createInferRuntime(logger));
+  if (!value->runtime) {
+    fail("create TensorRT runtime");
+    return nullptr;
+  }
+  value->engine.reset(value->runtime->deserializeCudaEngine(bytes.data(), bytes.size()));
+  if (!value->engine) {
+    if (last_error.empty()) fail("deserialize TensorRT engine");
+    return nullptr;
+  }
+  value->context.reset(value->engine->createExecutionContext());
+  if (!value->context) {
+    fail("create TensorRT execution context");
+    return nullptr;
+  }
+  return value.release();
+}
+
+void apxinf_trt_destroy(void* opaque) { delete static_cast<Engine*>(opaque); }
+
+int32_t apxinf_trt_num_io(void const* opaque) {
+  auto const* value = static_cast<Engine const*>(opaque);
+  return value ? value->engine->getNbIOTensors() : -1;
+}
+
+char const* apxinf_trt_tensor_name(void const* opaque, int32_t index) {
+  auto const* value = static_cast<Engine const*>(opaque);
+  if (!value || index < 0 || index >= value->engine->getNbIOTensors()) return nullptr;
+  return value->engine->getIOTensorName(index);
+}
+
+int32_t apxinf_trt_tensor_mode(void const* opaque, char const* name) {
+  auto const* value = static_cast<Engine const*>(opaque);
+  if (!value || !name) return -1;
+  return value->engine->getTensorIOMode(name) == nvinfer1::TensorIOMode::kINPUT ? 0 : 1;
+}
+
+int32_t apxinf_trt_tensor_dtype(void const* opaque, char const* name) {
+  auto const* value = static_cast<Engine const*>(opaque);
+  if (!value || !name) return -1;
+  // TensorRT appends data types without renumbering the stable ABI enum.
+  // Returning the numeric value keeps this adapter source-compatible with
+  // Jetson's older 10.3 headers (which do not name the newest FP4 member).
+  return static_cast<int32_t>(value->engine->getTensorDataType(name));
+}
+
+int32_t apxinf_trt_tensor_shape(void const* opaque, char const* name, int64_t* dims,
+                                int32_t capacity) {
+  auto const* value = static_cast<Engine const*>(opaque);
+  if (!value || !name) return -1;
+  auto shape = value->context->getTensorShape(name);
+  if (shape.nbDims < 0 || capacity < shape.nbDims) return -1;
+  for (int32_t i = 0; i < shape.nbDims; ++i) dims[i] = shape.d[i];
+  return shape.nbDims;
+}
+
+int32_t apxinf_trt_set_input_shape(void* opaque, char const* name, int64_t const* dims,
+                                   int32_t rank) {
+  last_error.clear();
+  auto* value = static_cast<Engine*>(opaque);
+  if (!value || !name || !dims || rank < 0 || rank > nvinfer1::Dims::MAX_DIMS) {
+    fail("invalid TensorRT input shape arguments");
+    return -1;
+  }
+  nvinfer1::Dims shape{};
+  shape.nbDims = rank;
+  for (int32_t i = 0; i < rank; ++i) shape.d[i] = dims[i];
+  if (!value->context->setInputShape(name, shape)) {
+    last_error = std::string("set TensorRT input shape: ") + name;
+    return -1;
+  }
+  return 0;
+}
+
+int32_t apxinf_trt_set_address(void* opaque, char const* name, void* address) {
+  last_error.clear();
+  auto* value = static_cast<Engine*>(opaque);
+  if (!value || !name || !address) {
+    fail("invalid TensorRT tensor address arguments");
+    return -1;
+  }
+  if (!value->context->setTensorAddress(name, address)) {
+    last_error = std::string("set TensorRT tensor address: ") + name;
+    return -1;
+  }
+  return 0;
+}
+
+int32_t apxinf_trt_enqueue(void* opaque, void* stream) {
+  last_error.clear();
+  auto* value = static_cast<Engine*>(opaque);
+  if (!value || !stream) {
+    fail("invalid TensorRT enqueue arguments");
+    return -1;
+  }
+  if (!value->context->enqueueV3(static_cast<cudaStream_t>(stream))) {
+    if (last_error.empty()) fail("TensorRT enqueueV3 failed");
+    return -1;
+  }
+  return 0;
+}
+
+}  // extern "C"

--- a/crates/apxinf-cuda/build.rs
+++ b/crates/apxinf-cuda/build.rs
@@ -116,6 +116,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_sm80)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_f16_sm100)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_direct_e4m3_sm100)");
+    println!("cargo:rustc-check-cfg=cfg(apxinf_tensorrt)");
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH");
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH_CUTLASS");
     println!("cargo:rerun-if-env-changed=APXINF_KERNEL_BUILD_ID");
@@ -272,6 +273,36 @@ fn main() {
                 kernel_files.iter().all(|path| path.is_file()),
                 "one or more required CUDA adapters are missing under {adapters_dir}"
             );
+
+            // TensorRT is optional at build time. Jetson deployment images
+            // provide the headers and runtime, while developer machines (and
+            // CPU-only CI) often do not. Compile the stable C ABI only when a
+            // complete installation is visible; the model loader reports a
+            // precise unsupported-runtime error otherwise.
+            let tensorrt_include_dirs = [
+                "/usr/include".to_string(),
+                format!("/usr/include/{arch}-linux-gnu"),
+                "/usr/include/aarch64-linux-gnu".to_string(),
+                "/usr/local/include".to_string(),
+            ];
+            let tensorrt_header = tensorrt_include_dirs
+                .iter()
+                .find(|dir| std::path::Path::new(dir).join("NvInfer.h").is_file())
+                .cloned();
+            let tensorrt_adapter = std::path::Path::new(&adapters_dir).join("tensorrt_adapter.cpp");
+            let has_tensorrt_library =
+                lib_dirs.iter().any(|dir| {
+                    std::path::Path::new(dir).join("libnvinfer.so").is_file()
+                        || std::path::Path::new(dir).join("libnvinfer.so.10").is_file()
+                }) || std::path::Path::new("/usr/lib/aarch64-linux-gnu/libnvinfer.so").is_file();
+            let has_tensorrt =
+                tensorrt_header.is_some() && has_tensorrt_library && tensorrt_adapter.is_file();
+            if has_tensorrt {
+                kernel_files.push(tensorrt_adapter.clone());
+                println!("cargo:rustc-cfg=apxinf_tensorrt");
+                println!("cargo:rustc-link-search=native=/usr/lib/aarch64-linux-gnu");
+                println!("cargo:rustc-link-lib=nvinfer");
+            }
 
             let cutlass_root = std::path::Path::new(&kernels_dir).join("cutlass");
             let cutlass_fmha_operator = cutlass_root.join("fmha_sm100.cu");
@@ -488,6 +519,13 @@ fn main() {
                             cmd.arg(format!("-I{include}"));
                         }
                     }
+                    if entry == &tensorrt_adapter {
+                        for include in &tensorrt_include_dirs {
+                            if std::path::Path::new(include).exists() {
+                                cmd.arg(format!("-I{include}"));
+                            }
+                        }
+                    }
                     if entry == &cutlass_fmha
                         || entry == &cutlass_gemm_operator
                         || entry == &cutlass_fp8_dual_operator
@@ -594,6 +632,9 @@ fn main() {
                 println!("cargo:rustc-link-lib=cublasLt");
                 println!("cargo:rustc-link-lib=cublas");
                 println!("cargo:rustc-link-lib=cudart");
+                if has_tensorrt {
+                    println!("cargo:rustc-link-lib=nvinfer");
+                }
                 println!("cargo:rustc-link-lib=stdc++");
             }
         }

--- a/crates/apxinf-cuda/src/ffi/custom.rs
+++ b/crates/apxinf-cuda/src/ffi/custom.rs
@@ -5,6 +5,22 @@ use std::ffi::c_void;
 use super::cuda::{cudaError_t, cudaStream_t};
 
 extern "C" {
+    pub fn apxinf_cast_f32_bf16(
+        input: *const c_void,
+        output: *mut c_void,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+
+    pub fn apxinf_scatter_rows_bf16(
+        source: *const c_void,
+        positions: *const u32,
+        destination: *mut c_void,
+        rows: i32,
+        cols: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+
     pub fn apxinf_static_evict_l2(
         buffer: *mut c_void,
         bytes: usize,

--- a/crates/apxinf-cuda/src/kernels/elementwise.rs
+++ b/crates/apxinf-cuda/src/kernels/elementwise.rs
@@ -11,6 +11,60 @@ use crate::context::CudaContext;
 use crate::ffi;
 use crate::workspace::output_buffer;
 
+pub fn cast_f32_to_bf16(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
+    if input.dtype() != DType::F32 || input.device() != apxinf_core::Device::Cuda(ctx.device_id()) {
+        return Err(Error::Other(
+            "f32-to-bf16 cast expects a CUDA f32 tensor on the active device".into(),
+        ));
+    }
+    let output = CudaBuffer::alloc(input.numel() * 2, ctx.device_id()).map_err(Error::Cuda)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_cast_f32_bf16(
+            gpu_ptr(input)?,
+            output.ptr(),
+            input.numel() as i64,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(make_gpu_tensor(
+        input.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+pub fn scatter_rows_bf16(
+    ctx: &CudaContext,
+    source: &Tensor,
+    positions: &CudaBuffer,
+    destination: &Tensor,
+) -> Result<()> {
+    let (rows, cols) = matrix_shape(source, "BF16 row scatter")?;
+    let destination_dims = destination.shape().dims();
+    if source.dtype() != DType::BF16
+        || destination.dtype() != DType::BF16
+        || destination_dims.len() != 2
+        || destination_dims[1] != cols
+        || positions.len() < rows * std::mem::size_of::<u32>()
+        || positions.device() != ctx.device_id()
+    {
+        return Err(Error::Other("BF16 row scatter shape mismatch".into()));
+    }
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_scatter_rows_bf16(
+            gpu_ptr(source)?,
+            positions.ptr().cast(),
+            gpu_ptr(destination)?,
+            rows as i32,
+            cols as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)
+    }
+}
+
 pub fn add_into(
     ctx: &CudaContext,
     dtype: DType,

--- a/crates/apxinf-cuda/src/lib.rs
+++ b/crates/apxinf-cuda/src/lib.rs
@@ -18,6 +18,11 @@ pub mod nvtx;
 pub mod profiler;
 mod sampling;
 pub mod stream;
+#[cfg(apxinf_tensorrt)]
+pub mod tensorrt;
+#[cfg(not(apxinf_tensorrt))]
+#[path = "tensorrt_stub.rs"]
+pub mod tensorrt;
 pub mod transfers;
 pub mod tuning;
 mod workspace;

--- a/crates/apxinf-cuda/src/tensorrt.rs
+++ b/crates/apxinf-cuda/src/tensorrt.rs
@@ -1,0 +1,218 @@
+//! Thin, owning TensorRT execution wrapper.
+//!
+//! TensorRT remains an optional platform capability. The C++ ABI boundary is
+//! deliberately confined to `adapters/tensorrt_adapter.cpp`; model code sees
+//! checked names, shapes, data types, and ApxInf-owned CUDA buffers.
+
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::path::Path;
+use std::ptr::NonNull;
+
+use crate::{CudaBuffer, CudaContext};
+
+unsafe extern "C" {
+    fn apxinf_trt_last_error() -> *const c_char;
+    fn apxinf_trt_load(path: *const c_char) -> *mut c_void;
+    fn apxinf_trt_destroy(engine: *mut c_void);
+    fn apxinf_trt_num_io(engine: *const c_void) -> i32;
+    fn apxinf_trt_tensor_name(engine: *const c_void, index: i32) -> *const c_char;
+    fn apxinf_trt_tensor_mode(engine: *const c_void, name: *const c_char) -> i32;
+    fn apxinf_trt_tensor_dtype(engine: *const c_void, name: *const c_char) -> i32;
+    fn apxinf_trt_tensor_shape(
+        engine: *const c_void,
+        name: *const c_char,
+        dims: *mut i64,
+        capacity: i32,
+    ) -> i32;
+    fn apxinf_trt_set_input_shape(
+        engine: *mut c_void,
+        name: *const c_char,
+        dims: *const i64,
+        rank: i32,
+    ) -> c_int;
+    fn apxinf_trt_set_address(
+        engine: *mut c_void,
+        name: *const c_char,
+        address: *mut c_void,
+    ) -> c_int;
+    fn apxinf_trt_enqueue(engine: *mut c_void, stream: *mut c_void) -> c_int;
+}
+
+fn last_error(operation: &str) -> String {
+    let detail = unsafe {
+        let value = apxinf_trt_last_error();
+        (!value.is_null())
+            .then(|| CStr::from_ptr(value).to_string_lossy().into_owned())
+            .unwrap_or_default()
+    };
+    if detail.is_empty() {
+        operation.to_owned()
+    } else {
+        format!("{operation}: {detail}")
+    }
+}
+
+fn name(value: &str) -> Result<CString, String> {
+    CString::new(value).map_err(|_| format!("TensorRT tensor name contains NUL: {value:?}"))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorMode {
+    Input,
+    Output,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorDType {
+    F32,
+    F16,
+    I8,
+    I32,
+    Bool,
+    U8,
+    Fp8,
+    BF16,
+    I64,
+    I4,
+    Fp4,
+}
+
+impl TensorDType {
+    pub fn size_in_bytes(self) -> usize {
+        match self {
+            Self::F32 | Self::I32 => 4,
+            Self::F16 | Self::BF16 => 2,
+            Self::I64 => 8,
+            Self::I8 | Self::Bool | Self::U8 | Self::Fp8 => 1,
+            Self::I4 | Self::Fp4 => 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TensorInfo {
+    pub name: String,
+    pub mode: TensorMode,
+    pub dtype: TensorDType,
+    pub shape: Vec<i64>,
+}
+
+pub struct Engine {
+    raw: NonNull<c_void>,
+}
+
+impl Engine {
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let path = CString::new(path.to_string_lossy().as_bytes())
+            .map_err(|_| format!("TensorRT engine path contains NUL: {}", path.display()))?;
+        let raw = NonNull::new(unsafe { apxinf_trt_load(path.as_ptr()) })
+            .ok_or_else(|| last_error("load TensorRT engine"))?;
+        Ok(Self { raw })
+    }
+
+    pub fn tensors(&self) -> Result<Vec<TensorInfo>, String> {
+        let count = unsafe { apxinf_trt_num_io(self.raw.as_ptr()) };
+        if count < 0 {
+            return Err(last_error("query TensorRT I/O count"));
+        }
+        (0..count)
+            .map(|index| {
+                let raw_name = unsafe { apxinf_trt_tensor_name(self.raw.as_ptr(), index) };
+                if raw_name.is_null() {
+                    return Err(format!("TensorRT I/O {index} has no name"));
+                }
+                let value = unsafe { CStr::from_ptr(raw_name) }
+                    .to_string_lossy()
+                    .into_owned();
+                Ok(TensorInfo {
+                    mode: self.mode(&value)?,
+                    dtype: self.dtype(&value)?,
+                    shape: self.shape(&value)?,
+                    name: value,
+                })
+            })
+            .collect()
+    }
+
+    pub fn mode(&self, tensor: &str) -> Result<TensorMode, String> {
+        match unsafe { apxinf_trt_tensor_mode(self.raw.as_ptr(), name(tensor)?.as_ptr()) } {
+            0 => Ok(TensorMode::Input),
+            1 => Ok(TensorMode::Output),
+            value => Err(format!("unknown TensorRT tensor mode {value} for {tensor}")),
+        }
+    }
+
+    pub fn dtype(&self, tensor: &str) -> Result<TensorDType, String> {
+        match unsafe { apxinf_trt_tensor_dtype(self.raw.as_ptr(), name(tensor)?.as_ptr()) } {
+            0 => Ok(TensorDType::F32),
+            1 => Ok(TensorDType::F16),
+            2 => Ok(TensorDType::I8),
+            3 => Ok(TensorDType::I32),
+            4 => Ok(TensorDType::Bool),
+            5 => Ok(TensorDType::U8),
+            6 => Ok(TensorDType::Fp8),
+            7 => Ok(TensorDType::BF16),
+            8 => Ok(TensorDType::I64),
+            9 => Ok(TensorDType::I4),
+            10 => Ok(TensorDType::Fp4),
+            value => Err(format!("unknown TensorRT dtype {value} for {tensor}")),
+        }
+    }
+
+    pub fn shape(&self, tensor: &str) -> Result<Vec<i64>, String> {
+        let tensor = name(tensor)?;
+        let mut dims = [0i64; 16];
+        let rank = unsafe {
+            apxinf_trt_tensor_shape(
+                self.raw.as_ptr(),
+                tensor.as_ptr(),
+                dims.as_mut_ptr(),
+                dims.len() as i32,
+            )
+        };
+        if rank < 0 {
+            return Err(last_error("query TensorRT tensor shape"));
+        }
+        Ok(dims[..rank as usize].to_vec())
+    }
+
+    pub fn set_input_shape(&self, tensor: &str, dims: &[i64]) -> Result<(), String> {
+        let tensor = name(tensor)?;
+        let status = unsafe {
+            apxinf_trt_set_input_shape(
+                self.raw.as_ptr(),
+                tensor.as_ptr(),
+                dims.as_ptr(),
+                dims.len() as i32,
+            )
+        };
+        (status == 0)
+            .then_some(())
+            .ok_or_else(|| last_error("set TensorRT input shape"))
+    }
+
+    pub fn set_address(&self, tensor: &str, buffer: &CudaBuffer) -> Result<(), String> {
+        let tensor = name(tensor)?;
+        let status = unsafe {
+            apxinf_trt_set_address(self.raw.as_ptr(), tensor.as_ptr(), buffer.address().ptr())
+        };
+        (status == 0)
+            .then_some(())
+            .ok_or_else(|| last_error("set TensorRT tensor address"))
+    }
+
+    pub fn enqueue(&self, context: &CudaContext) -> Result<(), String> {
+        let status = unsafe {
+            apxinf_trt_enqueue(self.raw.as_ptr(), context.stream().handle() as *mut c_void)
+        };
+        (status == 0)
+            .then_some(())
+            .ok_or_else(|| last_error("enqueue TensorRT engine"))
+    }
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        unsafe { apxinf_trt_destroy(self.raw.as_ptr()) }
+    }
+}

--- a/crates/apxinf-cuda/src/tensorrt_stub.rs
+++ b/crates/apxinf-cuda/src/tensorrt_stub.rs
@@ -1,0 +1,77 @@
+//! Build-time fallback for CUDA installations without TensorRT development files.
+
+use std::path::Path;
+
+use crate::{CudaBuffer, CudaContext};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorMode {
+    Input,
+    Output,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorDType {
+    F32,
+    F16,
+    I8,
+    I32,
+    Bool,
+    U8,
+    Fp8,
+    BF16,
+    I64,
+    I4,
+    Fp4,
+}
+
+impl TensorDType {
+    pub fn size_in_bytes(self) -> usize {
+        match self {
+            Self::F32 | Self::I32 => 4,
+            Self::F16 | Self::BF16 => 2,
+            Self::I64 => 8,
+            _ => 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TensorInfo {
+    pub name: String,
+    pub mode: TensorMode,
+    pub dtype: TensorDType,
+    pub shape: Vec<i64>,
+}
+
+pub struct Engine;
+
+impl Engine {
+    pub fn load(path: &Path) -> Result<Self, String> {
+        Err(format!(
+            "TensorRT support was not compiled (cannot load {}); install NvInfer.h and libnvinfer before building ApxInf",
+            path.display()
+        ))
+    }
+    pub fn tensors(&self) -> Result<Vec<TensorInfo>, String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn mode(&self, _tensor: &str) -> Result<TensorMode, String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn dtype(&self, _tensor: &str) -> Result<TensorDType, String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn shape(&self, _tensor: &str) -> Result<Vec<i64>, String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn set_input_shape(&self, _tensor: &str, _dims: &[i64]) -> Result<(), String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn set_address(&self, _tensor: &str, _buffer: &CudaBuffer) -> Result<(), String> {
+        Err("TensorRT support was not compiled".into())
+    }
+    pub fn enqueue(&self, _context: &CudaContext) -> Result<(), String> {
+        Err("TensorRT support was not compiled".into())
+    }
+}

--- a/crates/apxinf-loader/src/safetensors.rs
+++ b/crates/apxinf-loader/src/safetensors.rs
@@ -15,8 +15,8 @@ use std::path::{Component, Path};
 use memmap2::Mmap;
 use serde::Deserialize;
 
-use bytemuck;
 use apxinf_core::{DType, Device, Shape, Tensor};
+use bytemuck;
 
 use crate::config::ModelConfig;
 
@@ -104,6 +104,85 @@ pub fn load_native_path(
     }
 }
 
+/// Load only the named tensors from a SafeTensors file, index, or checkpoint
+/// directory. Large compiled-engine runtimes commonly retain a few glue
+/// weights while the bulk of the checkpoint lives in the engine; reading every
+/// shard would waste both startup time and host memory.
+pub fn load_native_selected_path(
+    path: &Path,
+    names: &[&str],
+) -> Result<HashMap<String, Tensor>, String> {
+    let requested = names.iter().copied().collect::<BTreeSet<_>>();
+    if requested.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let index_path = if path.is_dir() {
+        let index = path.join("model.safetensors.index.json");
+        if index.is_file() {
+            index
+        } else {
+            let model = path.join("model.safetensors");
+            if !model.is_file() {
+                return Err(format!(
+                    "no SafeTensors model or index in {}",
+                    path.display()
+                ));
+            }
+            model
+        }
+    } else {
+        path.to_path_buf()
+    };
+    if index_path.extension().and_then(|value| value.to_str()) != Some("json") {
+        return load_impl_selected(&index_path, false, Some(&requested)).map(|(values, _)| values);
+    }
+    let raw = std::fs::read_to_string(&index_path)
+        .map_err(|error| format!("failed to read {}: {error}", index_path.display()))?;
+    let index: SafetensorsIndex = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "invalid SafeTensors index {}: {error}",
+            index_path.display()
+        )
+    })?;
+    let parent = index_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut by_shard: HashMap<&str, BTreeSet<&str>> = HashMap::new();
+    for name in &requested {
+        let shard = index
+            .weight_map
+            .get(*name)
+            .ok_or_else(|| format!("tensor `{name}` is not indexed by {}", index_path.display()))?;
+        by_shard.entry(shard).or_default().insert(name);
+    }
+    let mut tensors = HashMap::with_capacity(requested.len());
+    for (shard, shard_names) in by_shard {
+        let shard_path = Path::new(shard);
+        if shard_path.is_absolute()
+            || shard_path
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(format!(
+                "unsafe shard path `{shard}` in {}",
+                index_path.display()
+            ));
+        }
+        let (values, _) = load_impl_selected(&parent.join(shard), false, Some(&shard_names))?;
+        tensors.extend(values);
+    }
+    let missing = requested
+        .iter()
+        .filter(|name| !tensors.contains_key(**name))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "selected SafeTensors values are missing: {}",
+            missing.join(", ")
+        ));
+    }
+    Ok(tensors)
+}
+
 /// Load all shards named by a Hugging Face `*.safetensors.index.json` file.
 /// Each indexed tensor is checked against the shard in which it was found.
 pub fn load_native_sharded(
@@ -172,6 +251,14 @@ fn load_impl(
     path: &Path,
     upcast_bf16: bool,
 ) -> Result<(HashMap<String, Tensor>, HashMap<String, String>), String> {
+    load_impl_selected(path, upcast_bf16, None)
+}
+
+fn load_impl_selected(
+    path: &Path,
+    upcast_bf16: bool,
+    selected: Option<&BTreeSet<&str>>,
+) -> Result<(HashMap<String, Tensor>, HashMap<String, String>), String> {
     let file = File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
     let mmap = unsafe { Mmap::map(&file).map_err(|e| format!("mmap failed: {e}"))? };
 
@@ -214,6 +301,9 @@ fn load_impl(
 
     for (name, value) in &raw {
         if name == "__metadata__" {
+            continue;
+        }
+        if selected.is_some_and(|names| !names.contains(name.as_str())) {
             continue;
         }
 

--- a/crates/apxinf-model/Cargo.toml
+++ b/crates/apxinf-model/Cargo.toml
@@ -11,6 +11,7 @@ apxinf-loader = { path = "../apxinf-loader" }
 thiserror = "1"
 once_cell = "1"
 half = "2"
+bytemuck = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/apxinf-model/examples/pi05_auto_smoke.rs
+++ b/crates/apxinf-model/examples/pi05_auto_smoke.rs
@@ -52,6 +52,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             DType::F32,
         )),
         token_ids: vec![0; token_count],
+        state: None,
+        embodiment_id: None,
     };
     let noise = Tensor::zeros(vec![config.action_horizon, config.action_dim], DType::F32);
     let request = VlaRequest::provided(&observation, &noise);

--- a/crates/apxinf-model/src/auto.rs
+++ b/crates/apxinf-model/src/auto.rs
@@ -172,7 +172,7 @@ impl LoadedModel {
         self.vla()?.infer_host_f32(request)
     }
 
-    pub fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference>> {
+    pub fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference + '_>> {
         self.vla()?.prepare(spec)
     }
 }

--- a/crates/apxinf-model/src/builtin.rs
+++ b/crates/apxinf-model/src/builtin.rs
@@ -20,6 +20,8 @@ pub fn register_builtin_models() {
 
     #[cfg(feature = "cuda")]
     crate::pi05::register_builtin();
+    #[cfg(feature = "cuda")]
+    crate::gr00t_n17::register_builtin();
 }
 fn load_llama(
     path: &Path,

--- a/crates/apxinf-model/src/gr00t_n17/config.rs
+++ b/crates/apxinf-model/src/gr00t_n17/config.rs
@@ -1,0 +1,138 @@
+use std::path::Path;
+
+use apxinf_core::{Error, Result};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct DiffusionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+    pub output_dim: usize,
+    pub norm_type: String,
+    pub interleave_self_attention: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct VlSelfAttentionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Gr00tN17Config {
+    pub model_type: String,
+    pub model_name: String,
+    pub action_horizon: usize,
+    pub max_action_dim: usize,
+    pub max_state_dim: usize,
+    pub max_num_embodiments: usize,
+    #[serde(default = "default_state_history_length")]
+    pub state_history_length: usize,
+    pub hidden_size: usize,
+    #[serde(default = "default_input_embedding_dim")]
+    pub input_embedding_dim: usize,
+    pub backbone_embedding_dim: usize,
+    pub num_inference_timesteps: usize,
+    pub num_timestep_buckets: usize,
+    pub max_seq_len: usize,
+    pub select_layer: usize,
+    pub add_pos_embed: bool,
+    pub use_alternate_vl_dit: bool,
+    pub use_vlln: bool,
+    pub diffusion_model_cfg: DiffusionConfig,
+    pub vl_self_attention_cfg: VlSelfAttentionConfig,
+}
+
+const fn default_state_history_length() -> usize {
+    1
+}
+
+const fn default_input_embedding_dim() -> usize {
+    1536
+}
+
+impl Gr00tN17Config {
+    pub fn from_json_file(path: &Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|error| Error::Other(format!("read {}: {error}", path.display())))?;
+        Self::from_json_str(&raw)
+    }
+
+    pub fn from_json_str(raw: &str) -> Result<Self> {
+        let config: Self = serde_json::from_str(raw)
+            .map_err(|error| Error::Other(format!("GR00T N1.7 config: {error}")))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.model_type != "Gr00tN1d7" {
+            return Err(Error::Other(format!(
+                "expected model_type Gr00tN1d7, got {}",
+                self.model_type
+            )));
+        }
+        if self.model_name != "nvidia/Cosmos-Reason2-2B" {
+            return Err(Error::Other(format!(
+                "GR00T N1.7 requires Cosmos-Reason2-2B, got {}",
+                self.model_name
+            )));
+        }
+        if self.action_horizon == 0
+            || self.max_action_dim == 0
+            || self.max_state_dim == 0
+            || self.state_history_length == 0
+            || self.num_inference_timesteps == 0
+        {
+            return Err(Error::Other(
+                "GR00T N1.7 dimensions and denoising steps must be non-zero".into(),
+            ));
+        }
+        if self.input_embedding_dim != 1536
+            || self.backbone_embedding_dim != 2048
+            || self.hidden_size != 1024
+        {
+            return Err(Error::Other(format!(
+                "unsupported GR00T N1.7 hidden contract: action={}, backbone={}, output={}",
+                self.input_embedding_dim, self.backbone_embedding_dim, self.hidden_size
+            )));
+        }
+        if !self.use_alternate_vl_dit || !self.use_vlln {
+            return Err(Error::Other(
+                "ApxInf GR00T N1.7 supports the released AlternateVLDiT + VLLN checkpoint".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RELEASED: &str = r#"{
+      "model_type":"Gr00tN1d7", "model_name":"nvidia/Cosmos-Reason2-2B",
+      "action_horizon":40, "max_action_dim":132, "max_state_dim":132,
+      "max_num_embodiments":32, "state_history_length":1,
+      "hidden_size":1024, "input_embedding_dim":1536,
+      "backbone_embedding_dim":2048, "num_inference_timesteps":4,
+      "num_timestep_buckets":1000, "max_seq_len":1024, "select_layer":16,
+      "add_pos_embed":true, "use_alternate_vl_dit":true, "use_vlln":true,
+      "diffusion_model_cfg":{"attention_head_dim":48,"num_attention_heads":32,
+        "num_layers":32,"output_dim":1024,"norm_type":"ada_norm",
+        "interleave_self_attention":true},
+      "vl_self_attention_cfg":{"attention_head_dim":64,"num_attention_heads":32,
+        "num_layers":4}
+    }"#;
+
+    #[test]
+    fn parses_released_libero_contract() {
+        let config = Gr00tN17Config::from_json_str(RELEASED).unwrap();
+        assert_eq!(config.action_horizon, 40);
+        assert_eq!(config.diffusion_model_cfg.num_layers, 32);
+        assert_eq!(config.vl_self_attention_cfg.num_layers, 4);
+        assert_eq!(config.select_layer, 16);
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/engine_bundle.rs
+++ b/crates/apxinf-model/src/gr00t_n17/engine_bundle.rs
@@ -1,0 +1,129 @@
+use std::path::{Path, PathBuf};
+
+use apxinf_core::{Error, Result};
+use serde::Deserialize;
+
+use super::Gr00tN17Config;
+
+const REQUIRED_ENGINES: &[&str] = &[
+    "vit.engine",
+    "llm_bf16.engine",
+    "vl_self_attention.engine",
+    "state_encoder.engine",
+    "action_encoder.engine",
+    "dit_bf16.engine",
+    "action_decoder.engine",
+];
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct EngineMetadata {
+    pub schema_version: u32,
+    pub model_version: String,
+    pub sa_seq_len: usize,
+    pub vl_seq_len: usize,
+    pub llm_seq_len: usize,
+    pub llm_hidden_size: usize,
+    pub num_deepstack: usize,
+    pub num_vis_tokens: usize,
+    pub num_patches: usize,
+    pub num_merged_patches: usize,
+    pub action_horizon: usize,
+    pub max_action_dim: usize,
+    pub max_state_dim: usize,
+    pub state_history_length: usize,
+    pub hidden_size: usize,
+    pub input_embedding_dim: usize,
+    pub backbone_embedding_dim: usize,
+    pub precision: String,
+    pub batch_size: usize,
+    pub vit_grid_thw: Vec<[usize; 3]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EngineBundle {
+    root: PathBuf,
+    pub metadata: EngineMetadata,
+}
+
+impl EngineBundle {
+    pub fn load(checkpoint: &Path, config: &Gr00tN17Config) -> Result<Self> {
+        let root = checkpoint.join("apxinf-engines");
+        let metadata_path = root.join("export_metadata.json");
+        let raw = std::fs::read_to_string(&metadata_path).map_err(|error| {
+            Error::Other(format!(
+                "read GR00T TensorRT metadata {}: {error}; install the target-built engine bundle under apxinf-engines/",
+                metadata_path.display()
+            ))
+        })?;
+        let metadata: EngineMetadata = serde_json::from_str(&raw).map_err(|error| {
+            Error::Other(format!(
+                "parse GR00T TensorRT metadata {}: {error}",
+                metadata_path.display()
+            ))
+        })?;
+        Self::validate_metadata(&metadata, config)?;
+        for name in REQUIRED_ENGINES {
+            let path = root.join(name);
+            if !path.is_file() {
+                return Err(Error::Other(format!(
+                    "GR00T TensorRT engine is missing: {}",
+                    path.display()
+                )));
+            }
+        }
+        Ok(Self { root, metadata })
+    }
+
+    fn validate_metadata(metadata: &EngineMetadata, config: &Gr00tN17Config) -> Result<()> {
+        if metadata.schema_version != 1
+            || metadata.model_version != "n1d7"
+            || metadata.precision != "bf16"
+            || metadata.batch_size != 1
+        {
+            return Err(Error::Other(format!(
+                "unsupported GR00T engine bundle: schema={}, model={}, precision={}, batch={}",
+                metadata.schema_version,
+                metadata.model_version,
+                metadata.precision,
+                metadata.batch_size
+            )));
+        }
+        let expected = (
+            config.action_horizon,
+            config.max_action_dim,
+            config.max_state_dim,
+            config.state_history_length,
+            config.hidden_size,
+            config.input_embedding_dim,
+            config.backbone_embedding_dim,
+        );
+        let actual = (
+            metadata.action_horizon,
+            metadata.max_action_dim,
+            metadata.max_state_dim,
+            metadata.state_history_length,
+            metadata.hidden_size,
+            metadata.input_embedding_dim,
+            metadata.backbone_embedding_dim,
+        );
+        if actual != expected {
+            return Err(Error::Other(format!(
+                "GR00T engine/checkpoint shape mismatch: engine={actual:?}, checkpoint={expected:?}"
+            )));
+        }
+        if metadata.sa_seq_len != config.action_horizon + 1
+            || metadata.llm_seq_len != metadata.vl_seq_len
+            || metadata.llm_hidden_size != config.backbone_embedding_dim
+            || metadata.num_patches != metadata.num_merged_patches * 4
+        {
+            return Err(Error::Other(
+                "GR00T engine metadata has an inconsistent sequence contract".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/mod.rs
+++ b/crates/apxinf-model/src/gr00t_n17/mod.rs
@@ -1,0 +1,18 @@
+//! NVIDIA GR00T N1.7 VLA.
+//!
+//! The runtime consumes target-built TensorRT plans through ApxInf's native
+//! CUDA layer. It does not import the reference Python package at runtime.
+
+mod config;
+mod engine_bundle;
+#[cfg(feature = "cuda")]
+mod runtime;
+
+pub use config::{DiffusionConfig, Gr00tN17Config, VlSelfAttentionConfig};
+pub use engine_bundle::{EngineBundle, EngineMetadata};
+
+#[cfg(feature = "cuda")]
+pub(crate) fn register_builtin() {
+    crate::registry::register("Gr00tN1d7-cuda", runtime::load_registered);
+    crate::registry::register("gr00t_n17-cuda", runtime::load_registered);
+}

--- a/crates/apxinf-model/src/gr00t_n17/runtime.rs
+++ b/crates/apxinf-model/src/gr00t_n17/runtime.rs
@@ -1,0 +1,722 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use apxinf_core::{Backend, DType, Device, Error, Result, SamplingBackend, Shape, Tensor};
+use apxinf_cuda::kernels;
+use apxinf_cuda::tensorrt::{Engine, TensorMode};
+use apxinf_cuda::{CudaBuffer, CudaContext};
+use half::bf16;
+
+use crate::auto::{LoadOptions, LoadedModel, ModelPrecision};
+use crate::vla::{
+    Action, InferenceSpec, InitialLatent, PreparedInference, VisionObservation, VlaRequest,
+    VlaRuntime,
+};
+
+use super::{EngineBundle, Gr00tN17Config};
+
+const IMAGE_TOKEN_ID: u32 = 151_655;
+const VLLN_EPS: f32 = 1e-5;
+
+struct Stage {
+    engine: Engine,
+    outputs: Vec<(String, apxinf_cuda::tensorrt::TensorDType)>,
+    buffers: RefCell<HashMap<String, CudaBuffer>>,
+}
+
+struct StageInput<'a> {
+    name: &'a str,
+    shape: &'a [i64],
+    buffer: &'a CudaBuffer,
+}
+
+impl Stage {
+    fn load(path: &Path) -> Result<Self> {
+        let engine = Engine::load(path).map_err(Error::Cuda)?;
+        let outputs = engine
+            .tensors()
+            .map_err(Error::Cuda)?
+            .into_iter()
+            .filter(|info| info.mode == TensorMode::Output)
+            .map(|info| (info.name, info.dtype))
+            .collect();
+        Ok(Self {
+            engine,
+            outputs,
+            buffers: RefCell::new(HashMap::new()),
+        })
+    }
+
+    fn run(
+        &self,
+        context: &CudaContext,
+        inputs: &[StageInput<'_>],
+    ) -> Result<HashMap<String, CudaBuffer>> {
+        if inputs.is_empty() {
+            return Err(Error::Other(
+                "TensorRT stage requires at least one input".into(),
+            ));
+        }
+        for input in inputs {
+            self.engine
+                .set_input_shape(input.name, input.shape)
+                .map_err(Error::Cuda)?;
+            self.engine
+                .set_address(input.name, input.buffer)
+                .map_err(Error::Cuda)?;
+        }
+        let device = inputs[0].buffer.device();
+        if inputs.iter().any(|input| input.buffer.device() != device) {
+            return Err(Error::Other(
+                "TensorRT stage inputs span multiple CUDA devices".into(),
+            ));
+        }
+        let mut outputs = HashMap::new();
+        let mut cached = self.buffers.borrow_mut();
+        for (name, dtype) in &self.outputs {
+            let shape = self.engine.shape(name).map_err(Error::Cuda)?;
+            let elements = shape.iter().try_fold(1usize, |count, &dim| {
+                usize::try_from(dim)
+                    .ok()
+                    .and_then(|dim| count.checked_mul(dim))
+                    .ok_or_else(|| {
+                        Error::Other(format!(
+                            "TensorRT output {} has unresolved/overflowing shape {shape:?}",
+                            name
+                        ))
+                    })
+            })?;
+            let bytes = elements
+                .checked_mul(dtype.size_in_bytes())
+                .ok_or_else(|| Error::Other("TensorRT output byte size overflow".into()))?;
+            let buffer = match cached.get(name) {
+                Some(buffer) if buffer.len() == bytes && buffer.device() == device => {
+                    buffer.clone()
+                }
+                _ => {
+                    let buffer = CudaBuffer::alloc(bytes, device).map_err(Error::Cuda)?;
+                    cached.insert(name.clone(), buffer.clone());
+                    buffer
+                }
+            };
+            self.engine
+                .set_address(name, &buffer)
+                .map_err(Error::Cuda)?;
+            outputs.insert(name.clone(), buffer);
+        }
+        self.engine.enqueue(context).map_err(Error::Cuda)?;
+        Ok(outputs)
+    }
+}
+
+fn take_output(outputs: &mut HashMap<String, CudaBuffer>, name: &str) -> Result<CudaBuffer> {
+    outputs
+        .remove(name)
+        .ok_or_else(|| Error::Other(format!("TensorRT stage did not produce `{name}`")))
+}
+
+struct Stages {
+    vit: Stage,
+    llm: Stage,
+    vl_self_attention: Stage,
+    state_encoder: Stage,
+    action_encoder: Stage,
+    dit: Stage,
+    action_decoder: Stage,
+}
+
+struct GlueWeights {
+    token_embedding: Tensor,
+    vlln_weight: Tensor,
+    vlln_bias: Tensor,
+    action_position: Tensor,
+}
+
+pub struct Gr00tN17Runtime {
+    config: Gr00tN17Config,
+    bundle: EngineBundle,
+    backend: Arc<apxinf_cuda::CudaBackend>,
+    stages: Stages,
+    weights: GlueWeights,
+}
+
+impl Gr00tN17Runtime {
+    fn load(
+        checkpoint: &Path,
+        backend: Arc<apxinf_cuda::CudaBackend>,
+        options: &LoadOptions,
+    ) -> Result<Self> {
+        if !matches!(
+            options.precision,
+            ModelPrecision::Auto | ModelPrecision::Bf16
+        ) {
+            return Err(Error::Other(
+                "GR00T N1.7 currently supports the released BF16 TensorRT contract only".into(),
+            ));
+        }
+        let config = Gr00tN17Config::from_json_file(&checkpoint.join("config.json"))?;
+        let bundle = EngineBundle::load(checkpoint, &config)?;
+        let stages = Stages {
+            vit: Stage::load(&bundle.path("vit.engine"))?,
+            llm: Stage::load(&bundle.path("llm_bf16.engine"))?,
+            vl_self_attention: Stage::load(&bundle.path("vl_self_attention.engine"))?,
+            state_encoder: Stage::load(&bundle.path("state_encoder.engine"))?,
+            action_encoder: Stage::load(&bundle.path("action_encoder.engine"))?,
+            dit: Stage::load(&bundle.path("dit_bf16.engine"))?,
+            action_decoder: Stage::load(&bundle.path("action_decoder.engine"))?,
+        };
+        let names = [
+            "backbone.model.model.language_model.embed_tokens.weight",
+            "action_head.vlln.weight",
+            "action_head.vlln.bias",
+            "action_head.position_embedding.weight",
+        ];
+        let mut host = apxinf_loader::safetensors::load_native_selected_path(checkpoint, &names)
+            .map_err(|error| Error::Other(format!("load GR00T glue weights: {error}")))?;
+        let upload = |name: &str, values: &mut HashMap<String, Tensor>| -> Result<Tensor> {
+            let value = values
+                .remove(name)
+                .ok_or_else(|| Error::Other(format!("missing GR00T weight `{name}`")))?;
+            backend.to_device(&value)
+        };
+        let token_embedding = upload(names[0], &mut host)?;
+        let vlln_weight = upload(names[1], &mut host)?;
+        let vlln_bias = upload(names[2], &mut host)?;
+        let action_position_full = upload(names[3], &mut host)?;
+        let position_bytes = config.action_horizon * config.input_embedding_dim * 2;
+        let action_position = CudaBuffer::from_tensor(&action_position_full)
+            .map_err(Error::Cuda)?
+            .view(0, position_bytes)
+            .map_err(Error::Cuda)?
+            .as_tensor(
+                Shape::new(vec![config.action_horizon, config.input_embedding_dim]),
+                DType::BF16,
+            )
+            .map_err(Error::Cuda)?;
+        Ok(Self {
+            config,
+            bundle,
+            backend,
+            stages,
+            weights: GlueWeights {
+                token_embedding,
+                vlln_weight,
+                vlln_bias,
+                action_position,
+            },
+        })
+    }
+
+    fn context(&self) -> &CudaContext {
+        self.backend.context()
+    }
+
+    fn device(&self) -> usize {
+        self.backend.device_id()
+    }
+
+    fn upload_bytes(&self, bytes: &[u8]) -> Result<CudaBuffer> {
+        let buffer = CudaBuffer::alloc(bytes.len(), self.device()).map_err(Error::Cuda)?;
+        buffer.copy_from_host(bytes).map_err(Error::Cuda)?;
+        Ok(buffer)
+    }
+
+    fn upload_u32(&self, values: &[u32]) -> Result<CudaBuffer> {
+        self.upload_bytes(bytemuck::cast_slice(values))
+    }
+
+    fn upload_i64(&self, values: &[i64]) -> Result<CudaBuffer> {
+        self.upload_bytes(bytemuck::cast_slice(values))
+    }
+
+    fn ensure_device_f32(&self, value: &Tensor) -> Result<Tensor> {
+        if value.dtype() != DType::F32 {
+            return Err(Error::Other(format!(
+                "GR00T ViT expects f32 pixel values, got {}",
+                value.dtype()
+            )));
+        }
+        if value.device() == Device::Cuda(self.device()) {
+            Ok(value.clone())
+        } else if value.device() == Device::Cpu {
+            self.backend.to_device(value)
+        } else {
+            Err(Error::DeviceMismatch {
+                expected: Device::Cuda(self.device()),
+                got: value.device(),
+            })
+        }
+    }
+
+    fn ensure_device_bf16(&self, value: &Tensor, shape: &[usize], label: &str) -> Result<Tensor> {
+        if value.shape().dims() != shape {
+            return Err(Error::Other(format!(
+                "GR00T {label} expected {shape:?}, got {:?}",
+                value.shape().dims()
+            )));
+        }
+        match (value.device(), value.dtype()) {
+            (Device::Cuda(device), DType::BF16) if device == self.device() => Ok(value.clone()),
+            (Device::Cuda(device), DType::F32) if device == self.device() => {
+                kernels::elementwise::cast_f32_to_bf16(self.context(), value)
+            }
+            (Device::Cpu, DType::BF16) => self.backend.to_device(value),
+            (Device::Cpu, DType::F32) => {
+                let converted = value
+                    .as_f32()?
+                    .iter()
+                    .map(|&item| bf16::from_f32(item))
+                    .collect::<Vec<_>>();
+                self.backend
+                    .to_device(&Tensor::from_bf16(shape.to_vec(), &converted)?)
+            }
+            (device, dtype) => Err(Error::Other(format!(
+                "GR00T {label} does not support {dtype} on {device}"
+            ))),
+        }
+    }
+
+    fn initial_actions(&self, latent: InitialLatent<'_>) -> Result<Tensor> {
+        let shape = [self.config.action_horizon, self.config.max_action_dim];
+        match latent {
+            InitialLatent::Provided(value) => self.ensure_device_bf16(value, &shape, "noise"),
+            InitialLatent::Generate { rng } => {
+                let storage = CudaBuffer::alloc(shape.iter().product::<usize>() * 2, self.device())
+                    .map_err(Error::Cuda)?;
+                let output = storage
+                    .as_tensor(Shape::new(shape.to_vec()), DType::BF16)
+                    .map_err(Error::Cuda)?;
+                let mut generator = self.backend.create_normal_generator(output)?;
+                Ok(generator.generate(rng)?.clone())
+            }
+        }
+    }
+
+    fn mrope_positions(&self, token_ids: &[u32]) -> Result<Vec<i64>> {
+        let grids = &self.bundle.metadata.vit_grid_thw;
+        let mut token_major = Vec::<[i64; 3]>::with_capacity(token_ids.len());
+        let mut start = 0usize;
+        let mut image_index = 0usize;
+        let mut next = 0i64;
+        loop {
+            let image_start =
+                (start..token_ids.len()).find(|&index| token_ids[index] == IMAGE_TOKEN_ID);
+            let Some(image_start) = image_start else {
+                for _ in start..token_ids.len() {
+                    token_major.push([next, next, next]);
+                    next += 1;
+                }
+                break;
+            };
+            for _ in start..image_start {
+                token_major.push([next, next, next]);
+                next += 1;
+            }
+            let [t, h, w] = *grids.get(image_index).ok_or_else(|| {
+                Error::Other("GR00T token stream contains more images than the engine grid".into())
+            })?;
+            image_index += 1;
+            let (t, h, w) = (t as i64, (h / 2) as i64, (w / 2) as i64);
+            for ti in 0..t {
+                for hi in 0..h {
+                    for wi in 0..w {
+                        token_major.push([next + ti, next + hi, next + wi]);
+                    }
+                }
+            }
+            next += t.max(h).max(w);
+            start = image_start + (t * h * w) as usize;
+        }
+        if image_index != grids.len() || token_major.len() != token_ids.len() {
+            return Err(Error::Other(format!(
+                "GR00T image-token/grid mismatch: images={}, grids={}, positions={}",
+                image_index,
+                grids.len(),
+                token_major.len()
+            )));
+        }
+        let mut axis_major = Vec::with_capacity(token_ids.len() * 3);
+        for axis in 0..3 {
+            axis_major.extend(token_major.iter().map(|position| position[axis]));
+        }
+        Ok(axis_major)
+    }
+
+    fn infer_device(&self, request: &VlaRequest<'_>) -> Result<Tensor> {
+        request.observation.validate()?;
+        let token_ids = &request.observation.token_ids;
+        if token_ids.len() > 312 {
+            return Err(Error::Other(format!(
+                "GR00T token length {} exceeds TensorRT profile maximum 312",
+                token_ids.len()
+            )));
+        }
+        let image_positions = token_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &token)| (token == IMAGE_TOKEN_ID).then_some(index as u32))
+            .collect::<Vec<_>>();
+        if image_positions.len() != self.bundle.metadata.num_merged_patches {
+            return Err(Error::Other(format!(
+                "GR00T expected {} image tokens, got {}",
+                self.bundle.metadata.num_merged_patches,
+                image_positions.len()
+            )));
+        }
+        let pixels = match &request.observation.vision {
+            VisionObservation::Patches(value) => self.ensure_device_f32(value)?,
+            VisionObservation::RgbU8 { .. } => {
+                return Err(Error::Other(
+                    "GR00T native runtime expects canonical Qwen3-VL pixel_values".into(),
+                ))
+            }
+        };
+        if pixels.shape().dims()
+            != [
+                self.bundle.metadata.num_patches,
+                self.config.input_embedding_dim,
+            ]
+        {
+            return Err(Error::Other(format!(
+                "GR00T pixel_values expected [{}, {}], got {:?}",
+                self.bundle.metadata.num_patches,
+                self.config.input_embedding_dim,
+                pixels.shape().dims()
+            )));
+        }
+        let pixel_buffer = CudaBuffer::from_tensor(&pixels).map_err(Error::Cuda)?;
+        let mut vit = self.stages.vit.run(
+            self.context(),
+            &[StageInput {
+                name: "pixel_values",
+                shape: &[
+                    self.bundle.metadata.num_patches as i64,
+                    self.config.input_embedding_dim as i64,
+                ],
+                buffer: &pixel_buffer,
+            }],
+        )?;
+        let primary_f32 = take_output(&mut vit, "image_embeds")?
+            .as_tensor(
+                Shape::new(vec![
+                    self.bundle.metadata.num_merged_patches,
+                    self.config.backbone_embedding_dim,
+                ]),
+                DType::F32,
+            )
+            .map_err(Error::Cuda)?;
+        let deepstack_f32 = take_output(&mut vit, "deepstack_features")?;
+        let primary = kernels::elementwise::cast_f32_to_bf16(self.context(), &primary_f32)?;
+        let deepstack_bytes = self.bundle.metadata.num_merged_patches
+            * self.config.backbone_embedding_dim
+            * DType::F32.size_in_bytes();
+        let mut deepstack = Vec::with_capacity(self.bundle.metadata.num_deepstack);
+        for layer in 0..self.bundle.metadata.num_deepstack {
+            let value = deepstack_f32
+                .view(layer * deepstack_bytes, deepstack_bytes)
+                .map_err(Error::Cuda)?
+                .as_tensor(
+                    Shape::new(vec![
+                        self.bundle.metadata.num_merged_patches,
+                        self.config.backbone_embedding_dim,
+                    ]),
+                    DType::F32,
+                )
+                .map_err(Error::Cuda)?;
+            deepstack.push(kernels::elementwise::cast_f32_to_bf16(
+                self.context(),
+                &value,
+            )?);
+        }
+
+        let token_buffer = self.upload_u32(token_ids)?;
+        let embeddings = kernels::embedding::lookup(
+            self.context(),
+            &self.weights.token_embedding,
+            &token_buffer,
+            token_ids.len(),
+        )?;
+        let positions = self.upload_u32(&image_positions)?;
+        kernels::elementwise::scatter_rows_bf16(self.context(), &primary, &positions, &embeddings)?;
+
+        let sequence = token_ids.len();
+        let attention = self.upload_i64(&vec![1i64; sequence])?;
+        let position_ids = self.upload_i64(&self.mrope_positions(token_ids)?)?;
+        let image_mask_host = token_ids
+            .iter()
+            .map(|&token| u8::from(token == IMAGE_TOKEN_ID))
+            .collect::<Vec<_>>();
+        let image_mask = self.upload_bytes(&image_mask_host)?;
+        let full_mask = self.upload_bytes(&vec![1u8; sequence])?;
+        let embeddings_buffer = CudaBuffer::from_tensor(&embeddings).map_err(Error::Cuda)?;
+        let deepstack_buffers = deepstack
+            .iter()
+            .map(CudaBuffer::from_tensor)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Error::Cuda)?;
+        let mut llm = self.stages.llm.run(
+            self.context(),
+            &[
+                StageInput {
+                    name: "inputs_embeds",
+                    shape: &[1, sequence as i64, 2048],
+                    buffer: &embeddings_buffer,
+                },
+                StageInput {
+                    name: "attention_mask",
+                    shape: &[1, sequence as i64],
+                    buffer: &attention,
+                },
+                StageInput {
+                    name: "position_ids",
+                    shape: &[3, 1, sequence as i64],
+                    buffer: &position_ids,
+                },
+                StageInput {
+                    name: "visual_pos_masks",
+                    shape: &[1, sequence as i64],
+                    buffer: &image_mask,
+                },
+                StageInput {
+                    name: "deepstack_0",
+                    shape: &[128, 2048],
+                    buffer: &deepstack_buffers[0],
+                },
+                StageInput {
+                    name: "deepstack_1",
+                    shape: &[128, 2048],
+                    buffer: &deepstack_buffers[1],
+                },
+                StageInput {
+                    name: "deepstack_2",
+                    shape: &[128, 2048],
+                    buffer: &deepstack_buffers[2],
+                },
+            ],
+        )?;
+        let llm_output = take_output(&mut llm, "embeddings")?
+            .as_tensor(Shape::new(vec![sequence, 2048]), DType::BF16)
+            .map_err(Error::Cuda)?;
+        let normalized = kernels::norm::layer_bf16(
+            self.context(),
+            &llm_output,
+            &self.weights.vlln_weight,
+            &self.weights.vlln_bias,
+            VLLN_EPS,
+        )?;
+        let normalized_buffer = CudaBuffer::from_tensor(&normalized).map_err(Error::Cuda)?;
+        let mut vl_sa = self.stages.vl_self_attention.run(
+            self.context(),
+            &[StageInput {
+                name: "hidden_states",
+                shape: &[1, sequence as i64, 2048],
+                buffer: &normalized_buffer,
+            }],
+        )?;
+        let vl_embeds = take_output(&mut vl_sa, "output")?
+            .as_tensor(Shape::new(vec![sequence, 2048]), DType::BF16)
+            .map_err(Error::Cuda)?;
+
+        let state =
+            request.observation.state.as_ref().ok_or_else(|| {
+                Error::Other("GR00T observation is missing normalized state".into())
+            })?;
+        let state = self.ensure_device_bf16(state, &[1, 1, self.config.max_state_dim], "state")?;
+        let embodiment = request
+            .observation
+            .embodiment_id
+            .ok_or_else(|| Error::Other("GR00T observation is missing embodiment_id".into()))?;
+        if embodiment as usize >= self.config.max_num_embodiments {
+            return Err(Error::Other(format!(
+                "GR00T embodiment {embodiment} is outside 0..{}",
+                self.config.max_num_embodiments
+            )));
+        }
+        let embodiment_buffer = self.upload_i64(&[embodiment as i64])?;
+        let state_buffer = CudaBuffer::from_tensor(&state).map_err(Error::Cuda)?;
+        let mut state_output = self.stages.state_encoder.run(
+            self.context(),
+            &[
+                StageInput {
+                    name: "state",
+                    shape: &[1, 1, 132],
+                    buffer: &state_buffer,
+                },
+                StageInput {
+                    name: "embodiment_id",
+                    shape: &[1],
+                    buffer: &embodiment_buffer,
+                },
+            ],
+        )?;
+        let state_features = take_output(&mut state_output, "output")?
+            .as_tensor(Shape::new(vec![1, 1536]), DType::BF16)
+            .map_err(Error::Cuda)?;
+
+        let mut actions = self.initial_actions(request.initial_latent)?;
+        let vl_buffer = CudaBuffer::from_tensor(&vl_embeds).map_err(Error::Cuda)?;
+        for step in 0..self.config.num_inference_timesteps {
+            let bucket =
+                step * self.config.num_timestep_buckets / self.config.num_inference_timesteps;
+            let timestep = self.upload_i64(&[bucket as i64])?;
+            let actions_buffer = CudaBuffer::from_tensor(&actions).map_err(Error::Cuda)?;
+            let mut encoded = self.stages.action_encoder.run(
+                self.context(),
+                &[
+                    StageInput {
+                        name: "actions",
+                        shape: &[1, 40, 132],
+                        buffer: &actions_buffer,
+                    },
+                    StageInput {
+                        name: "timesteps",
+                        shape: &[1],
+                        buffer: &timestep,
+                    },
+                    StageInput {
+                        name: "embodiment_id",
+                        shape: &[1],
+                        buffer: &embodiment_buffer,
+                    },
+                ],
+            )?;
+            let action_features = take_output(&mut encoded, "output")?
+                .as_tensor(Shape::new(vec![40, 1536]), DType::BF16)
+                .map_err(Error::Cuda)?;
+            let action_features = self
+                .backend
+                .add(&action_features, &self.weights.action_position)?;
+            let state_action = kernels::elementwise::concat_rows_bf16(
+                self.context(),
+                &state_features,
+                &action_features,
+            )?;
+            let sa_buffer = CudaBuffer::from_tensor(&state_action).map_err(Error::Cuda)?;
+            let mut dit = self.stages.dit.run(
+                self.context(),
+                &[
+                    StageInput {
+                        name: "sa_embs",
+                        shape: &[1, 41, 1536],
+                        buffer: &sa_buffer,
+                    },
+                    StageInput {
+                        name: "vl_embs",
+                        shape: &[1, sequence as i64, 2048],
+                        buffer: &vl_buffer,
+                    },
+                    StageInput {
+                        name: "timestep",
+                        shape: &[1],
+                        buffer: &timestep,
+                    },
+                    StageInput {
+                        name: "image_mask",
+                        shape: &[1, sequence as i64],
+                        buffer: &image_mask,
+                    },
+                    StageInput {
+                        name: "backbone_attention_mask",
+                        shape: &[1, sequence as i64],
+                        buffer: &full_mask,
+                    },
+                ],
+            )?;
+            let model_output = take_output(&mut dit, "output")?;
+            let mut decoded = self.stages.action_decoder.run(
+                self.context(),
+                &[
+                    StageInput {
+                        name: "model_output",
+                        shape: &[1, 41, 1024],
+                        buffer: &model_output,
+                    },
+                    StageInput {
+                        name: "embodiment_id",
+                        shape: &[1],
+                        buffer: &embodiment_buffer,
+                    },
+                ],
+            )?;
+            let decoded = take_output(&mut decoded, "output")?;
+            let velocity = decoded
+                .view(
+                    self.config.max_action_dim * 2,
+                    self.config.action_horizon * self.config.max_action_dim * 2,
+                )
+                .map_err(Error::Cuda)?
+                .as_tensor(
+                    Shape::new(vec![self.config.action_horizon, self.config.max_action_dim]),
+                    DType::BF16,
+                )
+                .map_err(Error::Cuda)?;
+            actions = kernels::elementwise::euler_update_bf16(
+                self.context(),
+                &actions,
+                &velocity,
+                1.0 / self.config.num_inference_timesteps as f32,
+            )?;
+        }
+        Ok(actions)
+    }
+}
+
+struct Gr00tPrepared<'a> {
+    runtime: &'a Gr00tN17Runtime,
+    spec: InferenceSpec,
+}
+
+impl PreparedInference for Gr00tPrepared<'_> {
+    fn spec(&self) -> &InferenceSpec {
+        &self.spec
+    }
+
+    fn run(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        if !self.spec.matches(request.observation) {
+            return Err(Error::Other(
+                "GR00T prepared inference spec mismatch".into(),
+            ));
+        }
+        Ok(Action::new(self.runtime.infer_device(request)?))
+    }
+}
+
+impl VlaRuntime for Gr00tN17Runtime {
+    fn infer(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        Ok(Action::new(self.infer_device(request)?))
+    }
+
+    fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference + '_>> {
+        spec.validate()?;
+        if spec.image_layout.is_some() {
+            return Err(Error::Other(
+                "GR00T prepared inference expects canonical pixel_values patches".into(),
+            ));
+        }
+        Ok(Box::new(Gr00tPrepared {
+            runtime: self,
+            spec: *spec,
+        }))
+    }
+
+    fn infer_host_f32(&self, request: &VlaRequest<'_>) -> Result<Vec<f32>> {
+        self.backend
+            .to_cpu(&self.infer_device(request)?)?
+            .to_f32_vec()
+    }
+}
+
+pub(crate) fn load_registered(
+    path: &Path,
+    _device: Device,
+    backend: Arc<dyn Backend>,
+    options: &LoadOptions,
+) -> Result<LoadedModel> {
+    let backend = crate::accelerator::cuda::downcast_arc(backend)
+        .ok_or_else(|| Error::Other("GR00T N1.7 requires the CUDA backend".into()))?;
+    Ok(LoadedModel::Vla(Box::new(Gr00tN17Runtime::load(
+        path, backend, options,
+    )?)))
+}

--- a/crates/apxinf-model/src/lib.rs
+++ b/crates/apxinf-model/src/lib.rs
@@ -4,6 +4,7 @@ mod accelerator;
 pub mod builtin;
 pub mod debug;
 mod generation_config;
+pub mod gr00t_n17;
 pub mod llama;
 pub mod llm_trait;
 pub mod registry;
@@ -16,6 +17,7 @@ pub mod vla;
 pub use builtin::register_builtin_models;
 pub use debug::{DebugCapture, DebugConfig};
 pub use generation_config::{GenerationConfigSource, GenerationOptions, SamplingMode};
+pub use gr00t_n17::Gr00tN17Config;
 pub use llama::{GeneralLlama, LlamaModel, LlamaWeights, TransformerLayer, KVCache};
 pub use llm_trait::{
     generate_streaming, generate_streaming_with_options, GeneratedToken, GenerationOutput,

--- a/crates/apxinf-model/src/pi05/config.rs
+++ b/crates/apxinf-model/src/pi05/config.rs
@@ -576,6 +576,27 @@ mod tests {
     }
 
     #[test]
+    fn parses_the_config_json_synthesised_from_an_openpi_metadata_pt() {
+        // An openpi PyTorch export ships no config.json at all, so the Python
+        // side reads metadata.pt and hands the loader this string through
+        // `Model.load(config_json=...)`. Without it the loader fell back to
+        // `Pi05Config::default()` in silence, serving a 3-view/50-step default
+        // whatever the checkpoint actually was. This is the exact spelling
+        // `apxinf.checkpoints.train_config_facts` emits, so a change on either
+        // side that breaks the handshake fails here rather than on a robot.
+        let cfg = Pi05Config::from_json_str(
+            r#"{"action_dim": 32, "action_horizon": 50, "discrete_state_input": true,
+                "max_token_len": 200, "num_views": 3}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.action_dim, 32);
+        assert_eq!(cfg.action_horizon, 50);
+        assert_eq!(cfg.max_token_len, 200);
+        assert_eq!(cfg.num_views, 3);
+        assert!(cfg.discrete_state_input);
+    }
+
+    #[test]
     fn language_dual_geglu_shapes_are_reachable_only_for_two_view_profile() {
         assert!(Pi05Config::thor_two_view().language_dual_geglu_shape_possible());
         assert!(!Pi05Config::default().language_dual_geglu_shape_possible());

--- a/crates/apxinf-model/src/pi05/math.rs
+++ b/crates/apxinf-model/src/pi05/math.rs
@@ -26,12 +26,41 @@ pub fn sinusoidal_time_embedding(
     sin
 }
 
-/// Match NumPy `digitize(state, linspace(-1, 1, 257)[:-1]) - 1`, with
-/// saturation for out-of-range sensor values.
-pub fn discretize_state(state: &[f32]) -> Vec<u8> {
+/// Match NumPy `digitize(state, linspace(-1, 1, 257)[:-1]) - 1`.
+///
+/// `digitize` returns `0` for `v < -1`, so the bin is `-1`, and openpi writes
+/// that straight into the prompt (`models/tokenizer.py`) — it is a value the
+/// model saw during training, so it must not be clamped to `0`. The return type
+/// is therefore signed. Values `>= 1` do saturate, to `255`.
+///
+/// Implemented as a search over the edges, which is what `digitize` does, rather
+/// than the arithmetic `floor((v + 1.0) * 128.0)`. The two are not equal: adding
+/// `1.0` to a value just below an edge in `[-0.5, -0.25)` moves it into a binade
+/// with twice the ulp, the sum rounds *up* onto the edge, and the floor lands one
+/// bin high. `-0.4921875` (edge 65) is the one f32 value where this happens, and
+/// one bin is a different prompt string, different token ids, different rollout.
+///
+/// Every edge is `-1 + i/128` with `i <= 255`, i.e. `(i - 128)/128` — at most
+/// eight significant bits — so it is exact in f32 and each comparison below is
+/// exact. NaN falls out as `-1` here (all comparisons false); NaN state is
+/// rejected upstream and is not a supported input on either side.
+pub fn discretize_state(state: &[f32]) -> Vec<i16> {
     state
         .iter()
-        .map(|&value| (((value + 1.0) * 128.0).floor() as i32).clamp(0, 255) as u8)
+        .map(|&value| {
+            // Binary search for the number of edges <= value, i.e.
+            // `searchsorted(edges, value, side="right")`; the bin is that minus one.
+            let (mut lo, mut hi) = (0i32, 256i32);
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2;
+                if -1.0 + mid as f32 / 128.0 <= value {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            (lo - 1) as i16
+        })
         .collect()
 }
 
@@ -42,7 +71,7 @@ pub fn pi05_prompt(task: &str, normalized_state: &[f32], discrete_state_input: b
     }
     let state = discretize_state(normalized_state)
         .iter()
-        .map(u8::to_string)
+        .map(i16::to_string)
         .collect::<Vec<_>>()
         .join(" ");
     format!("Task: {task}, State: {state};\nAction: ")
@@ -73,14 +102,63 @@ mod tests {
     #[test]
     fn state_discretization_and_prompt_match_pi05() {
         assert_eq!(
-            discretize_state(&[-2.0, -1.0, 0.0, 0.999, 1.0, 2.0]),
-            vec![0, 0, 128, 255, 255, 255]
+            discretize_state(&[-2.0, -1.000_001, -1.0, 0.0, 0.999, 1.0, 2.0]),
+            vec![-1, -1, 0, 128, 255, 255, 255]
         );
         assert_eq!(
-            pi05_prompt(" pick_up\ncup ", &[-1.0, 0.0, 1.0], true),
-            "Task: pick up cup, State: 0 128 255;\nAction: "
+            pi05_prompt(" pick_up\ncup ", &[-2.0, -1.0, 0.0, 1.0], true),
+            "Task: pick up cup, State: -1 0 128 255;\nAction: "
         );
         assert_eq!(pi05_prompt("pick_up", &[], false), "pick up\n");
+    }
+
+    /// The next representable f32 below `x`. `0.0` steps to the smallest
+    /// negative subnormal, which is what makes edge 128 (exactly `0.0`) testable.
+    fn next_below(x: f32) -> f32 {
+        if x > 0.0 {
+            f32::from_bits(x.to_bits() - 1)
+        } else if x < 0.0 {
+            f32::from_bits(x.to_bits() + 1)
+        } else {
+            -f32::from_bits(1)
+        }
+    }
+
+    fn next_above(x: f32) -> f32 {
+        -next_below(-x)
+    }
+
+    #[test]
+    fn discretization_matches_digitize_at_every_bin_edge() {
+        // Each edge and both of its f32 neighbours: the edge itself opens its own
+        // bin, one ulp below stays in the previous one. The arithmetic form
+        // `floor((v + 1.0) * 128.0)` gets exactly one of these 768 cases wrong.
+        for i in 0..256i32 {
+            let edge = -1.0 + i as f32 / 128.0;
+            assert_eq!(discretize_state(&[edge]), vec![i as i16], "edge {i}");
+            assert_eq!(
+                discretize_state(&[next_below(edge)]),
+                vec![(i - 1) as i16],
+                "one ulp below edge {i}"
+            );
+            assert_eq!(
+                discretize_state(&[next_above(edge)]),
+                vec![i as i16],
+                "one ulp above edge {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn discretization_does_not_round_up_onto_an_edge() {
+        // One ulp below edge 65 (-0.4921875). Adding 1.0 lands the value in a
+        // binade with twice the ulp, so the sum rounds up to exactly 0.5078125
+        // and a floor-based index returns 65 instead of 64 -- a different prompt
+        // string for a state that is, by NumPy's reckoning, in bin 64.
+        let v = f32::from_bits((-0.4921875f32).to_bits() + 1);
+        assert!(v < -0.4921875, "one ulp below the edge");
+        assert_eq!(((v + 1.0) * 128.0).floor() as i32, 65, "the trap this guards");
+        assert_eq!(discretize_state(&[v]), vec![64]);
     }
 
     #[test]

--- a/crates/apxinf-model/src/pi05/vla_runtime.rs
+++ b/crates/apxinf-model/src/pi05/vla_runtime.rs
@@ -616,14 +616,15 @@ pub(super) fn load_registered(
                     &calibration,
                 )?)
             };
-            // A checkpoint-free synthetic load relies on the kernel's tactic
-            // fallback, so a tuning database is only required for real FP8 runs.
-            if synthetic.is_none() {
-                tuning_database.as_ref().ok_or_else(|| {
-                    Error::Other(
-                        "FP8 PI0.5 requires LoadOptions.tuning_path or tactics.json".into(),
-                    )
-                })?;
+            // No tuning database is fatal: the FP8 GEMM falls back to a
+            // shape-heuristic tactic. Warn on real weights, where an untuned
+            // tactic is a silent latency regression rather than a wrong answer.
+            if synthetic.is_none() && tuning_database.is_none() {
+                eprintln!(
+                    "[apxinf] FP8 PI0.5 running without a GEMM tactic database \
+                     (no LoadOptions.tuning_path, no tactics.json in the checkpoint); \
+                     using heuristic tactics, expect lower throughput"
+                );
             }
             let weights = Arc::new(StaticFp8Pi05Weights::from_host(
                 &host_weights,

--- a/crates/apxinf-model/src/vla/mod.rs
+++ b/crates/apxinf-model/src/vla/mod.rs
@@ -23,6 +23,10 @@ pub enum VisionObservation {
 pub struct Observation {
     pub vision: VisionObservation,
     pub token_ids: Vec<u32>,
+    /// Optional normalized proprioceptive state.
+    pub state: Option<Tensor>,
+    /// Optional checkpoint-defined embodiment category.
+    pub embodiment_id: Option<u32>,
 }
 
 impl Observation {
@@ -137,7 +141,7 @@ pub trait PreparedInference {
 /// directly hold heterogeneous model runtimes.
 pub trait VlaRuntime {
     fn infer(&self, request: &VlaRequest<'_>) -> Result<Action>;
-    fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference>>;
+    fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference + '_>>;
 
     /// Run inference and copy the resulting action to host as `f32`.
     ///
@@ -162,6 +166,8 @@ mod tests {
                 layout: ImageLayout::Nhwc,
             },
             token_ids: vec![1, 2, 3],
+            state: None,
+            embodiment_id: None,
         }
     }
 
@@ -180,6 +186,8 @@ mod tests {
         let empty = Observation {
             vision: VisionObservation::Patches(Tensor::zeros((1, 2), DType::F32)),
             token_ids: Vec::new(),
+            state: None,
+            embodiment_id: None,
         };
         assert!(empty.validate().is_err());
     }

--- a/crates/apxinf-py/apxinf_py.pyi
+++ b/crates/apxinf-py/apxinf_py.pyi
@@ -18,6 +18,7 @@ class Model:
         precision: str = ...,
         calibration: str | None = ...,
         tactics: str | None = ...,
+        config_json: str | None = ...,
         action_horizon: int | None = ...,
         num_views: int | None = ...,
         sampling_seed: int = ...,
@@ -26,6 +27,10 @@ class Model:
 
         ``device`` is ``cuda:N`` (default) or ``cpu``.
         ``precision`` is ``auto`` (default), ``fp8``, ``bf16``, or ``int8``.
+        ``config_json`` supplies the architecture for a checkpoint that has no
+        ``config.json`` — an openpi PyTorch export keeps its constants in
+        ``metadata.pt``, which :mod:`apxinf.checkpoints` reads and passes here.
+        ``None`` reads ``config.json`` from the checkpoint directory as before.
         ``action_horizon`` overrides the checkpoint's chunk length (a sequence
         length, not a weight dimension).
         ``num_views`` serves fewer cameras than the checkpoint declares (1..=its

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -241,6 +241,15 @@ impl Model {
     /// * `calibration` / `tactics` — optional FP8 calibration / tactics json.
     /// * `sampling_seed` — seed for the implicit device-side noise stream used
     ///   when inference is called without `noise`.
+    /// * `config_json` — the architecture, as a `config.json`-shaped string,
+    ///   for a checkpoint that has no `config.json`. An openpi PyTorch export
+    ///   never carries one: its constants live in `metadata.pt`, which the
+    ///   Python side reads (`apxinf.checkpoints`) and passes through here.
+    ///   Without it such a checkpoint silently loaded at `Pi05Config::default()`,
+    ///   so a chunk length or view count that differed from the default was
+    ///   wrong with no error anywhere. `None` keeps the old behaviour: read
+    ///   `config.json` from the checkpoint directory, else fall back to the
+    ///   default.
     /// * `action_horizon` — override the checkpoint's chunk length. `None`
     ///   (default) runs the native `config.json` value; an explicit value wins
     ///   over it. The horizon is a sequence length, not a weight dimension, so
@@ -255,7 +264,7 @@ impl Model {
     /// tokens per step. Nothing weight-shaped depends on the count; it only sizes
     /// the prefix, so this is a load-time constant, not a per-request one.
     #[staticmethod]
-    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, action_horizon=None, num_views=None, sampling_seed=0))]
+    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, config_json=None, action_horizon=None, num_views=None, sampling_seed=0))]
     fn load(
         model: &str,
         path: PathBuf,
@@ -263,16 +272,19 @@ impl Model {
         precision: &str,
         calibration: Option<PathBuf>,
         tactics: Option<PathBuf>,
+        config_json: Option<&str>,
         action_horizon: Option<usize>,
         num_views: Option<usize>,
         sampling_seed: u64,
     ) -> PyResult<Self> {
         let device = parse_device(device)?;
-        let mut config = load_config(&path)?;
         // Only hand the loader an explicit config when the caller actually
-        // overrode something; otherwise it reads `config.json` itself, exactly
-        // as before.
-        let mut overridden = false;
+        // supplied or overrode one; otherwise it reads `config.json` itself,
+        // exactly as before.
+        let (mut config, mut overridden) = match config_json {
+            Some(raw) => (Pi05Config::from_json_str(raw).map_err(runtime_err)?, true),
+            None => (load_config(&path)?, false),
+        };
         if let Some(horizon) = action_horizon {
             config.action_horizon = horizon;
             overridden = true;

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -465,6 +465,8 @@ impl Model {
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
+            state: None,
+            embodiment_id: None,
         };
         match noise {
             Some(noise) => {
@@ -517,6 +519,8 @@ impl Model {
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
+            state: None,
+            embodiment_id: None,
         };
         self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
     }
@@ -570,6 +574,8 @@ impl Model {
         let observation = Observation {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
+            state: None,
+            embodiment_id: None,
         };
         match noise {
             Some(noise) => {
@@ -626,6 +632,8 @@ impl Model {
         let observation = Observation {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
+            state: None,
+            embodiment_id: None,
         };
         self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
     }

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -17,13 +17,16 @@ arrives as `observation/image` or as `obs["images"]["cam_high"]`, whether the
 state vector is discretized into the prompt or dropped, or whether the 32-wide
 model output should be truncated to 7 or to 16.
 
-Before presets, `Pi05Policy`'s LIBERO defaults applied to *every* checkpoint. A
-G1 checkpoint served with no extra arguments ran LIBERO's keys, dropped state,
-and skipped the G1 delta→absolute and 32→16 steps. Nothing failed. Nothing
-logged. It looked exactly like a "model accuracy problem."
+Before presets, `Pi05Policy` defaulted `image_keys` to LIBERO's two, so that
+contract applied to *every* checkpoint. A G1 checkpoint served with no extra
+arguments ran LIBERO's keys, dropped state, and skipped the G1 delta→absolute and
+32→16 steps. Nothing failed. Nothing logged. It looked exactly like a "model
+accuracy problem."
 
-So the embodiment is a named, explicit launch flag on both sides — the same shape
-OpenPI uses, so the two line up one-to-one:
+The model layer now names no wire keys at all — construct a policy without them
+and it falls back to its own view slots, which no client sends, so a mismatch is
+a `KeyError` naming both sides. The embodiment is a named, explicit launch flag
+on both sides — the same shape OpenPI uses, so the two line up one-to-one:
 
 ```
 openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
@@ -37,7 +40,7 @@ things and they never need to be equal.
 
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
-| **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `robots/presets.py` | never — the *order* is baked into the weights |
+| **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
 | **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `slots` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
@@ -46,6 +49,13 @@ order-significant: entry *i* is stacked into model view slot *i*. A tuple writte
 in the wrong order still stacks, still has the right shape, and silently feeds
 the wrong camera to each slot — pairing every key with its slot makes that
 reviewable instead of positional.
+
+The slot names live in `policies/base.py`, not in the preset table: they are
+*model* vocabulary, so the robot layer reads them rather than restating them. The
+policy layer holds **no** wire keys at all. Construct a policy without naming
+cameras and it names them after its own view slots — a client sending
+`observation/image` then gets a `KeyError` naming both sides, instead of the old
+behaviour where LIBERO's two keys were the built-in default for every checkpoint.
 
 ## Launching a server for an existing embodiment
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -77,7 +77,7 @@ connect-time metadata. Read one of them **before** concluding anything about
 accuracy:
 
 ```
-INFO serving robot=unitree_g1 H=50 x D=32
+INFO serving robot=unitree_g1 robot_steps=True H=50 x D=32
      image_keys=['images/cam_high', 'images/cam_left_wrist', 'images/cam_right_wrist']
      state=state discrete_state=False
 ```
@@ -89,14 +89,17 @@ from openpi_client import websocket_client_policy as wcp
 c = wcp.WebsocketClientPolicy(host="127.0.0.1", port=8000)
 meta = c.get_server_metadata()
 assert meta["robot"] == "unitree_g1"
+assert meta["robot_steps"] is True      # this robot's arithmetic is actually wired
 assert meta["image_keys"] == [...]      # the keys you are actually sending
 assert meta["discrete_state"] is True   # a joint-space robot needs this on
 ```
 
-Published keys: `robot`, `robot_slots`, `model_type`, `image_keys`, `state_key`,
-`prompt_key`, `discrete_state`, `state_normalized`, `action_horizon`,
-`action_dim`, `model_action_dim`, `num_views`, `image_size`, `input_pipeline`,
-`output_pipeline`. A key mismatch is invisible on the wire but obvious here.
+Published keys: `robot`, `robot_steps`, `robot_slots`, `model_type`,
+`image_keys`, `state_key`, `prompt_key`, `discrete_state`, `state_normalized`,
+`action_horizon`, `action_dim`, `model_action_dim`, `num_views`, `image_size`,
+`input_pipeline`, `output_pipeline`. A key mismatch is invisible on the wire but
+obvious here. `robot_steps` is `False` on a server that serves a preset's keys
+without running its builder — see `--random-weights` below.
 
 ### Per-field overrides
 
@@ -275,7 +278,7 @@ suffix — `unitree_g1`.
 
 ### Step 5 — tests
 
-Add to `tests/test_robot_presets.py`. Four things are worth asserting, and they
+Add to `tests/test_robot_presets.py`. Five things are worth asserting, and they
 run on CPU with a mock model — no GPU, no checkpoint:
 
 1. **the preset matches the openpi transform it mirrors** — keys, order, widths,
@@ -286,7 +289,11 @@ run on CPU with a mock model — no GPU, no checkpoint:
 3. **the wrong dialect fails loudly** — a LIBERO-shaped observation against your
    server must raise, naming the served `image_keys`;
 4. **slot order is load-bearing** — reordering `image_keys` reorders the stacked
-   views (`ImageSlotOrderTest` asserts this against the tensor, not the metadata).
+   views (`ImageSlotOrderTest` asserts this against the tensor, not the metadata);
+5. **the contract you publish is the one you serve** — `BuildRobotPolicyTest`
+   asserts the resolved keys and `robot_steps` reach the builder and the metadata,
+   and `SyntheticContractTest` asserts a checkpoint-free server names what it
+   cannot honour instead of passing for the real embodiment.
 
 ```bash
 python3 tests/test_robot_presets.py          # no GPU needed
@@ -318,9 +325,13 @@ constant. A hard-coded expected shape tests your memory of the checkpoint rather
 than the server.
 
 For a transport-only check with no weights on disk, `--random-weights --robot
-<preset>` serves the preset's key layout on synthetic weights. Its actions are
-numerically meaningless, and it cannot honour `discrete_state=True` (the
-synthetic tokenizer never reads state) — it warns at startup when you ask it to.
+<preset>` serves the preset's key layout and view count on synthetic weights.
+That is all it serves: the actions are numerically meaningless, and the preset's
+`builder` never runs, so none of its robot pre/post steps is wired. It publishes
+`robot_steps=false` and warns once at startup naming every gap — `discrete_state`
+(the synthetic tokenizer never reads state) and, for a robot-step preset, the
+skipped factory and the action width that came out of the model instead of out of
+the encode step.
 
 ## Gotchas we hit
 
@@ -342,10 +353,12 @@ synthetic tokenizer never reads state) — it warns at startup when you ask it t
 6. **A preset's `num_views` must equal the checkpoint's**, unless you pass
    `--num-views` to load fewer. `Pi05Policy.default_pipelines` rejects a mismatch
    and names the fix in the message.
-7. **`--random-weights` cannot preview a `discrete_state=True` contract.** Its
-   synthetic tokenizer ignores state, so the published metadata says
-   `discrete_state=False` — truthful about that server, misleading as a preview.
-   It warns; use a checkpoint for a real contract check.
+7. **`--random-weights` previews the wire layer only.** Its synthetic tokenizer
+   ignores state, so the published metadata says `discrete_state=False`, and it
+   never runs `preset.builder`, so no robot pre/post step is wired and the action
+   width is the model's rather than the encode step's. Truthful about that server,
+   misleading as a preview — hence `robot_steps=false` in the metadata and a
+   startup warning per gap. Use a checkpoint for a real contract check.
 8. **Metadata is the contract; assert it from the client.** Every silent failure
    in this area is visible in the connect-time metadata one line before it
    becomes an "accuracy problem."

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -41,7 +41,7 @@ things and they never need to be equal.
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
 | **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
-| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `slots` | yes — this is what the client sends |
+| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `Convention` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
 A preset pairs each view slot with the wire key that fills it. `image_keys` is
@@ -268,28 +268,55 @@ width instead of advertising one nothing emits.
 One entry in `python/apxinf/apxinf/robots/presets.py`. This is the whole
 registration step — OpenPI's `training/config.py` equivalent.
 
+A preset is two halves, because the arm and the key convention vary
+independently. An `Embodiment` is the **body**: camera count, deployable action
+width, which pre/post steps its actions need. It survives a change of dataset. A
+`Convention` is a **dataset's recording dialect**: the wire keys and the state
+routing that follows from how the data was recorded. It survives a change of
+robot.
+
 ```python
+MY_ARM = Embodiment(
+    name="myarm",
+    num_cameras=2,
+    action_dim=7,               # None keeps full width when an encode step truncates
+    builder=build_my_robot_policy,   # omit for the stock policy
+    builder_kwargs={},          # constants the builder always receives
+)
+
+MY_DATASET_KEYS = Convention(
+    name="mydataset",
+    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
+    state_key="observation/state",
+    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
+)
+
 MY_ROBOT = RobotPreset(
     name="myarm_mydataset",
-    slots=(
-        ("base_0_rgb", "observation/image"),
-        ("left_wrist_0_rgb", "observation/wrist_image"),
-    ),
-    state_key="observation/state",
-    action_dim=7,               # None keeps full width when an encode step truncates
-    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
-    builder=build_my_robot_policy,   # omit for the stock policy
+    embodiment=MY_ARM,
+    convention=MY_DATASET_KEYS,
     summary="MyArm, MyDataset keys: 2 cameras, 7-dim action",
-    builder_kwargs={},          # constants the builder always receives
 )
 
 ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 ```
 
-`__post_init__` rejects a `slots` tuple that is not an in-order prefix of
-`VIEW_SLOTS`, and rejects duplicate wire keys. A checkpoint fills view slots from
-0 up, so there is no way to spell "wrist camera only" other than putting it in
-slot 0.
+Serving the same arm under a second dataset's keys is then one more `Convention`
+and one more pairing — no builder edit, no duplicated action width.
+
+Only the *pairing* is deployable, so `--robot` stays a single flag over
+`ROBOT_PRESETS` rather than becoming `--robot` + `--convention`. Separate flags
+would let an operator spell a combination nobody ever recorded, and a body served
+under a convention it was not recorded on is exactly the silent mismatch this
+mechanism exists to prevent.
+
+Validation runs when the module loads. `Convention.__post_init__` rejects
+duplicate wire keys and more keys than there are view slots;
+`Embodiment.__post_init__` rejects a camera count outside `1..len(VIEW_SLOTS)`;
+`RobotPreset.__post_init__` rejects a convention whose camera count disagrees
+with the body's. Slot names are *derived* from `image_keys` in order, so "base +
+right wrist" is not expressible at all — a checkpoint fills view slots from 0 up,
+and the only way to spell "wrist camera only" is to put it in slot 0.
 
 Add an entry to `ROBOT_ALIASES` if a deployment already says something else in
 its launch scripts; a rename should not break a running system.
@@ -303,6 +330,10 @@ a preset is named for the arm **and** the dataset convention whose keys it
 implements: `franka_libero`, not `libero` (a benchmark, not a robot) and not
 `franka` (ambiguous). A single-embodiment robot that owns its convention needs no
 suffix — `unitree_g1`.
+
+The `Embodiment`/`Convention` split is that naming rule made structural: the two
+halves of the name are the two halves of the preset, and `franka_droid` would
+reuse `FRANKA` rather than restating its width and builder.
 
 ### Step 5 — tests
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -294,6 +294,8 @@ MY_ARM = Embodiment(
     name="myarm",
     num_cameras=2,
     action_dim=7,               # None keeps full width when an encode step truncates
+    state_dim=8,                # how wide norm_stats["state"] has to be
+    action_width=7,             # how wide norm_stats["actions"] has to be
     builder=build_my_robot_policy,   # omit for the stock policy
     builder_kwargs={},          # constants the builder always receives
 )
@@ -331,6 +333,26 @@ duplicate wire keys and more keys than there are view slots;
 with the body's. Slot names are *derived* from `image_keys` in order, so "base +
 right wrist" is not expressible at all — a checkpoint fills view slots from 0 up,
 and the only way to spell "wrist camera only" is to put it in slot 0.
+
+**Fill in `state_dim` and `action_width`.** They are the only thing that lets
+the startup preflight (Step 6) tell your robot's `norm_stats.json` from some
+other robot's — leave them `None` and that check silently does nothing. They are
+two fields rather than one because a robot's state and action spaces need not
+match: LIBERO is 8-dim state / 7-dim EEF-delta action. `action_width` exists
+separately from `action_dim` because the two answer different questions —
+`action_dim` is a *loading* knob ("trim the model down to this"), `action_width`
+is a fact about the body ("this is how many columns its actions have"). A preset
+whose encode step owns the 32→N truncation sets `action_dim=None`, and `None` is
+not a width: G1 declares `action_dim=None, action_width=16`.
+
+**Set `norm_dtype="float64"` in `builder_kwargs` if the checkpoint came from
+openpi.** openpi parses `norm_stats.json` into float64 and never demotes it, so
+its whole chain runs in float64 whatever dtype the robot sends. Ours follows the
+input. The difference is ~1e-7 and invisible on the output side, but a robot that
+discretizes state into its prompt compares the normalized value against bin edges
+1/128 apart, and an element near an edge crosses it — different prompt, different
+tokens, different rollout. It is a per-body flag rather than a global default so
+that presets nobody has re-benchmarked keep their existing numbers exactly.
 
 Add an entry to `ROBOT_ALIASES` if a deployment already says something else in
 its launch scripts; a rename should not break a running system.
@@ -372,6 +394,33 @@ run on CPU with a mock model — no GPU, no checkpoint:
 python3 tests/test_robot_presets.py          # no GPU needed
 ```
 
+### Step 6 — check the preflight refuses the wrong checkpoint
+
+A preset and a checkpoint directory are two independent claims about the same
+robot, and until the preflight existed nothing compared them. `--robot myarm`
+pointed at another robot's checkpoint loads, serves, and returns well-shaped
+actions in a plausible numeric range that mean nothing; the only symptom is that
+the model "got worse". Run it against your checkpoint before you serve it:
+
+```bash
+python3 scripts/openpi_metadata_to_apxinf.py --model-dir "$CKPT" --robot <preset>
+```
+
+It reads the checkpoint's `norm_stats.json` widths and tokenizer, and — when the
+checkpoint carries openpi's `metadata.pt` — cross-checks your preset field by
+field against openpi's own serialized `TrainConfig` (camera wire keys,
+`discrete_state_input`, `adapt_to_pi`, `use_delta_joint_actions`,
+`action_horizon`, `max_token_len`). Exit status is 1 on any fatal finding, so it
+can gate a deployment. The same directory checks run inside
+`pi05_openpi_websocket_server.py` **before** the weights load, and refuse to
+start; `--skip-preflight` overrides that, and exists only to reproduce a
+known-bad configuration deliberately.
+
+Add cases to `tests/test_preflight.py` if your robot has a width rule the generic
+checks miss. The check that matters most is the boring one: a *correct*
+checkpoint must produce zero fatal findings, or operators will learn to pass
+`--skip-preflight` by reflex.
+
 ## Verification recipe
 
 Offline first, then one GPU pass. In order, because each step localizes a
@@ -380,20 +429,24 @@ different class of bug:
 ```bash
 # 1. contract + plumbing, CPU only, mock model
 python3 tests/test_robot_presets.py
+python3 -m pytest tests/test_preflight.py
 
-# 2. real checkpoint, native contract
+# 2. does the checkpoint agree with the preset? (seconds; no weights loaded)
+python3 scripts/openpi_metadata_to_apxinf.py --model-dir "$CKPT" --robot <preset>
+
+# 3. real checkpoint, native contract
 python3 scripts/pi05_openpi_websocket_server.py \
   --model-dir "$CKPT" --robot <preset> --precision bf16 --port 8000
 #    -> read the "serving robot=..." line; assert every field
 
-# 3. real transport, unmodified openpi client
+# 4. real transport, unmodified openpi client
 #    -> assert actions.shape == (meta["action_horizon"], meta["action_dim"])
 #    -> assert np.isfinite(actions).all()
 
-# 4. wrong-dialect rejection: send another preset's keys; it must raise
+# 5. wrong-dialect rejection: send another preset's keys; it must raise
 ```
 
-Step 3's shape assertion should read the shape **off the metadata**, not off a
+Step 4's shape assertion should read the shape **off the metadata**, not off a
 constant. A hard-coded expected shape tests your memory of the checkpoint rather
 than the server.
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -204,36 +204,54 @@ returns `data` unchanged when there is no state, so state-off serving degrades t
 ### Step 3 — the adapter
 
 `python/apxinf/apxinf/robots/<robot>.py`. One factory that loads the checkpoint
-through the generic `Pi05Policy.from_pretrained` and then splices the robot steps
-into the default pipelines:
+through `AutoPolicy` — so `config.json` decides which model it is, not this file
+— and then wraps the robot steps *around* whatever chain that policy has:
 
 ```python
-def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **kwargs):
-    base = Pi05Policy.from_pretrained(
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy, Policy
+
+def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **load_kwargs):
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,      # keep full model width; the encode step truncates
         state_key=state_key,
-        **kwargs,
+        **load_kwargs,
     )
-    input_pipeline = base.input_pipeline.insert_before(
-        "tokenize", ("<robot>_decode_state", <Robot>DecodeState(state_key))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(f"{type(base).__name__} has no with_adapter(); ...")
+    return base.with_adapter(
+        before=[("<robot>_decode_state", <Robot>DecodeState(state_key))],
+        after=[("<robot>_absolute", <Robot>AbsoluteActions(state_key)),
+               ("<robot>_encode",   <Robot>EncodeActions())],
+        action_dim=ROBOT_DIM,             # the width the encode step leaves behind
+        metadata={"robot": "<robot>"},
     )
-    output_pipeline = Pipeline([
-        ("unnormalize", base.output_pipeline["unnormalize"]),
-        ("<robot>_absolute", <Robot>AbsoluteActions(state_key)),
-        ("<robot>_encode", <Robot>EncodeActions()),
-    ])
-    return Pi05Policy(base.model, input_pipeline=..., output_pipeline=..., ...)
 ```
+
+The adapter names **no model class and no step inside the model's chain**. That
+is deliberate: a robot's requirement is an *ordering* — its steps run outside the
+model's, in both directions — not a claim about what those steps are called.
+`Pipeline.prepend`/`append` are the only editing verbs that express ordering
+without a name, and `with_adapter`
+([`ComposablePolicy`](../python/apxinf/apxinf/policies/base.py)) is how a policy
+exposes them. Reaching for `insert_before("tokenize", ...)` instead would make
+your robot depend on one model's private vocabulary, and on that model class by
+import.
 
 Two orderings matter and are easy to get wrong:
 
-* the decode-state step goes **before** `tokenize`, so discretized state (when
-  on) and the delta→absolute output step both see the decoded state;
+* the decode-state step goes **before** the model's whole input chain, so
+  discretized state (when on) and the delta→absolute output step both see the
+  decoded state;
 * unnormalize runs at **full model width**, before any truncation, so
-  delta→absolute sees the whole action. Pass `action_dim=None` into
-  `from_pretrained` and let the encode step truncate.
+  delta→absolute sees the whole action. Pass `action_dim=None` into the loader
+  and let the encode step truncate.
+
+Declare `action_dim=` only for the width a step you appended actually produces.
+Without the truncating step there is nothing to claim — inherit the model's own
+width instead of advertising one nothing emits.
 
 ### Step 4 — register the preset
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -41,7 +41,7 @@ things and they never need to be equal.
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
 | **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
-| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `Convention` | yes — this is what the client sends |
+| **wire keys** | `observation/image`, `images/cam_high`, … | a `Convention` in `conventions.py` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
 A preset pairs each view slot with the wire key that fills it. `image_keys` is
@@ -221,7 +221,10 @@ through `AutoPolicy` — so `config.json` decides which model it is, not this fi
 from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy, Policy
 
-def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **load_kwargs):
+# state_key / image_keys are required and have no defaults — they belong to the
+# dataset (Step 4), not to this body. A default here would mean the same arm,
+# re-recorded under new keys, silently keeps serving the old ones.
+def build_<robot>_policy(model_dir, *, state_key, image_keys, **load_kwargs):
     base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
@@ -265,7 +268,8 @@ width instead of advertising one nothing emits.
 
 ### Step 4 — register the preset
 
-One entry in `python/apxinf/apxinf/robots/presets.py`. This is the whole
+Two entries: a `Convention` in `python/apxinf/apxinf/conventions.py` and a body +
+pairing in `python/apxinf/apxinf/robots/presets.py`. That is the whole
 registration step — OpenPI's `training/config.py` equivalent.
 
 A preset is two halves, because the arm and the key convention vary
@@ -273,9 +277,19 @@ independently. An `Embodiment` is the **body**: camera count, deployable action
 width, which pre/post steps its actions need. It survives a change of dataset. A
 `Convention` is a **dataset's recording dialect**: the wire keys and the state
 routing that follows from how the data was recorded. It survives a change of
-robot.
+robot, which is why it lives in its own module and not under `robots/` — a
+dialect that lived in one robot's file could only ever be that robot's.
 
 ```python
+# apxinf/conventions.py — the dialect, independent of any arm
+MY_DATASET_KEYS = Convention(
+    name="mydataset",
+    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
+    state_key="observation/state",
+    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
+)
+
+# apxinf/robots/presets.py — the body, and the pairing
 MY_ARM = Embodiment(
     name="myarm",
     num_cameras=2,
@@ -284,17 +298,10 @@ MY_ARM = Embodiment(
     builder_kwargs={},          # constants the builder always receives
 )
 
-MY_DATASET_KEYS = Convention(
-    name="mydataset",
-    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
-    state_key="observation/state",
-    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
-)
-
 MY_ROBOT = RobotPreset(
     name="myarm_mydataset",
     embodiment=MY_ARM,
-    convention=MY_DATASET_KEYS,
+    convention=conventions.MY_DATASET_KEYS,
     summary="MyArm, MyDataset keys: 2 cameras, 7-dim action",
 )
 
@@ -303,6 +310,13 @@ ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 
 Serving the same arm under a second dataset's keys is then one more `Convention`
 and one more pairing — no builder edit, no duplicated action width.
+
+If your robot lives in **your own package**, do not patch either file. Call
+`register_convention(...)` and `register_robot_preset(..., aliases=(...))` at
+your module scope; importing that module before the server starts is enough to
+make it `--robot <name>`. Re-registering an existing name needs an explicit
+`replace=True`, and an alias may never shadow a canonical preset name — a silent
+overwrite would change what a launch command already in production resolves to.
 
 Only the *pairing* is deployable, so `--robot` stays a single flag over
 `ROBOT_PRESETS` rather than becoming `--robot` + `--convention`. Separate flags
@@ -397,7 +411,10 @@ the encode step.
 1. **`discrete_state=False` drops state; it does not pass it through raw.**
    There is no third state. A joint-space robot served with `discrete_state=False`
    loses its proprioception silently, which also makes any delta→absolute step a
-   no-op (a delta cannot be resolved without current joint positions).
+   no-op (a delta cannot be resolved without current joint positions). This is
+   also why `state_key` is **required whenever it is read**: a wrong camera key
+   raises on the first inference, but a missing state key is silent, so the
+   policy refuses to be built with `discrete_state=True` and no key.
 2. **`image_keys` order is the view slot order.** Wrong order → right shape,
    wrong cameras, no error. This is why presets pair keys with slot names.
 3. **Truncate after unnormalize, not before.** Unnormalize at full model width so
@@ -429,6 +446,7 @@ the encode step.
    omission should fail at startup.
 2. **Robot steps are model-agnostic; adapters are where they meet a policy.**
    `processors/robots/` imports no policy symbols; `robots/` does the assembly.
+   Neither holds a wire key: those are a dataset's, and live in `conventions.py`.
 3. **Fail loudly with the served contract in the message.** Every error in this
    layer names what the server is actually serving, because the person reading it
    is comparing two dialects.
@@ -443,6 +461,7 @@ The Unitree G1 port is the reference implementation — it exercises every step,
 including the ones `franka_libero` skips:
 
 - `python/apxinf/apxinf/robots/presets.py` — the registry and both presets
+- `python/apxinf/apxinf/conventions.py` — the LIBERO and G1 wire dialects
 - `python/apxinf/apxinf/processors/robots/unitree_g1.py` — decode-state,
   delta→absolute, 32→16 encode
 - `python/apxinf/apxinf/robots/unitree_g1.py` — the adapter that splices them in

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -16,9 +16,11 @@ Three layers, kept deliberately decoupled:
   policy by ``config.json`` model type; :class:`~apxinf.policies.base.Policy` is
   the structural contract they all satisfy.
 * **robots** — the assembly layer (:mod:`apxinf.robots`). A ``build_*`` factory
-  binds one robot to a model policy by wiring its
-  :mod:`apxinf.processors.robots` steps into the policy pipelines. Depends
-  downward on both ``policies`` and ``processors``; neither depends back.
+  binds one robot to a model policy by wrapping its
+  :mod:`apxinf.processors.robots` steps *around* the policy's own chain, through
+  :class:`~apxinf.policies.base.ComposablePolicy`. It names no model class, so the
+  dependency is on a capability rather than on ``Pi05Policy``; ``policies`` and
+  ``processors`` never depend back.
 * **bindings** — :class:`Model` re-exports the ``apxinf_py`` PyO3 handle (L1
   bare-model inference; an internal L0 patches path exists but is private). It is
   the single public surface; you never import ``apxinf_py`` directly.
@@ -34,7 +36,7 @@ policy's ``from_pretrained`` pull in the ``apxinf_py`` binding.
 from __future__ import annotations
 
 from . import processors
-from .policies import AutoPolicy, Pi05Policy, Policy
+from .policies import AutoPolicy, ComposablePolicy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
     RobotPreset,
@@ -58,6 +60,7 @@ __all__ = [
     "processors",
     # policy contract (outward); BareModel (inward) lives in apxinf.policies
     "Policy",
+    "ComposablePolicy",
     # L2 policies
     "Pi05Policy",
     "AutoPolicy",

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -15,12 +15,18 @@ Three layers, kept deliberately decoupled:
   :class:`~apxinf.policies.auto.AutoPolicy` dispatches a checkpoint to its concrete
   policy by ``config.json`` model type; :class:`~apxinf.policies.base.Policy` is
   the structural contract they all satisfy.
+* :mod:`apxinf.conventions` — dataset **recording dialects**: the camera and
+  state wire keys a client sends, and whether state was recorded into the prompt.
+  A dialect is a property of the data, not of the arm or the weights, so it
+  depends on neither and both can change under it.
 * **robots** — the assembly layer (:mod:`apxinf.robots`). A ``build_*`` factory
   binds one robot to a model policy by wrapping its
   :mod:`apxinf.processors.robots` steps *around* the policy's own chain, through
   :class:`~apxinf.policies.base.ComposablePolicy`. It names no model class, so the
-  dependency is on a capability rather than on ``Pi05Policy``; ``policies`` and
-  ``processors`` never depend back.
+  dependency is on a capability rather than on ``Pi05Policy``; ``policies``,
+  ``processors`` and ``conventions`` never depend back. A
+  :class:`~apxinf.robots.presets.RobotPreset` pairs one body with one convention
+  and is the only deployable unit.
 * **bindings** — :class:`Model` re-exports the ``apxinf_py`` PyO3 handle (L1
   bare-model inference; an internal L0 patches path exists but is private). It is
   the single public surface; you never import ``apxinf_py`` directly.
@@ -35,15 +41,23 @@ policy's ``from_pretrained`` pull in the ``apxinf_py`` binding.
 
 from __future__ import annotations
 
-from . import processors
+from . import conventions, processors
+from .conventions import (
+    Convention,
+    available_conventions,
+    get_convention,
+    register_convention,
+)
 from .policies import AutoPolicy, ComposablePolicy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     build_unitree_g1_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from .processors import (
     GaussianNoise,
@@ -58,6 +72,7 @@ from .processors import (
 
 __all__ = [
     "processors",
+    "conventions",
     # policy contract (outward); BareModel (inward) lives in apxinf.policies
     "Policy",
     "ComposablePolicy",
@@ -66,11 +81,18 @@ __all__ = [
     "AutoPolicy",
     # robot adapters
     "build_unitree_g1_policy",
-    # robot presets (embodiment -> wire keys + pipelines), openpi's TrainConfig analogue
+    # dataset dialects (wire keys + state routing), independent of any body
+    "Convention",
+    "available_conventions",
+    "get_convention",
+    "register_convention",
+    # robot presets (body x convention -> wire contract), openpi's TrainConfig analogue
+    "Embodiment",
     "RobotPreset",
     "ROBOT_PRESETS",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
     # bindings (lazy)
     "Model",

--- a/python/apxinf/apxinf/checkpoints/__init__.py
+++ b/python/apxinf/apxinf/checkpoints/__init__.py
@@ -1,0 +1,53 @@
+"""Checkpoint-directory layout: which format, and where is each file.
+
+One place that answers "what shape is this checkpoint" for all three callers who
+need to know — the policy loader, the preflight checks, and the offline auditor —
+so a directory convention is written down once rather than guessed three times.
+
+    from apxinf.checkpoints import detect_checkpoint, require_norm_stats
+
+    layout = detect_checkpoint("~/airs/airs-model")
+    stats = require_norm_stats(layout)      # raises, naming every path tried
+    config_json = layout.config_json_text() # -> apxinf_py.Model.load(config_json=...)
+
+Run ``python -m apxinf.checkpoints <dir>`` to see the same answer as a report.
+Nothing here loads weights, imports torch, or touches the network.
+"""
+
+from __future__ import annotations
+
+from .layout import (
+    FORMATS,
+    LEROBOT,
+    NORM_STATS_NAME,
+    OPENPI_PYTORCH,
+    TOKENIZER_NAMES,
+    CheckpointError,
+    CheckpointLayout,
+    detect_checkpoint,
+    require_norm_stats,
+    resolve_tokenizer,
+)
+from .metadata import (
+    MetadataError,
+    read_metadata_pt,
+    repack_structure,
+    train_config_facts,
+)
+
+__all__ = [
+    "CheckpointError",
+    "CheckpointLayout",
+    "FORMATS",
+    "LEROBOT",
+    "MetadataError",
+    "NORM_STATS_NAME",
+    "OPENPI_PYTORCH",
+    "TOKENIZER_NAMES",
+    "detect_checkpoint",
+    "read_metadata_pt",
+    "repack_structure",
+    "require_norm_stats",
+    "resolve_tokenizer",
+    "train_config_facts",
+]

--- a/python/apxinf/apxinf/checkpoints/__init__.py
+++ b/python/apxinf/apxinf/checkpoints/__init__.py
@@ -6,7 +6,7 @@ so a directory convention is written down once rather than guessed three times.
 
     from apxinf.checkpoints import detect_checkpoint, require_norm_stats
 
-    layout = detect_checkpoint("~/airs/airs-model")
+    layout = detect_checkpoint(model_dir)
     stats = require_norm_stats(layout)      # raises, naming every path tried
     config_json = layout.config_json_text() # -> apxinf_py.Model.load(config_json=...)
 
@@ -25,6 +25,7 @@ from .layout import (
     CheckpointError,
     CheckpointLayout,
     detect_checkpoint,
+    has_layout_metadata,
     require_norm_stats,
     resolve_tokenizer,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "OPENPI_PYTORCH",
     "TOKENIZER_NAMES",
     "detect_checkpoint",
+    "has_layout_metadata",
     "read_metadata_pt",
     "repack_structure",
     "require_norm_stats",

--- a/python/apxinf/apxinf/checkpoints/__main__.py
+++ b/python/apxinf/apxinf/checkpoints/__main__.py
@@ -1,0 +1,7 @@
+"""``python -m apxinf.checkpoints <dir>`` — the standalone checkpoint inspector."""
+
+from __future__ import annotations
+
+from .layout import _main
+
+raise SystemExit(_main())

--- a/python/apxinf/apxinf/checkpoints/layout.py
+++ b/python/apxinf/apxinf/checkpoints/layout.py
@@ -53,6 +53,7 @@ __all__ = [
     "OPENPI_PYTORCH",
     "TOKENIZER_NAMES",
     "detect_checkpoint",
+    "has_layout_metadata",
     "require_norm_stats",
     "resolve_tokenizer",
 ]
@@ -190,7 +191,7 @@ def _resolve_norm_stats(
         parts = _asset_parts(asset_id)
         # openpi's official convention, written by train_pytorch.py.
         candidates.append(root.joinpath("assets", *parts, NORM_STATS_NAME))
-        # Some forks (RLinf) also drop a copy without the assets/ prefix.
+        # Some exporters also drop a copy without the assets/ prefix.
         candidates.append(root.joinpath(*parts, NORM_STATS_NAME))
     flat = root / NORM_STATS_NAME
     tried = (*candidates, flat)
@@ -207,6 +208,20 @@ def _resolve_norm_stats(
     if flat.is_file():
         return flat, tried, bool(candidates), tuple(notes)
     return None, tried, False, tuple(notes)
+
+
+def has_layout_metadata(model_dir) -> bool:
+    """True when the directory declares its own layout (``metadata.pt``/``config.json``).
+
+    Callers that must keep serving the hand-assembled flat directories that
+    predate this module — ``model.safetensors`` + ``norm_stats.json`` and nothing
+    that says what the checkpoint is — use this to decide whether
+    :func:`detect_checkpoint` has anything to work with. Detection itself refuses
+    to guess, which is right for a real checkpoint and wrong as a hard regression
+    for a directory that used to load.
+    """
+    root = Path(model_dir)
+    return (root / METADATA_NAME).is_file() or (root / CONFIG_NAME).is_file()
 
 
 def detect_checkpoint(
@@ -275,7 +290,7 @@ def detect_checkpoint(
             raise CheckpointError(f"{metadata_pt}: {exc}") from exc
         arch = dict(facts["arch"])
         if has_config:
-            # The customer's directory is exactly this: a hand-added config.json
+            # A shipped directory can be exactly this: a hand-added config.json
             # from a *different* training run sitting next to the real metadata.
             notes.append(
                 f"{config_json} is ignored — for an openpi export metadata.pt is the "

--- a/python/apxinf/apxinf/checkpoints/layout.py
+++ b/python/apxinf/apxinf/checkpoints/layout.py
@@ -1,0 +1,460 @@
+"""What shape is this checkpoint directory, and where is each file?
+
+Five directory layouts turn up in the field and only two of them matter here:
+
+``openpi_pytorch``
+    What ``scripts/train_pytorch.py`` writes and what ships to a customer:
+    ``model.safetensors`` + ``metadata.pt`` (+ ``optimizer.pt``) with the
+    statistics under ``assets/<asset_id>/norm_stats.json``. **There is no
+    config.json**, so every architecture constant has to come out of
+    ``metadata.pt``.
+
+``lerobot``
+    A HuggingFace robot-policy directory: ``config.json`` with ``"type": "pi05"``
+    plus ``model.safetensors``. LeRobot keeps normalization statistics inside
+    ``policy_preprocessor_step_<N>_normalizer_processor.safetensors`` rather than
+    a JSON file (and the official pi05 repo deleted even that), so a servable
+    LeRobot checkpoint needs a ``norm_stats.json`` supplied alongside it.
+
+The tensor names are **identical** between the two — 812 of them, exact set
+equality — so nothing about weight loading changes. Only the sidecar metadata
+differs, which is the entire job of this module.
+
+Why this is its own layer rather than a few lines in ``Pi05Policy.from_pretrained``:
+three callers need the same answer and only one of them may import the CUDA
+binding. :mod:`apxinf.robots.preflight` runs *before* anything heavy loads, and
+``scripts/openpi_metadata_to_apxinf.py`` runs on a laptop. Previously each of
+them hard-coded its own guess at the layout — ``norm_stats.json`` alone was
+spelled out in three places and ``metadata.pt`` was read in none of the serving
+ones.
+
+The failure this exists to prevent: a checkpoint directory that contains a
+*syntactically valid but semantically wrong* ``norm_stats.json`` loads without a
+single error and unnormalizes every action through the wrong physical range. So
+the resolver names every path it tried, logs the one it settled on, and refuses
+to guess when nothing matches.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from .metadata import MetadataError, read_metadata_pt, train_config_facts
+
+__all__ = [
+    "CheckpointError",
+    "CheckpointLayout",
+    "LEROBOT",
+    "NORM_STATS_NAME",
+    "OPENPI_PYTORCH",
+    "TOKENIZER_NAMES",
+    "detect_checkpoint",
+    "require_norm_stats",
+    "resolve_tokenizer",
+]
+
+LOGGER = logging.getLogger("apxinf.checkpoints")
+
+#: openpi's PyTorch training export. Authority: ``metadata.pt``.
+OPENPI_PYTORCH = "openpi_pytorch"
+#: A LeRobot / HuggingFace robot-policy directory. Authority: ``config.json``.
+LEROBOT = "lerobot"
+#: Accepted values of ``checkpoint_format=`` / ``--ckpt-format``.
+FORMATS = ("auto", OPENPI_PYTORCH, LEROBOT)
+
+NORM_STATS_NAME = "norm_stats.json"
+WEIGHTS_NAME = "model.safetensors"
+METADATA_NAME = "metadata.pt"
+CONFIG_NAME = "config.json"
+
+#: SentencePiece filenames a checkpoint may carry, in preference order. apxinf
+#: never downloads one: openpi pulls it from ``gs://big_vision`` and LeRobot from
+#: a gated HF repo, and a serving box is not assumed to reach either.
+TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
+
+_TOKENIZER_HELP = (
+    "The tokenizer is not distributed with any pi05 checkpoint — the same ~4 MB "
+    "SentencePiece model serves the whole PaliGemma family, so openpi downloads it "
+    "from gs://big_vision/paligemma_tokenizer.model at runtime and LeRobot pulls "
+    "google/paligemma-3b-pt-224 from the HF Hub (a gated repo: 401 without an "
+    "accepted licence). apxinf never downloads anything, so the file has to be put "
+    "in place once, by hand."
+)
+
+
+class CheckpointError(RuntimeError):
+    """The checkpoint directory is not a layout apxinf can serve, as-is."""
+
+
+@dataclass(frozen=True)
+class CheckpointLayout:
+    """Every path and constant resolved from one checkpoint directory."""
+
+    #: :data:`OPENPI_PYTORCH` or :data:`LEROBOT`.
+    format: str
+    root: Path
+    weights: Optional[Path]
+    config_json: Optional[Path]
+    metadata_pt: Optional[Path]
+    #: openpi's ``data.assets.asset_id or data.repo_id``; ``None`` for LeRobot.
+    asset_id: Optional[str] = None
+    asset_id_source: str = ""
+    #: The statistics file, or ``None`` when nothing matched — see
+    #: :func:`require_norm_stats` for the error a caller should raise.
+    norm_stats: Optional[Path] = None
+    #: Every candidate considered, in order, whether or not it existed.
+    norm_stats_tried: Tuple[Path, ...] = ()
+    #: True when the asset-path candidates all missed and the root file was used.
+    norm_stats_is_fallback: bool = False
+    #: ``Pi05Config::from_json_str``-shaped architecture overrides. Empty for
+    #: LeRobot, where the Rust loader reads ``config.json`` itself.
+    arch: Mapping[str, Any] = field(default_factory=dict)
+    #: Deployment facts from ``metadata.pt`` (cameras, delta convention, ...).
+    openpi: Mapping[str, Any] = field(default_factory=dict)
+    #: Human-readable observations worth surfacing but not worth failing on.
+    notes: Tuple[str, ...] = ()
+
+    def config_json_text(self) -> Optional[str]:
+        """The ``config_json=`` string to hand ``apxinf_py.Model.load``.
+
+        ``None`` means "let the Rust loader read ``config.json`` as before",
+        which is exactly right for a LeRobot directory.
+        """
+        return json.dumps(dict(self.arch), sort_keys=True) if self.arch else None
+
+    def describe(self) -> str:
+        """A multi-line report for a log line or the standalone inspector."""
+        lines = [
+            f"format:       {self.format}",
+            f"root:         {self.root}",
+            f"weights:      {self.weights if self.weights else '(missing)'}",
+        ]
+        if self.metadata_pt:
+            lines.append(f"metadata.pt:  {self.metadata_pt}")
+        if self.config_json:
+            lines.append(f"config.json:  {self.config_json}")
+        if self.asset_id:
+            lines.append(f"asset_id:     {self.asset_id!r} (from {self.asset_id_source})")
+        stats = self.norm_stats or "(none found)"
+        suffix = "  [ROOT FALLBACK]" if self.norm_stats_is_fallback else ""
+        lines.append(f"norm_stats:   {stats}{suffix}")
+        if len(self.norm_stats_tried) > 1:
+            for candidate in self.norm_stats_tried:
+                mark = "*" if candidate == self.norm_stats else ("+" if candidate.is_file() else "-")
+                lines.append(f"                {mark} {candidate}")
+        if self.arch:
+            rendered = ", ".join(f"{k}={v}" for k, v in sorted(self.arch.items()))
+            lines.append(f"architecture: {rendered}")
+        for key in ("exp_name", "global_step", "image_keys", "state_key",
+                    "adapt_to_pi", "use_delta_joint_actions", "default_prompt"):
+            value = self.openpi.get(key)
+            if value not in (None, (), ""):
+                lines.append(f"{(key + ':').ljust(13)} {value!r}")
+        for note in self.notes:
+            lines.append(f"note:         {note}")
+        return "\n".join(lines)
+
+
+def _asset_parts(asset_id: str) -> Tuple[str, ...]:
+    """Split an ``asset_id`` into path components, refusing traversal.
+
+    openpi's asset ids are often ``org/dataset``, which becomes nested
+    directories on disk. They come from a checkpoint we did not write, so a
+    ``..`` component would read outside the checkpoint directory.
+    """
+    parts = tuple(p for p in asset_id.split("/") if p)
+    if not parts or any(p in (".", "..") for p in parts):
+        raise CheckpointError(
+            f"asset_id {asset_id!r} is not a usable relative path; pass "
+            f"--norm-stats explicitly"
+        )
+    return parts
+
+
+def _resolve_norm_stats(
+    root: Path, asset_id: Optional[str], explicit
+) -> Tuple[Optional[Path], Tuple[Path, ...], bool, Tuple[str, ...]]:
+    """Find the statistics file. Returns ``(path, tried, is_fallback, notes)``."""
+    if explicit is not None:
+        path = Path(explicit)
+        if not path.is_file():
+            raise CheckpointError(f"norm_stats path {path} does not exist")
+        return path, (path,), False, ()
+
+    candidates = []
+    if asset_id:
+        parts = _asset_parts(asset_id)
+        # openpi's official convention, written by train_pytorch.py.
+        candidates.append(root.joinpath("assets", *parts, NORM_STATS_NAME))
+        # Some forks (RLinf) also drop a copy without the assets/ prefix.
+        candidates.append(root.joinpath(*parts, NORM_STATS_NAME))
+    flat = root / NORM_STATS_NAME
+    tried = (*candidates, flat)
+
+    notes = []
+    for candidate in candidates:
+        if candidate.is_file():
+            if flat.is_file():
+                notes.append(
+                    f"{flat} exists but is ignored; the asset path {candidate} wins"
+                )
+            return candidate, tried, False, tuple(notes)
+
+    if flat.is_file():
+        return flat, tried, bool(candidates), tuple(notes)
+    return None, tried, False, tuple(notes)
+
+
+def detect_checkpoint(
+    model_dir,
+    *,
+    checkpoint_format: Optional[str] = None,
+    asset_id: Optional[str] = None,
+    norm_stats=None,
+) -> CheckpointLayout:
+    """Identify ``model_dir``'s layout and resolve every file it implies.
+
+    ``checkpoint_format`` pins the answer instead of sniffing it (``"auto"`` and
+    ``None`` both sniff). ``asset_id`` overrides what ``metadata.pt`` says, for a
+    checkpoint whose assets were reorganized after export. ``norm_stats`` is an
+    explicit path that outranks every convention.
+
+    Raises :class:`CheckpointError` when the directory matches neither layout, or
+    when a pinned format's authoritative file is absent. A **missing
+    norm_stats.json is not raised here** — the layout records what was tried and
+    :func:`require_norm_stats` turns it into an error, so preflight can report it
+    alongside its other findings instead of one crash at a time.
+    """
+    root = Path(model_dir)
+    if not root.is_dir():
+        raise CheckpointError(f"checkpoint directory {root} does not exist")
+
+    metadata_pt = root / METADATA_NAME
+    config_json = root / CONFIG_NAME
+    has_metadata, has_config = metadata_pt.is_file(), config_json.is_file()
+
+    resolved = (checkpoint_format or "auto").lower()
+    if resolved not in FORMATS:
+        raise CheckpointError(
+            f"unknown checkpoint format {checkpoint_format!r}; expected one of {list(FORMATS)}"
+        )
+    if resolved == "auto":
+        if has_metadata:
+            resolved = OPENPI_PYTORCH
+        elif has_config:
+            resolved = LEROBOT
+        else:
+            present = sorted(p.name for p in root.iterdir())[:12]
+            raise CheckpointError(
+                f"{root} matches neither checkpoint layout apxinf can load:\n"
+                f"  {OPENPI_PYTORCH}: needs {METADATA_NAME} "
+                f"(+ assets/<asset_id>/{NORM_STATS_NAME})\n"
+                f"  {LEROBOT}: needs {CONFIG_NAME} (+ {NORM_STATS_NAME})\n"
+                f"the directory holds: {present}"
+            )
+
+    notes = []
+    arch: Dict[str, Any] = {}
+    facts: Dict[str, Any] = {}
+
+    if resolved == OPENPI_PYTORCH:
+        if not has_metadata:
+            raise CheckpointError(
+                f"checkpoint_format={OPENPI_PYTORCH!r} but {metadata_pt} does not "
+                f"exist; an openpi PyTorch export always carries it (see openpi "
+                f"scripts/train_pytorch.py). Pass checkpoint_format='{LEROBOT}' if "
+                f"this is a LeRobot directory."
+            )
+        try:
+            facts = train_config_facts(read_metadata_pt(metadata_pt))
+        except MetadataError as exc:
+            raise CheckpointError(f"{metadata_pt}: {exc}") from exc
+        arch = dict(facts["arch"])
+        if has_config:
+            # The customer's directory is exactly this: a hand-added config.json
+            # from a *different* training run sitting next to the real metadata.
+            notes.append(
+                f"{config_json} is ignored — for an openpi export metadata.pt is the "
+                f"authority for the architecture"
+            )
+    else:
+        if not has_config:
+            raise CheckpointError(
+                f"checkpoint_format={LEROBOT!r} but {config_json} does not exist"
+            )
+        if has_metadata:
+            notes.append(
+                f"{metadata_pt} is present but ignored because checkpoint_format="
+                f"{LEROBOT!r} was requested"
+            )
+        # arch stays empty on purpose: the Rust loader reads config.json itself,
+        # which is the behaviour LeRobot checkpoints already had.
+
+    effective_asset_id = asset_id or facts.get("asset_id")
+    asset_id_source = (
+        "explicit override" if asset_id else facts.get("asset_id_source", "") or ""
+    )
+
+    stats, tried, is_fallback, stats_notes = _resolve_norm_stats(
+        root, effective_asset_id, norm_stats
+    )
+    notes.extend(stats_notes)
+
+    if is_fallback:
+        LOGGER.warning(
+            "norm_stats: %s (openpi's path for asset_id=%r, from %s) does not exist — "
+            "falling back to the checkpoint root %s. Verify those statistics belong to "
+            "this robot: a wrong-but-valid file unnormalizes silently.",
+            tried[0],
+            effective_asset_id,
+            asset_id_source or "unknown",
+            stats,
+        )
+    elif stats is not None:
+        LOGGER.info("norm_stats: using %s", stats)
+
+    weights = root / WEIGHTS_NAME
+    if not weights.is_file():
+        notes.append(f"{weights} not found; pass an explicit checkpoint= path")
+
+    return CheckpointLayout(
+        format=resolved,
+        root=root,
+        weights=weights if weights.is_file() else None,
+        config_json=config_json if has_config else None,
+        metadata_pt=metadata_pt if has_metadata else None,
+        asset_id=effective_asset_id,
+        asset_id_source=asset_id_source,
+        norm_stats=stats,
+        norm_stats_tried=tried,
+        norm_stats_is_fallback=is_fallback,
+        arch=arch,
+        openpi={k: v for k, v in facts.items() if k != "arch"},
+        notes=tuple(notes),
+    )
+
+
+def require_norm_stats(layout: CheckpointLayout) -> Path:
+    """The statistics path, or a :class:`CheckpointError` naming every candidate."""
+    if layout.norm_stats is not None:
+        return layout.norm_stats
+
+    tried = "\n".join(f"  {path}" for path in layout.norm_stats_tried)
+    if layout.format == OPENPI_PYTORCH:
+        asset = layout.asset_id or "<unknown>"
+        where = layout.openpi.get("assets_dir")
+        origin = f" (openpi computed them under {where}{asset}/ on the training machine)" if where else ""
+        hint = (
+            f"openpi writes this file to assets/<asset_id>/{NORM_STATS_NAME} when "
+            f"training finishes (scripts/train_pytorch.py). This checkpoint's asset_id "
+            f"is {asset!r}, from {layout.asset_id_source or 'metadata.pt'}{origin}. Ask "
+            f"whoever exported it for assets/{asset}/{NORM_STATS_NAME}, place it there, "
+            f"or point --norm-stats at it. Do not substitute another run's file: the "
+            f"statistics are what map the model's output into the robot's physical "
+            f"range, so a wrong one produces in-range, meaningless actions and no error."
+        )
+    else:
+        example = '{"actions": {"q01": [...], "q99": [...]}, "state": {...}}'
+        hint = (
+            f"LeRobot does not ship a {NORM_STATS_NAME}: it keeps the statistics inside "
+            f"policy_preprocessor_step_<N>_normalizer_processor.safetensors — and the "
+            f"official pi05 repo deleted even that on 2025-09-24 — or in the source "
+            f"dataset's meta/stats.json. apxinf parses neither. Convert them into "
+            f"{example} and put it in the checkpoint root, or pass --norm-stats."
+        )
+    raise CheckpointError(
+        f"no {NORM_STATS_NAME} for {layout.root}; tried:\n{tried}\n{hint}"
+    )
+
+
+def resolve_tokenizer(model_dir, tokenizer_path=None, *, env: Optional[Mapping[str, str]] = None) -> Path:
+    """Locate the SentencePiece model: explicit path, then env, then the directory.
+
+    ``APXINF_TOKENIZER`` exists so one hand-placed file can serve every
+    checkpoint on a box without copying it into each directory.
+    """
+    import os
+
+    environ = os.environ if env is None else env
+    if tokenizer_path is not None:
+        path = Path(tokenizer_path)
+        if not path.is_file():
+            raise CheckpointError(f"tokenizer {path} does not exist")
+        return path
+
+    from_env = environ.get("APXINF_TOKENIZER")
+    if from_env:
+        path = Path(from_env)
+        if not path.is_file():
+            raise CheckpointError(f"APXINF_TOKENIZER={from_env} does not exist")
+        return path
+
+    root = Path(model_dir)
+    candidates = [root / name for name in TOKENIZER_NAMES]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    rendered = "\n".join(f"  {path}" for path in candidates)
+    raise CheckpointError(
+        f"no SentencePiece tokenizer for {root}; tried:\n{rendered}\n{_TOKENIZER_HELP}\n"
+        f"Put the file at {root / TOKENIZER_NAMES[1]}, or set APXINF_TOKENIZER, or pass "
+        f"--tokenizer. Both servers in a comparison must use the *same* file or their "
+        f"token ids are not comparable."
+    )
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    """``python -m apxinf.checkpoints <dir>`` — inspect a checkpoint, load nothing."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m apxinf.checkpoints",
+        description=(
+            "Report how apxinf will read a checkpoint directory: which layout it is, "
+            "which norm_stats.json will actually be used, and what architecture the "
+            "loader will be given. Reads no weights and needs neither torch nor CUDA."
+        ),
+    )
+    parser.add_argument("model_dir", type=Path)
+    parser.add_argument("--ckpt-format", choices=FORMATS, default="auto")
+    parser.add_argument("--asset-id", default=None)
+    parser.add_argument("--norm-stats", type=Path, default=None)
+    parser.add_argument("--tokenizer", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    try:
+        layout = detect_checkpoint(
+            args.model_dir,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
+        )
+    except CheckpointError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    print(layout.describe())
+    print(f"config_json:  {layout.config_json_text() or '(read config.json in the loader)'}")
+
+    status = 0
+    for label, resolve in (
+        ("norm_stats", lambda: require_norm_stats(layout)),
+        ("tokenizer", lambda: resolve_tokenizer(args.model_dir, args.tokenizer)),
+    ):
+        try:
+            resolve()
+        except CheckpointError as exc:
+            print(f"\nFAIL [{label}]: {exc}")
+            status = 1
+    if status == 0:
+        print("\nOK: this checkpoint has everything apxinf needs to serve it.")
+    return status
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(_main())

--- a/python/apxinf/apxinf/checkpoints/metadata.py
+++ b/python/apxinf/apxinf/checkpoints/metadata.py
@@ -1,0 +1,299 @@
+"""Read an openpi PyTorch export's ``metadata.pt`` **without torch**.
+
+``scripts/train_pytorch.py`` in openpi ends a run with::
+
+    torch.save({"global_step": ..., "config": dataclasses.asdict(train_config),
+                "timestamp": ...}, checkpoint_dir / "metadata.pt")
+
+so the checkpoint carries its own serving contract: action width, chunk length,
+token budget, whether state is discretized, which cameras the client sends, and
+— the field that matters most here — the ``asset_id`` that says where the real
+``norm_stats.json`` lives. Nothing in apxinf's serving path read it, which is
+why an openpi export silently fell back to :func:`Pi05Config::default` for its
+architecture and to a flat ``norm_stats.json`` for its statistics.
+
+**Why not just call torch.load.** ``metadata.pt`` is a config object graph, not
+weights, so needing a 2 GB dependency to read 30 kB of nested dicts is
+backwards: the preflight checks are supposed to run *before* anything heavy, and
+``scripts/openpi_metadata_to_apxinf.py`` is supposed to run on a laptop.
+``torch.save``'s modern format is a plain zip whose ``<archive>/data.pkl``
+member is an ordinary pickle, so the standard library can read it — provided the
+unpickler refuses to import the openpi/flax/jax classes the stream names, which
+are not installed here and would be arbitrary code execution if they were.
+
+**Security.** :class:`_RestrictedUnpickler` never imports anything outside
+:data:`_ALLOWED`, which is a set of explicit ``(module, name)`` pairs. Allowing a
+whole module — ``builtins`` especially — would resolve ``builtins.eval`` and
+hand a hostile checkpoint the process. Everything else becomes an inert
+:class:`_Opaque` subclass that records what it was and drops what it held.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import pickle
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+__all__ = [
+    "MetadataError",
+    "read_metadata_pt",
+    "repack_structure",
+    "train_config_facts",
+]
+
+#: openpi's flow-matching step count when ``model.num_steps`` is absent, which
+#: is every upstream export (only forks serialize it). Matches the Rust
+#: ``Pi05Config::default``, so an absent field is left for the loader to fill.
+DEFAULT_NUM_FLOW_STEPS = 10
+#: pi05's trained view-slot count when the repack transform names no cameras.
+#: Also the Rust default, for the same reason.
+DEFAULT_NUM_VIEWS = 3
+
+
+class MetadataError(RuntimeError):
+    """``metadata.pt`` is absent, is not a torch archive, or is not openpi's."""
+
+
+# Classes the pickle stream is allowed to actually instantiate. Explicit pairs,
+# never whole modules: see the module docstring.
+_ALLOWED = frozenset(
+    {
+        ("collections", "OrderedDict"),
+        ("collections", "defaultdict"),
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("pathlib", "PosixPath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "WindowsPath"),
+        ("pathlib", "PureWindowsPath"),
+    }
+)
+
+
+class _Opaque:
+    """Inert stand-in for a class we refuse to import.
+
+    Must be a **class**, not a factory function: the ``NEWOBJ`` opcode calls
+    ``cls.__new__(cls, *args)`` and rejects a non-type. The reduce arguments are
+    kept because ``Enum`` pickles as ``EnumClass(value)`` — so an enum a caller
+    does care about is still readable through :func:`unwrap`.
+    """
+
+    _qualname = "?"
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._args = args
+        obj._state: Any = None
+        return obj
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D107 - see __new__
+        pass
+
+    def __setstate__(self, state: Any) -> None:
+        self._state = state
+        if isinstance(state, dict):
+            # Keep the recorded reduce args reachable even if the state shadows
+            # them, so unwrap() has something to fall back on.
+            self.__dict__.update({k: v for k, v in state.items() if k != "_args"})
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<opaque {self._qualname}>"
+
+
+_STUBS: Dict[Tuple[str, str], type] = {}
+
+
+def _stub(module: str, name: str) -> type:
+    key = (module, name)
+    cls = _STUBS.get(key)
+    if cls is None:
+        cls = type(
+            name, (_Opaque,), {"__module__": module, "_qualname": f"{module}.{name}"}
+        )
+        _STUBS[key] = cls
+    return cls
+
+
+def unwrap(value: Any) -> Any:
+    """Reduce an :class:`_Opaque` to its payload where that is unambiguous.
+
+    An ``Enum`` reduces to ``(cls, (value,))``, so a single positional argument
+    is the enum's value. Anything else stays as-is; callers treat it as absent.
+    """
+    if isinstance(value, _Opaque) and len(getattr(value, "_args", ())) == 1:
+        return value._args[0]
+    return value
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module: str, name: str):  # noqa: D102
+        if (module, name) in _ALLOWED:
+            return getattr(importlib.import_module(module), name)
+        return _stub(module, name)
+
+    def persistent_load(self, pid):  # noqa: D102
+        # Tensor storages resolve through the persistent-id table. metadata.pt
+        # holds a config graph rather than weights, so nothing we read ever
+        # dereferences one; returning None keeps the stream parseable.
+        return None
+
+
+def read_metadata_pt(path) -> Dict[str, Any]:
+    """Return the whole ``metadata.pt`` payload dict (``global_step``/``config``/…)."""
+    path = Path(path)
+    if not path.is_file():
+        raise MetadataError(f"{path} does not exist")
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = [
+                name
+                for name in archive.namelist()
+                if name == "data.pkl" or name.endswith("/data.pkl")
+            ]
+            if not members:
+                raise MetadataError(
+                    f"{path} is a zip but has no data.pkl member, so it is not a "
+                    f"torch archive; it holds {archive.namelist()[:10]}"
+                )
+            # Shortest name = the top-level record, not something nested.
+            raw = archive.read(min(members, key=len))
+    except zipfile.BadZipFile as exc:
+        raise MetadataError(
+            f"{path} is not a zip-format torch archive ({exc}). It was probably "
+            f"written with _use_new_zipfile_serialization=False, which this "
+            f"torch-free reader does not support; read it with torch instead."
+        ) from exc
+
+    payload = _RestrictedUnpickler(io.BytesIO(raw)).load()
+    if not isinstance(payload, Mapping):
+        raise MetadataError(
+            f"{path} unpickled to {type(payload).__name__}, expected a dict"
+        )
+    return dict(payload)
+
+
+def repack_structure(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
+
+    openpi's repack transform is written *inbound* — ``{wire_key: dataset_column}``
+    — so its keys are exactly what the client puts on the network, which is what
+    an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
+    """
+    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
+    for entry in inputs:
+        structure = entry.get("structure") if isinstance(entry, Mapping) else None
+        if isinstance(structure, Mapping):
+            return dict(structure)
+    return {}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    value = unwrap(value)
+    # bool is an int subclass; a flag is never a width.
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_text(value: Any) -> Optional[str]:
+    value = unwrap(value)
+    if value is None or isinstance(value, _Opaque):
+        return None
+    text = str(value)
+    return text or None
+
+
+def train_config_facts(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Split the serialized ``TrainConfig`` into architecture + deployment facts.
+
+    Returns ``{"arch": {...}, ...}`` where ``arch`` is already in the JSON shape
+    ``Pi05Config::from_json_str`` accepts (it takes openpi's field names as
+    aliases), and the remaining keys are what preflight and the preset diff need.
+    """
+    config = payload.get("config")
+    if not isinstance(config, Mapping):
+        raise MetadataError(
+            f"metadata.pt has no 'config' dict (keys: {sorted(payload)}); it was "
+            f"not written by openpi's train_pytorch.py"
+        )
+    model = config.get("model") if isinstance(config.get("model"), Mapping) else {}
+    data = config.get("data") if isinstance(config.get("data"), Mapping) else {}
+
+    # --- guards. These are architecture facts apxinf's pi05 runtime hard-codes,
+    #     so a checkpoint that disagrees cannot be served at all -- better to say
+    #     so here than to load 7.5 GB of weights into the wrong graph.
+    pi05 = unwrap(model.get("pi05"))
+    if pi05 is not None and not isinstance(pi05, _Opaque) and not pi05:
+        raise MetadataError(
+            "metadata.pt says pi05=False: this is a pi0 checkpoint, and apxinf's "
+            "pi05 path (discrete state in the prompt, quantile norm) cannot serve it"
+        )
+    for field, expected in (
+        ("paligemma_variant", "gemma_2b"),
+        ("action_expert_variant", "gemma_300m"),
+    ):
+        got = _as_text(model.get(field))
+        if got is not None and got != expected:
+            raise MetadataError(
+                f"metadata.pt says {field}={got!r}, but apxinf's pi05 runtime is "
+                f"built for {expected!r}; the weights would not match the graph"
+            )
+
+    # --- architecture, in Pi05Config::from_json_str's vocabulary. Only fields
+    #     the checkpoint actually states go in here: an absent one has to fall
+    #     through to the loader's own default rather than be asserted, or the
+    #     report would present a guess as a fact.
+    arch: Dict[str, Any] = {}
+    for field in ("action_dim", "action_horizon", "max_token_len"):
+        value = _as_int(model.get(field))
+        if value is not None:
+            arch[field] = value
+    # ``num_steps`` is the flow-matching Euler step count. Upstream openpi does
+    # not serialize it (it is DEFAULT_NUM_FLOW_STEPS by construction, which is
+    # also the loader's default); the RLinf fork does.
+    num_steps = _as_int(model.get("num_steps"))
+    if num_steps is not None:
+        arch["num_flow_steps"] = num_steps
+
+    structure = repack_structure(data)
+    images = structure.get("images")
+    image_keys = tuple(images) if isinstance(images, Mapping) else ()
+    if image_keys:
+        arch["num_views"] = len(image_keys)
+
+    discrete = unwrap(model.get("discrete_state_input"))
+    if isinstance(discrete, bool):
+        arch["discrete_state_input"] = discrete
+
+    # --- where the statistics live. openpi's own resolution order, verbatim:
+    #     `asset_id = data.assets.asset_id or data.repo_id` (openpi config.py).
+    assets = data.get("assets") if isinstance(data.get("assets"), Mapping) else {}
+    asset_id = _as_text(assets.get("asset_id"))
+    asset_id_source = "data.assets.asset_id"
+    if asset_id is None:
+        asset_id = _as_text(data.get("repo_id"))
+        asset_id_source = "data.repo_id"
+    if asset_id is None:
+        asset_id_source = ""
+
+    return {
+        "arch": arch,
+        "asset_id": asset_id,
+        "asset_id_source": asset_id_source,
+        # Where openpi computed them on the *training* machine. Useless as a
+        # path here, but it is the string to quote when asking for the file.
+        "assets_dir": _as_text(assets.get("assets_dir")),
+        "image_keys": image_keys,
+        "state_key": _as_text(structure.get("state")),
+        "adapt_to_pi": unwrap(data.get("adapt_to_pi")),
+        "use_delta_joint_actions": unwrap(data.get("use_delta_joint_actions")),
+        "discrete_state_input": discrete if isinstance(discrete, bool) else None,
+        "default_prompt": _as_text(data.get("default_prompt")),
+        "exp_name": _as_text(config.get("exp_name")) or _as_text(config.get("name")),
+        "global_step": _as_int(payload.get("global_step")),
+    }

--- a/python/apxinf/apxinf/checkpoints/metadata.py
+++ b/python/apxinf/apxinf/checkpoints/metadata.py
@@ -255,7 +255,7 @@ def train_config_facts(payload: Mapping[str, Any]) -> Dict[str, Any]:
             arch[field] = value
     # ``num_steps`` is the flow-matching Euler step count. Upstream openpi does
     # not serialize it (it is DEFAULT_NUM_FLOW_STEPS by construction, which is
-    # also the loader's default); the RLinf fork does.
+    # also the loader's default); some forks do.
     num_steps = _as_int(model.get("num_steps"))
     if num_steps is not None:
         arch["num_flow_steps"] = num_steps

--- a/python/apxinf/apxinf/conventions.py
+++ b/python/apxinf/apxinf/conventions.py
@@ -1,0 +1,160 @@
+"""Recording conventions: what a dataset's client calls things on the wire.
+
+The third axis of the robot / dataset / model split, and the one that had no
+home. A **convention** is a dialect: the camera wire keys in model view-slot
+order, the state key, the prompt key, and whether state was recorded into the
+prompt. It is a property of *how data was recorded*, not of the arm that
+recorded it and not of the weights that consume it.
+
+Keeping it here rather than in :mod:`apxinf.robots` is the point. LIBERO's keys
+describe a Franka today and would describe any arm recorded the same way; the
+same Franka under DROID's keys is a second convention, not a second body. A
+convention that lived in a robot's module could only ever be that robot's, and
+the G1's keys used to live in ``processors/robots/unitree_g1.py`` — a *dataset*
+fact defined inside a *body*'s processing steps, which is exactly the coupling
+this module removes.
+
+What a convention may depend on:
+
+* :data:`~apxinf.policies.base.VIEW_SLOTS` — model vocabulary, needed to say
+  which slot each camera key fills. That is a one-way read of a naming table; no
+  policy class is imported and no model is loaded.
+
+What it must not depend on: any robot body (an action width, a camera count, a
+builder) and any policy implementation. Nothing in this module imports either.
+
+A convention alone is not deployable — pairing it with an
+:class:`~apxinf.robots.presets.Embodiment` is, and
+:class:`~apxinf.robots.presets.RobotPreset` is where the two are validated
+against each other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .policies.base import VIEW_SLOTS
+
+__all__ = [
+    "Convention",
+    "LIBERO",
+    "UNITREE_G1",
+    "CONVENTIONS",
+    "available_conventions",
+    "get_convention",
+    "register_convention",
+]
+
+
+@dataclass(frozen=True)
+class Convention:
+    """A dataset's recording convention: what the client calls things.
+
+    Everything here is a string on the network, plus the one routing decision
+    that follows from how the data was recorded. It survives a change of robot.
+    Nothing here knows an action width or a camera count.
+    """
+
+    #: Convention name (a dataset, or an integrator's dialect).
+    name: str
+    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
+    image_keys: Tuple[str, ...]
+    #: Wire key of the proprioceptive state vector.
+    state_key: str
+    #: Wire key of the task instruction. ``prompt`` is openpi's protocol-level
+    #: name rather than any one dataset's, which is why it has a default here.
+    prompt_key: str = "prompt"
+    #: Whether state is discretized into the prompt. Off means state is *dropped*
+    #: — there is no third option where it is passed through raw.
+    discrete_state: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.image_keys:
+            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
+        if len(self.image_keys) > len(VIEW_SLOTS):
+            raise ValueError(
+                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
+                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
+            )
+        if len(set(self.image_keys)) != len(self.image_keys):
+            raise ValueError(
+                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
+            )
+
+    @property
+    def num_cameras(self) -> int:
+        """Cameras this convention names — cross-checked against a body's count."""
+        return len(self.image_keys)
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs — the pairing, for logs and review.
+
+        Derived rather than written by hand: a checkpoint fills view slots from 0
+        up, so "base + right wrist" is not a thing to spell wrong.
+        """
+        return tuple(zip(VIEW_SLOTS, self.image_keys))
+
+
+#: LIBERO (the 7-DoF sim benchmark), mirroring openpi's ``LiberoInputs``: flat
+#: ``observation/...`` keys. State is dropped, matching the numerics of the
+#: existing serving link.
+LIBERO = Convention(
+    name="libero",
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+    discrete_state=False,
+)
+
+#: The ``pi05_UnitreeG1`` fine-tune's dialect, from its
+#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``
+#: (spelled as a path for :func:`~apxinf.processors.transforms.lookup_key`), a
+#: flat top-level ``state`` rather than LIBERO's ``observation/state``, and state
+#: discretized into the prompt.
+UNITREE_G1 = Convention(
+    name="unitree_g1",
+    image_keys=("images/cam_high", "images/cam_left_wrist", "images/cam_right_wrist"),
+    state_key="state",
+    discrete_state=True,
+)
+
+#: Name -> convention. A registry rather than a module-level lookup so a
+#: third-party dialect can join it without editing this file
+#: (:func:`register_convention`).
+CONVENTIONS: Dict[str, Convention] = {c.name: c for c in (LIBERO, UNITREE_G1)}
+
+
+def available_conventions() -> Tuple[str, ...]:
+    """Registered convention names, for error messages and ``--help`` text."""
+    return tuple(CONVENTIONS)
+
+
+def get_convention(name: str) -> Convention:
+    """Look up a convention by name, with a listing in the error."""
+    try:
+        return CONVENTIONS[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown convention {name!r}; known: {list(available_conventions())}"
+        ) from None
+
+
+def register_convention(convention: Convention, *, replace: bool = False) -> Convention:
+    """Add ``convention`` to the registry and return it, for use at module scope.
+
+    Lets a deployment that speaks its own dialect register it from its own
+    package instead of patching this file. Re-registering a name is an error
+    unless ``replace=True``, because a silent overwrite would change what an
+    already-written preset resolves to.
+    """
+    if not isinstance(convention, Convention):
+        raise TypeError(f"expected a Convention, got {type(convention).__name__}")
+    existing = CONVENTIONS.get(convention.name)
+    if existing is not None and not replace:
+        raise ValueError(
+            f"convention {convention.name!r} is already registered "
+            f"(image_keys={list(existing.image_keys)}); pass replace=True to override it"
+        )
+    CONVENTIONS[convention.name] = convention
+    return convention

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -4,7 +4,8 @@ This package owns everything policy-related, mirroring how :mod:`apxinf.processo
 owns its own steps and :class:`~apxinf.processors.base.ProcessorStep`. It is split
 into a **stable** outer layer and a **volatile** inner one:
 
-* :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts.
+* :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts,
+  plus :class:`ComposablePolicy`, the opt-in seam a robot adapter wraps.
 * :mod:`~apxinf.policies.registry` — the ``model_type -> policy class`` registry.
 * :mod:`~apxinf.policies.auto` — :class:`AutoPolicy`, dispatch by ``config.json`` type.
 * :mod:`~apxinf.policies.impls` — the concrete per-model policies (``pi05``, ...),
@@ -24,7 +25,7 @@ inside ``from_pretrained`` — so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .auto import AutoPolicy
-from .base import BareModel, Policy
+from .base import BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
@@ -33,6 +34,7 @@ from .impls import Pi05Policy
 __all__ = [
     "Policy",
     "BareModel",
+    "ComposablePolicy",
     "AutoPolicy",
     "register_policy",
     "get_policy",

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -5,7 +5,8 @@ owns its own steps and :class:`~apxinf.processors.base.ProcessorStep`. It is spl
 into a **stable** outer layer and a **volatile** inner one:
 
 * :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts,
-  plus :class:`ComposablePolicy`, the opt-in seam a robot adapter wraps.
+  plus :class:`ComposablePolicy` (the opt-in seam a robot adapter wraps) and
+  :data:`VIEW_SLOTS` (the camera slot names the weights consume, in order).
 * :mod:`~apxinf.policies.registry` — the ``model_type -> policy class`` registry.
 * :mod:`~apxinf.policies.auto` — :class:`AutoPolicy`, dispatch by ``config.json`` type.
 * :mod:`~apxinf.policies.impls` — the concrete per-model policies (``pi05``, ...),
@@ -25,7 +26,7 @@ inside ``from_pretrained`` — so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .auto import AutoPolicy
-from .base import BareModel, ComposablePolicy, Policy
+from .base import VIEW_SLOTS, BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
@@ -35,6 +36,7 @@ __all__ = [
     "Policy",
     "BareModel",
     "ComposablePolicy",
+    "VIEW_SLOTS",
     "AutoPolicy",
     "register_policy",
     "get_policy",

--- a/python/apxinf/apxinf/policies/auto.py
+++ b/python/apxinf/apxinf/policies/auto.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from .base import Policy
 from .registry import available_policies, get_policy
+from ..checkpoints import OPENPI_PYTORCH, CheckpointError, detect_checkpoint
 
 __all__ = ["AutoPolicy"]
 
@@ -55,6 +56,22 @@ class AutoPolicy:
 def _read_model_type(model_dir: Path) -> str:
     config_path = model_dir / "config.json"
     if not config_path.is_file():
+        # An openpi PyTorch export has no config.json at all — its model type
+        # lives in metadata.pt, which is exactly what an openpi_pytorch layout
+        # means. Without this, every such checkpoint had to be served with an
+        # explicit model_type= even though the directory does say what it is.
+        try:
+            layout = detect_checkpoint(model_dir)
+        except CheckpointError as exc:
+            raise FileNotFoundError(
+                f"AutoPolicy: no config.json in {model_dir} and its layout could not "
+                f"be identified ({exc}); pass model_type= explicitly "
+                f"(known: {available_policies()})"
+            ) from exc
+        if layout.format == OPENPI_PYTORCH:
+            # train_config_facts already refused anything that is not pi05
+            # (pi05=False, or a backbone this runtime is not built for).
+            return "pi05"
         raise FileNotFoundError(
             f"AutoPolicy: no config.json in {model_dir}; pass model_type= explicitly "
             f"(known: {available_policies()})"

--- a/python/apxinf/apxinf/policies/base.py
+++ b/python/apxinf/apxinf/policies/base.py
@@ -14,6 +14,9 @@ points other layers code against:
 * :class:`ComposablePolicy` — the narrow extra capability a policy needs before
   an *outer* layer (a robot adapter) can wrap steps around its chain. Optional:
   a policy is a perfectly good :class:`Policy` without it.
+* :data:`VIEW_SLOTS` — the camera slot names a checkpoint's weights consume, in
+  order. Model vocabulary, kept here so a policy and a robot preset can both
+  name a slot without importing each other.
 
 It exists to pin these contracts *now*, before a second model lands, so the
 layout is set for whoever adds one. They intentionally stay tiny: extract richer
@@ -34,7 +37,22 @@ from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, runtime_che
 
 import numpy as np
 
-__all__ = ["Policy", "BareModel", "ComposablePolicy"]
+__all__ = ["Policy", "BareModel", "ComposablePolicy", "VIEW_SLOTS"]
+
+#: Camera view slots, in the order a checkpoint's weights consume them, as named
+#: by openpi's ``model.IMAGE_KEYS``.
+#:
+#: These are **model** vocabulary, not wire keys and not a dataset's convention.
+#: A checkpoint's ``num_views`` says how many of these it was trained on; the
+#: *order* is baked into the weights, and nothing here ever crosses the network.
+#: They live in this module rather than in a robot preset or in ``pi05.py``
+#: because both sides need to agree on them without either importing the other:
+#: a policy uses them to name the cameras it wants when the caller does not, and
+#: a robot preset uses them to say which slot each of its wire keys fills.
+#:
+#: The pi05 family shares this vocabulary. A model with a different camera layout
+#: declares its own rather than stretching this tuple.
+VIEW_SLOTS = ("base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb")
 
 
 @runtime_checkable

--- a/python/apxinf/apxinf/policies/base.py
+++ b/python/apxinf/apxinf/policies/base.py
@@ -11,6 +11,9 @@ points other layers code against:
   ``GrootPolicy``). Downstream consumers (the websocket server, the
   :class:`~apxinf.policies.auto.AutoPolicy` registry, a lerobot adaptor) code
   against this, never a concrete class.
+* :class:`ComposablePolicy` — the narrow extra capability a policy needs before
+  an *outer* layer (a robot adapter) can wrap steps around its chain. Optional:
+  a policy is a perfectly good :class:`Policy` without it.
 
 It exists to pin these contracts *now*, before a second model lands, so the
 layout is set for whoever adds one. They intentionally stay tiny: extract richer
@@ -27,11 +30,11 @@ anything beyond the two guaranteed ones.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Protocol, runtime_checkable
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, runtime_checkable
 
 import numpy as np
 
-__all__ = ["Policy", "BareModel"]
+__all__ = ["Policy", "BareModel", "ComposablePolicy"]
 
 
 @runtime_checkable
@@ -89,4 +92,48 @@ class Policy(Protocol):
 
     def close(self) -> None:
         """Release any underlying model resources."""
+        ...
+
+
+@runtime_checkable
+class ComposablePolicy(Protocol):
+    """A :class:`Policy` an outer layer can wrap without knowing its internals.
+
+    This is the seam between the **robot** layer and the **model** layer. A robot
+    adapter (``apxinf.robots.unitree_g1``) has to run its own steps around the
+    model's — decode the wire state before anything model-specific reads it, turn
+    the model's delta actions into absolute joint targets after unnormalization.
+    That is an *ordering* requirement and nothing more: outside, in both
+    directions, exactly the way openpi's ``data_transforms`` sit outside its
+    ``model_transforms``.
+
+    Without this method the only way to express it is to reach into the concrete
+    policy — import ``Pi05Policy``, address its steps by name
+    (``insert_before("tokenize", ...)``), and rebuild it. That makes every robot
+    adapter depend on one model class and on that class's private step names.
+    :meth:`with_adapter` states the ordering instead, so the robot layer imports
+    no model and the model layer knows about no robot.
+
+    Only this one method is promoted, and only because real code calls it. The
+    rest of the composition surface (``input_pipeline``, ``output_pipeline``,
+    ``model``) stays private to the concrete class until a second model shows
+    what is genuinely shared.
+    """
+
+    def with_adapter(
+        self,
+        *,
+        before: Sequence[Any] = (),
+        after: Sequence[Any] = (),
+        action_dim: Optional[int] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "Policy":
+        """Return a policy running ``before`` ahead of, and ``after`` behind, its own chain.
+
+        Each entry is a ``(name, step)`` pair (a
+        :data:`~apxinf.processors.base.StepSpec`). ``action_dim`` declares the
+        deployable width the wrapped chain now emits, since an appended step may
+        change it; ``metadata`` is merged over the inherited description. The
+        returned policy shares the underlying model handle — do not close both.
+        """
         ...

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -23,13 +23,21 @@ returns the **unnormalized-domain** chunk. The intermediate normalized action is
 also returned (``normalized_actions``) so the layering invariant
 ``L2 minus unnormalize == L1`` can be checked directly.
 
-**State injection (opt-in, off by default):** ``observation/state`` is dropped by
-default so the numerics match today's serving link. Enable it with
-``discrete_state=True``: the raw state is first mapped to ``[-1, 1]`` by a
-``state_normalizer`` (a :class:`~apxinf.processors.Normalizer` over
-``norm_stats["state"]`` by default), then discretized into the prompt — matching
-openpi's "normalize then discretize" order. This path does **not** assume the
-incoming state is already in ``[-1, 1]``.
+**State injection (opt-in, off by default):** state is dropped by default so the
+numerics match today's serving link. Enable it with ``discrete_state=True``: the
+raw state is first mapped to ``[-1, 1]`` by a ``state_normalizer`` (a
+:class:`~apxinf.processors.Normalizer` over ``norm_stats["state"]`` by default),
+then discretized into the prompt — matching openpi's "normalize then discretize"
+order. This path does **not** assume the incoming state is already in ``[-1, 1]``.
+
+**This module names no dataset's wire keys.** ``image_keys`` falls back to the
+model's own :data:`~apxinf.policies.base.VIEW_SLOTS`, and ``state_key`` has no
+fallback at all — it is required exactly when state is read and may stay ``None``
+when state is dropped. ``("observation/image", "observation/wrist_image")`` and
+``"observation/state"`` used to be the defaults here, which is LIBERO's dialect
+applied to every checkpoint: a G1 checkpoint served bare ran LIBERO's contract
+and looked like an accuracy problem. Wire keys belong to
+:mod:`apxinf.conventions`; a robot preset pairs one with a body.
 
 This module registers ``Pi05Policy`` under ``model_type="pi05"`` so
 :class:`~apxinf.policies.auto.AutoPolicy` can dispatch to it.
@@ -77,7 +85,9 @@ from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
 
-_STATE_KEY = "observation/state"
+#: ``prompt`` is openpi's *protocol*-level name for the instruction field — every
+#: dialect on this wire uses it — so unlike the camera and state keys it is not
+#: any one dataset's convention and keeps a default here.
 _PROMPT_KEY = "prompt"
 
 
@@ -93,7 +103,7 @@ class Pi05Policy:
         output_pipeline: Pipeline,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         action_dim: Optional[int] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ):
@@ -115,6 +125,16 @@ class Pi05Policy:
         tokenizer = getattr(tokenize, "tokenizer", None)
         self.discrete_state = bool(getattr(tokenizer, "discrete_state", False))
         state_normalized = getattr(tokenize, "state_normalizer", None) is not None
+        if self.discrete_state and self.state_key is None:
+            # The chain reads state but nothing says from where. Left alone this
+            # would serve a policy whose published state_key is null while its
+            # tokenizer quietly injects nothing — proprioception lost in silence.
+            raise ValueError(
+                "Pi05Policy: this chain discretizes state into the prompt but no "
+                "state_key was given. Name the wire key your client sends (see "
+                "apxinf.conventions, or a robot preset), or build the policy with "
+                "discrete_state=False to drop state deliberately."
+            )
 
         # Kept apart from the derived half so ``with_adapter`` can carry the
         # caller's description forward while the rewired policy recomputes what
@@ -168,7 +188,7 @@ class Pi05Policy:
         noise: Optional[GaussianNoise] = None,
         state_normalizer: Optional[Normalizer] = None,
         image_keys: Optional[Sequence[str]] = None,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
     ) -> Tuple[Pipeline, Pipeline]:
         """Assemble the default ``(input_pipeline, output_pipeline)`` from parts.
 
@@ -182,6 +202,12 @@ class Pi05Policy:
         :data:`~apxinf.policies.base.VIEW_SLOTS`, because this layer has no
         business guessing anyone's wire keys — see :func:`_default_image_keys`.
         A real deployment states them, usually via a robot preset.
+
+        ``state_key`` has no such fallback and none is possible: there is no
+        model-side vocabulary for a state key the way ``VIEW_SLOTS`` is one for
+        cameras. It is therefore required exactly when it is read — i.e. when
+        ``state_normalizer`` / the tokenizer put state into the prompt — and may
+        stay ``None`` when state is dropped, in which case nothing looks it up.
 
         A deployment with *fewer* cameras than the checkpoint declares is served
         by loading with ``num_views=`` (``--num-views`` on the server), which
@@ -248,7 +274,7 @@ class Pi05Policy:
         image_pipeline: Optional[Pipeline] = None,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         num_views: Optional[int] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "Pi05Policy":
@@ -276,7 +302,9 @@ class Pi05Policy:
         validator accepts). State injection is off by default; with
         ``discrete_state=True`` a state normalizer is built from
         ``norm_stats[state_norm_key]`` to map raw state to ``[-1, 1]`` before it is
-        discretized into the prompt.
+        discretized into the prompt, and ``state_key`` becomes **required** —
+        there is no dataset-neutral name to fall back to, and guessing one would
+        drop proprioception silently.
 
         ``num_views`` loads the checkpoint for fewer cameras than it declares, for
         a deployment that has fewer. It must equal ``len(image_keys)``. This drops
@@ -295,6 +323,16 @@ class Pi05Policy:
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
         """
         model_dir = Path(model_dir)
+        if discrete_state and state_key is None:
+            # Caught here rather than deeper in Tokenize so the message can name
+            # the two flags the caller actually passed. discrete_state=True with
+            # no key would inject nothing and publish state_key=null.
+            raise ValueError(
+                "Pi05Policy.from_pretrained: discrete_state=True needs a state_key — "
+                "the wire key your client sends state under (see apxinf.conventions, "
+                "or use a robot preset via build_robot_policy). Pass "
+                "discrete_state=False to drop state instead."
+            )
         if unnormalizer is not None and action_dim is not None and int(action_dim) != unnormalizer.width:
             # Both name the deployable width; an injected map already fixes it, so
             # a disagreeing action_dim would silently lose to the injection.
@@ -389,7 +427,7 @@ class Pi05Policy:
         seed: int = 0,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         warn: bool = True,
     ) -> "Pi05Policy":

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -45,7 +45,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 import numpy as np
 
 from ..._tactics import resolve_pi05_tactics
-from ..base import BareModel
+from ..base import VIEW_SLOTS, BareModel
 from ...processors import (
     GaussianNoise,
     ImageStack,
@@ -77,7 +77,6 @@ from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
 
-_DEFAULT_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
 _STATE_KEY = "observation/state"
 _PROMPT_KEY = "prompt"
 
@@ -92,7 +91,7 @@ class Pi05Policy:
         *,
         input_pipeline: Pipeline,
         output_pipeline: Pipeline,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
         state_key: str = _STATE_KEY,
         action_dim: Optional[int] = None,
@@ -101,7 +100,9 @@ class Pi05Policy:
         self.model = model
         self.input_pipeline = input_pipeline
         self.output_pipeline = output_pipeline
-        self.image_keys = tuple(image_keys)
+        self.image_keys = tuple(
+            image_keys if image_keys is not None else _default_image_keys(model.num_views)
+        )
         self.prompt_key = prompt_key
         self.state_key = state_key
         self.action_dim_out = (
@@ -166,7 +167,7 @@ class Pi05Policy:
         image_pipeline: Optional[Pipeline] = None,
         noise: Optional[GaussianNoise] = None,
         state_normalizer: Optional[Normalizer] = None,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         state_key: str = _STATE_KEY,
     ) -> Tuple[Pipeline, Pipeline]:
         """Assemble the default ``(input_pipeline, output_pipeline)`` from parts.
@@ -177,12 +178,19 @@ class Pi05Policy:
         fewer. Absent cameras are never sent, so there is no padding: the model
         runs the real view shape directly.
 
+        Omitting ``image_keys`` names the cameras after the model's own
+        :data:`~apxinf.policies.base.VIEW_SLOTS`, because this layer has no
+        business guessing anyone's wire keys — see :func:`_default_image_keys`.
+        A real deployment states them, usually via a robot preset.
+
         A deployment with *fewer* cameras than the checkpoint declares is served
         by loading with ``num_views=`` (``--num-views`` on the server), which
         drops the trailing view slots at load time rather than zero-filling them
         per request.
         """
-        image_keys = tuple(image_keys)
+        image_keys = tuple(
+            image_keys if image_keys is not None else _default_image_keys(model.num_views)
+        )
         if len(image_keys) != model.num_views:
             fix = (
                 f"load with num_views={len(image_keys)} to serve fewer cameras "
@@ -238,7 +246,7 @@ class Pi05Policy:
         discrete_state: bool = False,
         state_norm_key: str = "state",
         image_pipeline: Optional[Pipeline] = None,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
         state_key: str = _STATE_KEY,
         num_views: Optional[int] = None,
@@ -418,7 +426,9 @@ class Pi05Policy:
             reset_sampling(int(seed))
 
         if image_keys is None:
-            image_keys = _synthetic_image_keys(model.num_views)
+            # Resolved here rather than left to the two consumers below, so the
+            # published metadata and the ImageStack step cannot drift apart.
+            image_keys = _default_image_keys(model.num_views)
 
         input_pipeline, output_pipeline = cls.default_pipelines(
             model,
@@ -625,18 +635,26 @@ class Pi05Policy:
         )
 
 
-def _synthetic_image_keys(num_views: int) -> Tuple[str, ...]:
-    """Generate exactly ``num_views`` camera keys for a checkpoint-free policy.
+def _default_image_keys(num_views: int) -> Tuple[str, ...]:
+    """Name exactly ``num_views`` cameras when the caller names none.
 
-    Reuses the default ``image``/``wrist_image`` names for the first two views and
-    appends ``image_2``, ``image_3``, ... beyond that, so ``default_pipelines``'
+    Returns the model's own :data:`~apxinf.policies.base.VIEW_SLOTS` vocabulary,
+    truncated to the loaded view count, so the fallback describes the *model*
+    rather than some dataset. That is the whole point of not having a default
+    here: ``("observation/image", "observation/wrist_image")`` used to be it, and
+    those are LIBERO's wire keys — as *the* default they silently applied to
+    every checkpoint, so a G1 checkpoint served bare ran LIBERO's contract and
+    looked like an accuracy problem. Slot names cannot masquerade as anyone's
+    wire keys: a client sending LIBERO keys against this fallback gets a
+    ``KeyError`` naming both sides, which is the loud failure we want.
+
+    Beyond the declared slots the names continue as ``view_3_rgb``, ... so the
     ``len(image_keys) == model.num_views`` contract holds for any view count.
     """
-    base = list(_DEFAULT_IMAGE_KEYS)
-    if num_views <= len(base):
-        return tuple(base[:num_views])
-    extra = [f"observation/image_{i}" for i in range(len(base), num_views)]
-    return tuple(base + extra)
+    if num_views <= len(VIEW_SLOTS):
+        return tuple(VIEW_SLOTS[:num_views])
+    extra = [f"view_{index}_rgb" for index in range(len(VIEW_SLOTS), num_views)]
+    return tuple(VIEW_SLOTS) + tuple(extra)
 
 
 def _resolve_tokenizer(model_dir: Path, tokenizer_path) -> Path:

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -12,7 +12,11 @@ between its input and output transforms.
 This makes the whole pre/post chain reorderable, insertable, and replaceable
 through the ordinary ``Pipeline`` machinery — a custom high-performance resize or
 tokenizer drops in with ``input_pipeline.replace(...)`` / ``insert_after(...)``
-without forking the framework.
+without forking the framework. Those verbs address steps *by name*, so they are
+for callers who know this chain. A caller who only needs to run steps **around**
+it — a robot adapter — uses :meth:`Pi05Policy.with_adapter`
+(:class:`~apxinf.policies.base.ComposablePolicy`) instead and stays ignorant of
+what the chain contains.
 
 Domain contract: the model returns a **normalized-domain** action; this policy
 returns the **unnormalized-domain** chunk. The intermediate normalized action is
@@ -56,6 +60,7 @@ from ...processors import (
     Trim,
     Unnormalizer,
 )
+from ...processors.base import StepSpec
 from ...processors.transforms import (
     ACTIONS,
     NOISE,
@@ -110,7 +115,30 @@ class Pi05Policy:
         self.discrete_state = bool(getattr(tokenizer, "discrete_state", False))
         state_normalized = getattr(tokenize, "state_normalizer", None) is not None
 
+        # Kept apart from the derived half so ``with_adapter`` can carry the
+        # caller's description forward while the rewired policy recomputes what
+        # it actually serves.
+        self._extra_metadata = dict(metadata) if metadata else {}
         self.metadata = {
+            **self._derived_metadata(model, input_pipeline, output_pipeline, state_normalized),
+            **self._extra_metadata,
+        }
+
+    def _derived_metadata(
+        self,
+        model: BareModel,
+        input_pipeline: Pipeline,
+        output_pipeline: Pipeline,
+        state_normalized: bool,
+    ) -> dict:
+        """The part of ``metadata`` this policy computes from its own wiring.
+
+        Split out because :meth:`with_adapter` inherits the caller-supplied half
+        of ``metadata`` but must let the rewired policy recompute this half —
+        carrying the old ``action_dim`` or pipeline names forward would publish a
+        wire contract the new policy does not serve.
+        """
+        return {
             "model_type": "pi05",
             "action_horizon": model.action_horizon,
             "action_dim": self.action_dim_out,
@@ -124,7 +152,6 @@ class Pi05Policy:
             "state_normalized": state_normalized,
             "input_pipeline": input_pipeline.names,
             "output_pipeline": output_pipeline.names,
-            **(dict(metadata) if metadata else {}),
         }
 
     # --- construction ------------------------------------------------------
@@ -204,6 +231,7 @@ class Pi05Policy:
         tactics=None,
         tokenizer_path=None,
         norm_key: str = "actions",
+        unnormalizer: Optional[Unnormalizer] = None,
         action_dim: Optional[int] = None,
         action_horizon: Optional[int] = None,
         seed: int = 0,
@@ -227,7 +255,13 @@ class Pi05Policy:
         ``state_norm_key``) — only this method knows ``model_dir``.
 
         ``action_dim`` trims the unnormalizer to the task's action width (e.g. 7
-        for LIBERO); ``None`` keeps the full vector. ``action_horizon`` overrides
+        for LIBERO); ``None`` keeps the full vector. ``unnormalizer`` supplies the
+        quantile map directly instead of reading ``norm_stats`` from disk — for a
+        shape/plumbing run on a stand-in checkpoint whose statistics belong to a
+        different robot (pass a full-width identity), where reading the file would
+        silently apply the wrong scale. It is mutually exclusive with
+        ``action_dim``, since an injected map already fixes the width.
+        ``action_horizon`` overrides
         the checkpoint's chunk length: ``None`` runs the native ``config.json``
         value, an explicit value outranks it (the horizon is a sequence length,
         not a weight dimension, so the same weights run at any horizon the config
@@ -253,6 +287,14 @@ class Pi05Policy:
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
         """
         model_dir = Path(model_dir)
+        if unnormalizer is not None and action_dim is not None and int(action_dim) != unnormalizer.width:
+            # Both name the deployable width; an injected map already fixes it, so
+            # a disagreeing action_dim would silently lose to the injection.
+            raise ValueError(
+                f"Pi05Policy.from_pretrained: action_dim={action_dim} conflicts with the "
+                f"supplied unnormalizer's width {unnormalizer.width}; the injected map "
+                "already sets the deployable width, so pass only one"
+            )
         if model is None:
             import apxinf_py  # lazy: processor-only users never import the binding
 
@@ -296,7 +338,11 @@ class Pi05Policy:
             max_token_len=model.max_token_len if hasattr(model, "max_token_len") else 200,
             discrete_state=discrete_state,
         )
-        unnormalizer = Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+        unnormalizer = (
+            unnormalizer
+            if unnormalizer is not None
+            else Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+        )
         state_normalizer = (
             Normalizer.from_norm_stats(model_dir, key=state_norm_key) if discrete_state else None
         )
@@ -389,6 +435,48 @@ class Pi05Policy:
             state_key=state_key,
             action_dim=width,
             metadata={"weights": "synthetic", **(dict(metadata) if metadata else {})},
+        )
+
+    # --- composition -------------------------------------------------------
+
+    def with_adapter(
+        self,
+        *,
+        before: Sequence[StepSpec] = (),
+        after: Sequence[StepSpec] = (),
+        action_dim: Optional[int] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "Pi05Policy":
+        """Return a copy running ``before`` ahead of, and ``after`` behind, this chain.
+
+        Implements :class:`~apxinf.policies.base.ComposablePolicy`. This is how a
+        robot adapter wires its body-specific steps without importing this class
+        or naming any step inside it: ``before`` lands ahead of ``image_stack``
+        (so it sees the raw client observation and can rewrite it before anything
+        model-specific reads it) and ``after`` lands behind ``unnormalize`` (so it
+        sees deployable-domain actions). That nesting is openpi's
+        ``data_transforms`` outside ``model_transforms``, and it is the whole of
+        what a robot needs from a model.
+
+        ``after`` steps receive the post-input observation alongside the actions
+        (see :meth:`infer`), so a delta→absolute step reads the same decoded
+        state the ``before`` steps produced.
+
+        ``action_dim`` declares the deployable width the appended steps leave
+        behind — pass it whenever ``after`` changes the width, since the derived
+        value would otherwise report this policy's pre-adapter width. The model
+        handle is **shared**, not reloaded: this is a rewiring, not a second load,
+        so only one of the two policies should be ``close()``d.
+        """
+        return type(self)(
+            self.model,
+            input_pipeline=self.input_pipeline.prepend(*before),
+            output_pipeline=self.output_pipeline.append(*after),
+            image_keys=self.image_keys,
+            prompt_key=self.prompt_key,
+            state_key=self.state_key,
+            action_dim=self.action_dim_out if action_dim is None else int(action_dim),
+            metadata={**self._extra_metadata, **(dict(metadata) if metadata else {})},
         )
 
     # --- inference ---------------------------------------------------------

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -45,6 +45,7 @@ This module registers ``Pi05Policy`` under ``model_type="pi05"`` so
 
 from __future__ import annotations
 
+import logging
 import time
 import warnings
 from pathlib import Path
@@ -53,6 +54,13 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 import numpy as np
 
 from ..._tactics import resolve_pi05_tactics
+from ...checkpoints import (
+    CheckpointError,
+    detect_checkpoint,
+    has_layout_metadata,
+    require_norm_stats,
+    resolve_tokenizer,
+)
 from ..base import VIEW_SLOTS, BareModel
 from ...processors import (
     GaussianNoise,
@@ -84,6 +92,8 @@ from ...processors.transforms import (
 from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
+
+_LOGGER = logging.getLogger("apxinf.policies.pi05")
 
 #: ``prompt`` is openpi's *protocol*-level name for the instruction field — every
 #: dialect on this wire uses it — so unlike the camera and state keys it is not
@@ -277,6 +287,9 @@ class Pi05Policy:
         prompt_key: str = _PROMPT_KEY,
         state_key: Optional[str] = None,
         num_views: Optional[int] = None,
+        checkpoint_format: Optional[str] = None,
+        asset_id: Optional[str] = None,
+        norm_stats=None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "Pi05Policy":
         """Build the **default** policy from a checkpoint directory.
@@ -329,6 +342,19 @@ class Pi05Policy:
         A checkpoint-local ``tactics.json`` takes precedence over source-tree
         defaults, so normal Python and serving callers share the same routing.
 
+        ``checkpoint_format`` / ``asset_id`` / ``norm_stats`` control how the
+        directory is read (see :mod:`apxinf.checkpoints`). By default the layout
+        is detected: an openpi PyTorch export declares its architecture in
+        ``metadata.pt`` and keeps its statistics under
+        ``assets/<asset_id>/norm_stats.json``, and both are picked up without any
+        flag. ``checkpoint_format`` pins the answer instead of sniffing it,
+        ``asset_id`` overrides the one the checkpoint names (for assets moved
+        after export), and ``norm_stats`` is an explicit path that outranks every
+        convention. The first two make detection strict — an unreadable layout
+        raises rather than falling back — because both assert that the directory
+        *has* a layout. ``norm_stats`` does not: it names a single file, so it
+        also works on a flat directory that declares nothing about itself.
+
         For a **fully custom** pre/post chain, do not funnel it through here:
         build the parts yourself and use :meth:`default_pipelines` +
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
@@ -352,6 +378,27 @@ class Pi05Policy:
                 f"supplied unnormalizer's width {unnormalizer.width}; the injected map "
                 "already sets the deployable width, so pass only one"
             )
+
+        # Read the directory's own account of itself before touching a weight.
+        # A hand-assembled flat directory (model.safetensors + norm_stats.json,
+        # nothing that says what it is) predates this layer and still loads:
+        # detection has nothing to work with there, so it is skipped rather than
+        # turned into a hard failure. Naming a format or an asset_id does assert
+        # a real layout, so detection runs and its errors propagate. ``norm_stats``
+        # deliberately does not: it names one file, not a directory shape, and it
+        # is exactly what a flat directory needs when its statistics live
+        # elsewhere.
+        layout = None
+        if checkpoint_format or asset_id or has_layout_metadata(model_dir):
+            layout = detect_checkpoint(
+                model_dir,
+                checkpoint_format=checkpoint_format,
+                asset_id=asset_id,
+                norm_stats=norm_stats,
+            )
+            for note in layout.notes:
+                _LOGGER.info("checkpoint %s: %s", model_dir, note)
+
         if model is None:
             import apxinf_py  # lazy: processor-only users never import the binding
 
@@ -362,6 +409,7 @@ class Pi05Policy:
                 model_dir=model_dir,
                 override=Path(tactics) if tactics is not None else None,
             )
+            config_json = layout.config_json_text() if layout is not None else None
             model = apxinf_py.Model.load(
                 model_name,
                 ckpt,
@@ -369,6 +417,10 @@ class Pi05Policy:
                 precision=precision,
                 **({"calibration": str(calibration)} if calibration else {}),
                 **({"tactics": str(tactics)} if tactics else {}),
+                # An openpi export has no config.json, so without this the Rust
+                # loader silently ran Pi05Config::default(). The constants come
+                # from the checkpoint's own metadata.pt.
+                **({"config_json": config_json} if config_json else {}),
                 **({"action_horizon": int(action_horizon)} if action_horizon else {}),
                 **({"num_views": int(num_views)} if num_views is not None else {}),
                 sampling_seed=int(seed),
@@ -395,15 +447,33 @@ class Pi05Policy:
             max_token_len=model.max_token_len if hasattr(model, "max_token_len") else 200,
             discrete_state=discrete_state,
         )
+        # Resolved once, and only when a file is actually read: an injected
+        # unnormalizer with state dropped is a deliberate no-statistics path, and
+        # demanding the file there would break a stand-in checkpoint run. An
+        # explicit path still works with no layout at all, which is the flat
+        # directory whose statistics were handed over separately.
+        needs_stats = unnormalizer is None or discrete_state
+        if not needs_stats:
+            stats_path = None
+        elif layout is not None:
+            stats_path = require_norm_stats(layout)
+        elif norm_stats is not None:
+            stats_path = Path(norm_stats)
+            if not stats_path.is_file():
+                raise CheckpointError(f"norm_stats path {stats_path} does not exist")
+        else:
+            stats_path = None
         unnormalizer = (
             unnormalizer
             if unnormalizer is not None
             else Unnormalizer.from_norm_stats(
-                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype
+                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype, path=stats_path
             )
         )
         state_normalizer = (
-            Normalizer.from_norm_stats(model_dir, key=state_norm_key, dtype=norm_dtype)
+            Normalizer.from_norm_stats(
+                model_dir, key=state_norm_key, dtype=norm_dtype, path=stats_path
+            )
             if discrete_state
             else None
         )
@@ -711,11 +781,11 @@ def _default_image_keys(num_views: int) -> Tuple[str, ...]:
 
 
 def _resolve_tokenizer(model_dir: Path, tokenizer_path) -> Path:
-    if tokenizer_path is not None:
-        return Path(tokenizer_path)
-    candidates = (model_dir / "tokenizer.model", model_dir / "paligemma_tokenizer.model")
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    rendered = ", ".join(str(path) for path in candidates)
-    raise FileNotFoundError(f"no SentencePiece tokenizer found under {model_dir}; checked {rendered}")
+    """Locate the SentencePiece model: explicit path, ``APXINF_TOKENIZER``, then the dir.
+
+    Delegates to :func:`apxinf.checkpoints.resolve_tokenizer` so the "where do I
+    get this file" message is written once. No pi05 checkpoint ships a tokenizer
+    — openpi downloads it from GCS and LeRobot from a gated HF repo — so the
+    error has to name both sources, and apxinf downloads neither.
+    """
+    return resolve_tokenizer(model_dir, tokenizer_path)

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -271,6 +271,7 @@ class Pi05Policy:
         seed: int = 0,
         discrete_state: bool = False,
         state_norm_key: str = "state",
+        norm_dtype: Optional[str] = None,
         image_pipeline: Optional[Pipeline] = None,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
@@ -305,6 +306,16 @@ class Pi05Policy:
         discretized into the prompt, and ``state_key`` becomes **required** —
         there is no dataset-neutral name to fall back to, and guessing one would
         drop proprioception silently.
+
+        ``norm_dtype`` pins the dtype both normalizers compute in; the default
+        follows the input, so a float32 observation is normalized in float32.
+        ``"float64"`` reproduces openpi, which parses ``norm_stats.json`` into
+        float64 and never demotes it. The difference is ~1e-7 either way and is
+        invisible on the output side, but on the input side normalization feeds
+        the state discretizer, whose bins are 1/128 apart: an element near a bin
+        edge crosses it, and the prompt — hence the entire rollout — changes.
+        A checkpoint whose statistics came from openpi wants ``"float64"``; the
+        preset table sets it per embodiment.
 
         ``num_views`` loads the checkpoint for fewer cameras than it declares, for
         a deployment that has fewer. It must equal ``len(image_keys)``. This drops
@@ -387,10 +398,14 @@ class Pi05Policy:
         unnormalizer = (
             unnormalizer
             if unnormalizer is not None
-            else Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+            else Unnormalizer.from_norm_stats(
+                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype
+            )
         )
         state_normalizer = (
-            Normalizer.from_norm_stats(model_dir, key=state_norm_key) if discrete_state else None
+            Normalizer.from_norm_stats(model_dir, key=state_norm_key, dtype=norm_dtype)
+            if discrete_state
+            else None
         )
         reset_sampling = getattr(model, "reset_sampling", None)
         if callable(reset_sampling):

--- a/python/apxinf/apxinf/processors/base.py
+++ b/python/apxinf/apxinf/processors/base.py
@@ -12,7 +12,10 @@ Design (mirrors the PRD's "narrow interface, thick module" goal):
   loaded SentencePiece model) is shared by shallow copy, not rebuilt.
 * :class:`Pipeline` chains named steps left-to-right, threading one value
   through, and supports whole-step replacement and per-step parameter override
-  while leaving the other steps untouched.
+  while leaving the other steps untouched. It also composes: ``prepend`` /
+  ``append`` wrap a chain from outside without naming anything inside it, which
+  is how one layer (a robot adapter) wraps another's chain (a model's pre/post
+  steps) without depending on its internals.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ import abc
 import copy
 from typing import Any, Iterable, Sequence, Tuple, Union
 
-__all__ = ["ProcessorStep", "Pipeline"]
+__all__ = ["ProcessorStep", "Pipeline", "StepSpec"]
 
 
 class ProcessorStep(abc.ABC):
@@ -136,6 +139,31 @@ class Pipeline:
             if step_name == name:
                 return i
         raise KeyError(f"Pipeline has no step named {name!r}; have {self.names}")
+
+    # --- composition: wrap a chain without knowing its steps -----------------
+    #
+    # ``prepend``/``append`` are the only editing verbs that do not name an
+    # existing step. That distinction is load-bearing: an *outer* layer (a robot
+    # adapter wrapping a model's pre/post chain) has an **ordering** requirement
+    # — "run before everything the model does" — not a *naming* one. Expressed
+    # with ``insert_before("tokenize", ...)`` it would have to know that the
+    # chain contains a step called ``tokenize``, which is the model's private
+    # business and changes when the model does. These two verbs let the outer
+    # layer state the ordering directly and stay ignorant of the inner names.
+
+    def prepend(self, *specs: StepSpec) -> "Pipeline":
+        """Return a new pipeline running ``specs``, in order, before every current step.
+
+        Names must not collide with the existing ones (``Pipeline.__init__``
+        rejects duplicates), so a wrapper cannot silently shadow an inner step.
+        """
+        return Pipeline([self._normalize(spec) for spec in specs] + list(self._steps))
+
+    def append(self, *specs: StepSpec) -> "Pipeline":
+        """Return a new pipeline running ``specs``, in order, after every current step."""
+        return Pipeline(list(self._steps) + [self._normalize(spec) for spec in specs])
+
+    # --- editing: address one existing step by name --------------------------
 
     def replace(self, name: str, step: ProcessorStep) -> "Pipeline":
         """Return a new pipeline with the whole step ``name`` swapped out."""

--- a/python/apxinf/apxinf/processors/normalize.py
+++ b/python/apxinf/apxinf/processors/normalize.py
@@ -36,15 +36,26 @@ _QUANTILE = "quantile"
 _MEAN_STD = "mean_std"
 
 
-def load_norm_stats(model_dir, key: str = "actions") -> dict:
+def load_norm_stats(model_dir=None, key: str = "actions", *, path=None) -> dict:
     """Return the raw stats dict for ``key`` (e.g. ``"actions"``/``"state"``).
 
     Handles both the nested ``{"norm_stats": {...}}`` and flat top-level layouts.
+
+    ``path`` names the file directly and is what callers should pass: an openpi
+    PyTorch export keeps its statistics at ``assets/<asset_id>/norm_stats.json``,
+    not in the checkpoint root, so :func:`apxinf.checkpoints.detect_checkpoint`
+    resolves the path and hands it over here. ``model_dir`` remains for the flat
+    layout — it just means ``<model_dir>/norm_stats.json``.
     """
-    document = json.loads((Path(model_dir) / "norm_stats.json").read_text())
+    if path is None:
+        if model_dir is None:
+            raise TypeError("load_norm_stats needs either model_dir or path")
+        path = Path(model_dir) / "norm_stats.json"
+    path = Path(path)
+    document = json.loads(path.read_text())
     stats = document.get("norm_stats", document)
     if key not in stats:
-        raise KeyError(f"norm_stats.json has no entry {key!r}; keys: {sorted(stats)}")
+        raise KeyError(f"{path} has no entry {key!r}; keys: {sorted(stats)}")
     return stats[key]
 
 
@@ -185,8 +196,8 @@ def _finite(array: np.ndarray, who: str) -> np.ndarray:
     return array
 
 
-def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype):
-    stats = load_norm_stats(model_dir, key)
+def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path=None):
+    stats = load_norm_stats(model_dir, key, path=path)
     if mode == _QUANTILE:
         return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps, dtype=dtype)
     return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps, dtype=dtype)
@@ -212,8 +223,9 @@ class Unnormalizer(ProcessorStep):
         self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
+    def from_norm_stats(cls, model_dir=None, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None, *, path=None):
+        """Build from a ``norm_stats.json``; ``path`` names the file directly."""
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path)
 
     @property
     def width(self) -> int:
@@ -250,8 +262,9 @@ class Normalizer(ProcessorStep):
         self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
+    def from_norm_stats(cls, model_dir=None, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None, *, path=None):
+        """Build from a ``norm_stats.json``; ``path`` names the file directly."""
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path)
 
     @property
     def width(self) -> int:

--- a/python/apxinf/apxinf/processors/normalize.py
+++ b/python/apxinf/apxinf/processors/normalize.py
@@ -12,6 +12,11 @@ lerobot's ``Normalizer``:
 Both steps broadcast over the trailing axis, so a ``[horizon, dim]`` action
 chunk unnormalizes in one call. :meth:`from_norm_stats` reads the quantiles /
 moments straight out of a checkpoint's ``norm_stats.json``.
+
+Widths follow OpenPI's asymmetry: :class:`Unnormalizer` accepts an array *wider*
+than its stats and passes the extra tail through unchanged (a checkpoint's stats
+are the robot's width, the model emits its padded width), while
+:class:`Normalizer` requires an exact match.
 """
 
 from __future__ import annotations
@@ -44,7 +49,10 @@ def load_norm_stats(model_dir, key: str = "actions") -> dict:
 
 
 def _as_vector(values: Sequence[float], name: str, dims: Optional[int]) -> np.ndarray:
-    vector = np.asarray(values, dtype=np.float32)
+    # Kept at float64 (the dtype norm_stats.json parses to). The compute dtype is
+    # decided per call in :meth:`_AffineStats._check`, which downcasts these to
+    # float32 for float32 inputs -- bit-identical to storing them as float32.
+    vector = np.asarray(values, dtype=np.float64)
     if vector.ndim != 1:
         raise ValueError(f"{name} must be rank 1, got shape {vector.shape}")
     if dims is not None:
@@ -57,12 +65,15 @@ def _as_vector(values: Sequence[float], name: str, dims: Optional[int]) -> np.nd
 class _AffineStats:
     """Shared statistics + the two-mode affine math for (un)normalization."""
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
         if mode not in (_QUANTILE, _MEAN_STD):
             raise ValueError(f"mode must be {_QUANTILE!r} or {_MEAN_STD!r}, got {mode!r}")
         self.mode = mode
         self.dims = None if dims is None else int(dims)
         self.eps = float(eps)
+        self.dtype = None if dtype is None else np.dtype(dtype)
+        # dtype -> (q01, q99, mean, std) downcast to that dtype; see _stats_as.
+        self._cast_cache: dict = {}
         if mode == _QUANTILE:
             if q01 is None or q99 is None:
                 raise ValueError("quantile mode requires q01 and q99")
@@ -86,31 +97,86 @@ class _AffineStats:
     def width(self) -> int:
         return (self.q01 if self.mode == _QUANTILE else self.mean).size
 
-    def _check(self, array: np.ndarray, who: str) -> np.ndarray:
-        array = np.asarray(array, dtype=np.float32)
-        if array.shape[-1] != self.width:
+    def _check(self, array: np.ndarray, who: str, *, allow_wider: bool = False) -> tuple:
+        """Coerce ``array`` and the stats to a common compute dtype, checking width.
+
+        The default dtype is ``result_type(array, float32)``: float32 in stays
+        float32 (bit-identical to the previous float32-only implementation,
+        because the stats are downcast *before* the arithmetic), while float64 in
+        stays float64. That matters for the pi05 prompt path -- openpi's numpy
+        input chain runs in float64, so a float32 state would discretize to a
+        different bin whenever a normalized value lands within ~1e-7 of a bin
+        edge. An explicit ``dtype=`` pins the compute dtype regardless of the
+        input, which is how a caller reproduces openpi's *output* chain: there
+        the stats stay float64 (they are parsed from JSON and never downcast), so
+        a float32 action array is promoted rather than the stats demoted.
+
+        ``allow_wider`` mirrors openpi's asymmetry: its ``Unnormalize`` widens
+        narrow stats by passing the tail through, its ``Normalize`` does not (a
+        wider array there is a broadcast error). See :meth:`unnormalize`.
+        """
+        array = np.asarray(array)
+        dtype = self.dtype if self.dtype is not None else np.result_type(array.dtype, np.float32)
+        array = array.astype(dtype, copy=False)
+        got = array.shape[-1]
+        if got < self.width or (got != self.width and not allow_wider):
             raise ValueError(
                 f"{who}: last dim must be {self.width}, got array shape {array.shape}"
             )
-        return array
+        return array, dtype
+
+    def _stats_as(self, dtype):
+        cached = self._cast_cache.get(dtype)
+        if cached is None:
+            cached = tuple(
+                None if v is None else v.astype(dtype, copy=False)
+                for v in (self.q01, self.q99, self.mean, self.std)
+            )
+            self._cast_cache[dtype] = cached
+        return cached
 
     def unnormalize(self, array: np.ndarray) -> np.ndarray:
-        array = self._check(array, "Unnormalizer")
+        """Map back to physical units, **passing a wider array's tail through**.
+
+        A checkpoint's ``norm_stats`` is computed from the dataset, so it is the
+        *robot's* width (16 for a Unitree G1) while the model emits its padded
+        width (32). openpi's ``Unnormalize._unnormalize_quantile`` handles that by
+        unnormalizing the head and concatenating ``x[..., dim:]`` verbatim; the
+        padded tail is unused downstream, so the passthrough exists to keep the
+        chain running rather than to produce meaningful numbers. Without it the
+        G1 path cannot serve a real 16-wide ``norm_stats.json`` at all.
+        """
+        array, dtype = self._check(array, "Unnormalizer", allow_wider=True)
+        head, tail = array[..., : self.width], array[..., self.width :]
+        q01, q99, mean, std = self._stats_as(dtype)
+        scalar = dtype.type
         if self.mode == _QUANTILE:
-            span = (self.q99 - self.q01 + np.float32(self.eps)) / np.float32(2.0)
-            out = (array + np.float32(1.0)) * span + self.q01
+            span = (q99 - q01 + scalar(self.eps)) / scalar(2.0)
+            out = (head + scalar(1.0)) * span + q01
         else:
-            out = array * self.std + self.mean
-        return _finite(out.astype(np.float32, copy=False), "Unnormalizer")
+            out = head * std + mean
+        if tail.shape[-1]:
+            out = np.concatenate([out, tail], axis=-1)
+        return _finite(out.astype(dtype, copy=False), "Unnormalizer")
 
     def normalize(self, array: np.ndarray) -> np.ndarray:
-        array = self._check(array, "Normalizer")
+        """Map to the normalized domain. Width must match exactly.
+
+        No tail passthrough here, matching openpi: its ``Normalize`` slices the
+        stats to the array width, which broadcast-fails on an array *wider* than
+        the stats. The input chain never hits that case anyway --
+        ``PadStatesAndActions`` runs after ``Normalize``, so state is still the
+        robot's width when it is normalized.
+        """
+        array, dtype = self._check(array, "Normalizer")
+        q01, q99, mean, std = self._stats_as(dtype)
+        scalar = dtype.type
         if self.mode == _QUANTILE:
-            span = self.q99 - self.q01 + np.float32(self.eps)
-            out = np.float32(2.0) * (array - self.q01) / span - np.float32(1.0)
+            span = q99 - q01 + scalar(self.eps)
+            out = scalar(2.0) * (array - q01) / span - scalar(1.0)
         else:
-            out = (array - self.mean) / self.std
-        return _finite(out.astype(np.float32, copy=False), "Normalizer")
+            out = (array - mean) / std
+        return _finite(out.astype(dtype, copy=False), "Normalizer")
 
 
 def _finite(array: np.ndarray, who: str) -> np.ndarray:
@@ -119,25 +185,35 @@ def _finite(array: np.ndarray, who: str) -> np.ndarray:
     return array
 
 
-def _from_norm_stats(cls, model_dir, key, mode, dims, eps):
+def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype):
     stats = load_norm_stats(model_dir, key)
     if mode == _QUANTILE:
-        return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps)
-    return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps)
+        return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps, dtype=dtype)
+    return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps, dtype=dtype)
 
 
 class Unnormalizer(ProcessorStep):
-    """Map a normalized-domain array back to physical units (last axis)."""
+    """Map a normalized-domain array back to physical units (last axis).
 
-    PARAMS = ("eps",)
+    An array wider than :attr:`width` keeps its tail unchanged, mirroring
+    OpenPI — see :meth:`_AffineStats.unnormalize`. A narrower one is an error.
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
-        self._stats = _AffineStats(q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps)
+    ``dtype`` pins the compute dtype; the default follows the input (see
+    :meth:`_AffineStats._check`).
+    """
+
+    PARAMS = ("eps", "dtype")
+
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
+        self._stats = _AffineStats(
+            q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps, dtype=dtype
+        )
         self.eps = self._stats.eps
+        self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps)
+    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
 
     @property
     def width(self) -> int:
@@ -149,23 +225,33 @@ class Unnormalizer(ProcessorStep):
     def _apply_overrides(self, overrides: dict) -> None:
         super()._apply_overrides(overrides)
         # ``with_overrides`` shallow-copied us, so ``_stats`` is still shared with
-        # the original; copy it before tweaking eps to avoid mutating the source.
+        # the original; copy it before tweaking the knobs to avoid mutating the
+        # source. ``_cast_cache`` is keyed by dtype, so sharing it stays correct.
         self._stats = copy.copy(self._stats)
         self._stats.eps = self.eps
+        self.dtype = None if self.dtype is None else np.dtype(self.dtype)
+        self._stats.dtype = self.dtype
 
 
 class Normalizer(ProcessorStep):
-    """Map a physical-units array to the normalized domain (last axis)."""
+    """Map a physical-units array to the normalized domain (last axis).
 
-    PARAMS = ("eps",)
+    ``dtype`` pins the compute dtype; the default follows the input (see
+    :meth:`_AffineStats._check`).
+    """
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
-        self._stats = _AffineStats(q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps)
+    PARAMS = ("eps", "dtype")
+
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
+        self._stats = _AffineStats(
+            q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps, dtype=dtype
+        )
         self.eps = self._stats.eps
+        self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps)
+    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
 
     @property
     def width(self) -> int:
@@ -178,3 +264,5 @@ class Normalizer(ProcessorStep):
         super()._apply_overrides(overrides)
         self._stats = copy.copy(self._stats)
         self._stats.eps = self.eps
+        self.dtype = None if self.dtype is None else np.dtype(self.dtype)
+        self._stats.dtype = self.dtype

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -20,7 +20,13 @@ camera rename + CHW->HWC       ``image_keys`` config + ``ParseImage`` (already
 ===========================  ==============================================
 
 These steps are model-agnostic — they reference no policy symbols and vary only
-with the G1 body. The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
+with the G1 body. They are also **dataset-agnostic**: the G1 client's wire keys
+(``images/cam_high``, a flat ``state``) are a recording convention, so they live
+in :mod:`apxinf.conventions` and reach these steps as arguments. What is left
+here is arithmetic that changes only if the hardware does — the 16-DoF layout,
+the delta mask, the gripper and joint-sign conventions.
+
+The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
 adapter wraps them around whichever policy the checkpoint turns out to be, using
 :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter`; it names no model
 class either.
@@ -46,22 +52,9 @@ __all__ = [
     "UnitreeG1DecodeState",
     "UnitreeG1AbsoluteActions",
     "UnitreeG1EncodeActions",
-    "G1_CAMERAS",
-    "G1_STATE_KEY",
     "G1_ROBOT_DIM",
     "G1_DELTA_MASK",
 ]
-
-#: G1 camera **wire keys**, ordered base / left-wrist / right-wrist to match the
-#: model's view slots (openpi ``base_0_rgb`` / ``left_wrist_0_rgb`` /
-#: ``right_wrist_0_rgb``). These are the keys an unmodified openpi G1 client
-#: sends, i.e. the nested ``obs["images"]["cam_high"]`` layout, spelled as a path
-#: for :func:`~apxinf.processors.transforms.lookup_key`.
-G1_CAMERAS = ("images/cam_high", "images/cam_left_wrist", "images/cam_right_wrist")
-
-#: G1 state wire key. openpi's G1 client sends a flat top-level ``"state"``, not
-#: LIBERO's ``"observation/state"``.
-G1_STATE_KEY = "state"
 
 #: G1 state/action layout: [L-arm 7, L-gripper 1, R-arm 7, R-gripper 1].
 G1_ROBOT_DIM = 16
@@ -111,9 +104,14 @@ class UnitreeG1DecodeState(ProcessorStep):
     and the delta->absolute output step both see the decoded state. Operates on a
     shallow copy of the observation so the caller's dict is left untouched. A
     no-op when no state is present (state-off serving).
+
+    ``state_key`` is required and has no default: which key carries state is a
+    property of the *convention* the data was recorded under
+    (:mod:`apxinf.conventions`), not of this body, and a default here would be
+    one dataset's dialect built into a robot's arithmetic.
     """
 
-    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 
@@ -138,9 +136,11 @@ class UnitreeG1AbsoluteActions(ProcessorStep):
     decoded state; gripper dims are already absolute and pass through. Reads the
     unnormalized ``actions`` and the decoded ``observation`` state threaded in by
     ``Pi05Policy.infer``. A no-op when state is absent (delta cannot be resolved).
+    ``state_key`` is required for the same reason as in
+    :class:`UnitreeG1DecodeState`.
     """
 
-    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -21,7 +21,9 @@ camera rename + CHW->HWC       ``image_keys`` config + ``ParseImage`` (already
 
 These steps are model-agnostic — they reference no policy symbols and vary only
 with the G1 body. The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
-adapter assembles them with a :class:`~apxinf.policies.impls.pi05.Pi05Policy`.
+adapter wraps them around whichever policy the checkpoint turns out to be, using
+:meth:`~apxinf.policies.base.ComposablePolicy.with_adapter`; it names no model
+class either.
 
 .. note::
    The joint-flip mask and gripper transforms in the integrator's file are

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -66,8 +66,14 @@ def _joint_flip_mask() -> np.ndarray:
 
     All ``+1`` in the integrator's file (a documented placeholder). Kept as the
     hook for real left/right mirror calibration.
+
+    Integer dtype on purpose, matching openpi's ``np.array([1, 1, ...])``: these
+    are exact signs, and the ``int64 * float32 -> float64`` promotion is what
+    puts openpi's whole G1 input chain in float64. Reproducing it is what makes
+    our discretized prompt bit-identical to theirs (see
+    :func:`~apxinf.processors.tokenize.discretize_state`).
     """
-    return np.ones(G1_ROBOT_DIM, dtype=np.float32)
+    return np.ones(G1_ROBOT_DIM, dtype=np.int64)
 
 
 def _gripper_to_angular(value: np.ndarray) -> np.ndarray:
@@ -122,7 +128,11 @@ class UnitreeG1DecodeState(ProcessorStep):
         raw = lookup_key(observation, self.state_key, None)
         if raw is None:
             return data
-        state = np.asarray(raw, dtype=np.float32) * _joint_flip_mask()
+        raw = np.asarray(raw)
+        # Promote to at least float32 before the flip so an integer state cannot
+        # be truncated by the gripper clip (openpi has no such guard). The int64
+        # flip mask then promotes the product to float64, matching openpi.
+        state = raw.astype(np.result_type(raw.dtype, np.float32), copy=False) * _joint_flip_mask()
         idx = list(_GRIPPER_INDICES)
         state[idx] = _gripper_to_angular(state[idx])
         data[self.observation_key] = set_key(observation, self.state_key, state)
@@ -149,9 +159,13 @@ class UnitreeG1AbsoluteActions(ProcessorStep):
         state = lookup_key(observation, self.state_key, None)
         if state is None:
             return data
-        actions = np.asarray(data[ACTIONS], dtype=np.float32).copy()
-        state = np.asarray(state, dtype=np.float32)[:G1_ROBOT_DIM]
-        offset = np.where(G1_DELTA_MASK, state, 0.0)
+        # Both operands keep their own dtype: openpi's output chain is float64
+        # end to end (its stats are float64 and its flip mask is int64), so
+        # coercing either side to float32 here would reintroduce the ~2e-7
+        # divergence the rest of the G1 path was aligned to remove (A15).
+        actions = np.array(data[ACTIONS], copy=True)
+        state = np.asarray(state)[:G1_ROBOT_DIM]
+        offset = np.where(G1_DELTA_MASK, state, state.dtype.type(0))
         actions[:, :G1_ROBOT_DIM] = actions[:, :G1_ROBOT_DIM] + offset
         data[ACTIONS] = actions
         return data
@@ -165,7 +179,13 @@ class UnitreeG1EncodeActions(ProcessorStep):
     """
 
     def __call__(self, data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        actions = np.asarray(data[ACTIONS], dtype=np.float32)[:, :G1_ROBOT_DIM] * _joint_flip_mask()
+        # No dtype coercion, in either direction. The +-1 flip is exact in any
+        # float dtype, but the int64 mask promotes a float32 input to float64 --
+        # which is precisely what openpi's ``_encode_actions`` does, so its G1
+        # server puts float64 actions on the wire. Matching that keeps the two
+        # servers' outputs comparable bit for bit (A15); an openpi G1 client
+        # reads the dtype off the msgpack payload either way.
+        actions = np.asarray(data[ACTIONS])[:, :G1_ROBOT_DIM] * _joint_flip_mask()
         idx = list(_GRIPPER_INDICES)
         actions[:, idx] = _gripper_from_angular(actions[:, idx])
         data[ACTIONS] = np.ascontiguousarray(actions)

--- a/python/apxinf/apxinf/processors/tokenize.py
+++ b/python/apxinf/apxinf/processors/tokenize.py
@@ -9,7 +9,7 @@ State injection (proprioception) is a **reserved** capability, matching the Rust
 ``pi05_prompt`` / ``discretize_state`` path but **off by default** so behavior is
 identical to the current serving link. When ``discrete_state=True`` the prompt
 becomes ``"Task: {task}, State: {s0 s1 ...};\nAction: "`` with the state
-discretized to ``0..=255`` — see :func:`discretize_state`. sentencepiece is
+discretized to ``-1..=255`` — see :func:`discretize_state`. sentencepiece is
 imported lazily so the rest of the processor library stays importable without it.
 """
 
@@ -24,16 +24,46 @@ from .base import ProcessorStep
 __all__ = ["PromptTokenizer", "SyntheticTokenizer", "discretize_state", "build_prompt"]
 
 
-def discretize_state(state: Sequence[float]) -> np.ndarray:
-    """Discretize a normalized state to ``uint8`` bins in ``0..=255``.
+#: The 256 bin edges openpi discretizes against, ``linspace(-1, 1, 257)[:-1]``.
+#: Every edge is ``-1 + i/128``, exact in binary floating point, so a comparison
+#: against one is exact — which is the whole reason :func:`discretize_state`
+#: compares instead of computing an index.
+_BIN_EDGES = np.linspace(-1.0, 1.0, 256 + 1)[:-1]
 
-    Matches NumPy ``digitize(state, linspace(-1, 1, 257)[:-1]) - 1`` with
-    saturation, i.e. the Rust ``discretize_state``:
-    ``clamp(floor((v + 1) * 128), 0, 255)``.
+
+def discretize_state(state: Sequence[float]) -> np.ndarray:
+    """Discretize a normalized state into the pi05 prompt's integer bins.
+
+    Reproduces NumPy ``digitize(state, linspace(-1, 1, 257)[:-1]) - 1``
+    *exactly*, including its **signed underflow bin**: ``digitize`` returns ``0``
+    for ``v < -1``, so the bin is ``-1``. openpi writes that ``-1`` verbatim into
+    the prompt (``models/tokenizer.py``), so it is a value the model saw during
+    training and must not be clamped away — hence ``int16``, not ``uint8``.
+    Values ``>= 1`` do saturate, to ``255``.
+
+    Normalized state *does* leave ``[-1, 1]`` on real hardware, because q01/q99
+    come from the training split; on the customer's own G1 validation set 7 of
+    3200 elements underflow. Clamping them to ``0`` changes the prompt string,
+    hence the token ids, hence the whole rollout.
+
+    Implemented as a search over the edges rather than the arithmetic
+    ``floor((v + 1) * 128)``, because that expression is not equal to
+    ``digitize`` for every input. Adding ``1.0`` to a value just under an edge in
+    ``[-1, -0.5)`` moves it into a coarser binade and the sum rounds *up* onto
+    the edge, putting it one bin too high::
+
+        v = nextafter(-0.4921875, -inf)     # one ulp below bin edge 65
+        v + 1.0 == 0.5078125                # exactly, by round-half-to-even
+        floor((v + 1.0) * 128) == 65        # wrong
+        digitize(v, edges) - 1  == 64       # right
+
+    ``searchsorted(..., side="right")`` is what ``digitize`` calls for increasing
+    bins, so this is the same comparison openpi makes, with no arithmetic on
+    ``v`` to round.
     """
     values = np.asarray(state, dtype=np.float64)
-    bins = np.floor((values + 1.0) * 128.0)
-    return np.clip(bins, 0, 255).astype(np.uint8)
+    bins = np.searchsorted(_BIN_EDGES, values, side="right") - 1
+    return bins.astype(np.int16)
 
 
 def _clean_task(prompt: str) -> str:

--- a/python/apxinf/apxinf/processors/transforms.py
+++ b/python/apxinf/apxinf/processors/transforms.py
@@ -214,7 +214,12 @@ class Tokenize(ProcessorStep):
             observation = _require(data, self.observation_key, "Tokenize")
             state = lookup_key(observation, self.state_key, None)
             if self.state_normalizer is not None and state is not None:
-                state = self.state_normalizer(np.asarray(state, dtype=np.float32))
+                # No dtype coercion: the state only ever reaches the model as
+                # prompt tokens, and openpi normalizes/discretizes it in whatever
+                # dtype its own transforms produced (float64 for adapt_to_pi
+                # robots). Forcing float32 here shifts values by ~1e-7, which is
+                # enough to land on the other side of a discretization bin edge.
+                state = self.state_normalizer(np.asarray(state))
             data[TOKEN_IDS] = self.tokenizer(prompt, state=state)
         else:
             data[TOKEN_IDS] = self.tokenizer(prompt)

--- a/python/apxinf/apxinf/processors/transforms.py
+++ b/python/apxinf/apxinf/processors/transforms.py
@@ -26,7 +26,7 @@ steps' keys.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping, Sequence
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
 import numpy as np
 
@@ -178,17 +178,30 @@ class Tokenize(ProcessorStep):
     Mirrors the policy's old state routing: when the tokenizer runs in
     ``discrete_state`` mode and a ``state_normalizer`` is set, the raw state is
     first mapped to ``[-1, 1]`` before discretization; otherwise state is dropped.
+
+    ``state_key`` has no default. It names a *dataset's* wire key, and this layer
+    has no business guessing one: ``"observation/state"`` used to be the default,
+    which is LIBERO's dialect quietly applied to every robot. ``None`` is allowed
+    only when the tokenizer does not read state at all, and is rejected when it
+    does — dropping proprioception silently is the failure this guards.
     """
 
     def __init__(
         self,
         tokenizer,
         state_normalizer=None,
-        state_key: str = "observation/state",
+        state_key: Optional[str] = None,
         *,
         observation_key: str = OBSERVATION,
         prompt_key: str = PROMPT,
     ):
+        if state_key is None and getattr(tokenizer, "discrete_state", False):
+            raise ValueError(
+                "Tokenize: the tokenizer discretizes state into the prompt but no "
+                "state_key was given, so there is no key to read it from. Name the "
+                "wire key your client sends (see apxinf.conventions), or use a "
+                "tokenizer with discrete_state=False to drop state deliberately."
+            )
         self.tokenizer = tokenizer
         self.state_normalizer = state_normalizer
         self.state_key = state_key

--- a/python/apxinf/apxinf/robots/__init__.py
+++ b/python/apxinf/apxinf/robots/__init__.py
@@ -7,11 +7,14 @@ A *robot adapter* binds that generic core to one robot by wiring the robot's
 :class:`~apxinf.processors.Pipeline` and loading its checkpoint / norm_stats.
 
 This is the top assembly layer: it depends *downward* on both
-:mod:`apxinf.policies` (the model) and :mod:`apxinf.processors` (the steps).
-Neither depends back on it, so adding a robot never touches the policy or
-processor packages — you write steps under ``processors/robots/`` and a
-``build_*`` factory here, then register both in :mod:`apxinf.robots.presets` so
-they are reachable as ``--robot <name>`` at serving time.
+:mod:`apxinf.policies` (the model) and :mod:`apxinf.processors` (the steps), and
+sideways on :mod:`apxinf.conventions` (the dataset dialect a preset pairs with a
+body). None of them depends back, so adding a robot never touches the policy,
+processor, or convention packages — you write steps under ``processors/robots/``
+and a ``build_*`` factory here, then register both in :mod:`apxinf.robots.presets`
+(or from your own package via
+:func:`~apxinf.robots.presets.register_robot_preset`) so they are reachable as
+``--robot <name>`` at serving time.
 """
 
 from __future__ import annotations
@@ -19,19 +22,25 @@ from __future__ import annotations
 from .presets import (
     ROBOT_PRESETS,
     VIEW_SLOTS,
+    Convention,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
     "build_unitree_g1_policy",
+    "Embodiment",
+    "Convention",
     "RobotPreset",
     "ROBOT_PRESETS",
     "VIEW_SLOTS",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
 ]

--- a/python/apxinf/apxinf/robots/__init__.py
+++ b/python/apxinf/apxinf/robots/__init__.py
@@ -19,6 +19,7 @@ and a ``build_*`` factory here, then register both in :mod:`apxinf.robots.preset
 
 from __future__ import annotations
 
+from .preflight import Finding, check_checkpoint, format_findings
 from .presets import (
     ROBOT_PRESETS,
     VIEW_SLOTS,
@@ -43,4 +44,7 @@ __all__ = [
     "get_robot_preset",
     "register_robot_preset",
     "build_robot_policy",
+    "Finding",
+    "check_checkpoint",
+    "format_findings",
 ]

--- a/python/apxinf/apxinf/robots/preflight.py
+++ b/python/apxinf/apxinf/robots/preflight.py
@@ -1,0 +1,282 @@
+"""Startup checks: does this checkpoint actually match the preset serving it?
+
+A checkpoint directory and a ``--robot`` preset are two independent claims about
+the same robot, and nothing forces them to agree. Serve a Unitree G1 checkpoint
+with a LIBERO ``norm_stats.json`` and ``--action-dim 7`` and every layer accepts
+it: the weights load, the tokenizer runs, the unnormalizer finds ``q01``/``q99``
+of *some* width, the server publishes an action shape, and the robot receives 7
+plausible-looking floats per step that mean nothing. The only visible symptom is
+that the model "got worse" — which reads as a model problem, gets escalated as a
+model problem, and is not one.
+
+That exact combination shipped. This module is the check that would have refused
+it, phrased as a list of :class:`Finding` s rather than an exception, so a caller
+can report all of them at once instead of fixing them one crash at a time.
+
+**What is checked here** is what can be read from the checkpoint *directory* with
+the standard library: ``norm_stats.json`` widths and keys, and the tokenizer
+file. The richer cross-check against openpi's own ``metadata.pt`` (its serialized
+``TrainConfig``: ``adapt_to_pi``, ``use_delta_joint_actions``, the repack wire
+keys, ``discrete_state_input``) needs torch to unpickle and lives in
+``scripts/openpi_metadata_to_apxinf.py``, which calls this module and adds to it.
+
+**What is deliberately not checked here** is anything already enforced elsewhere:
+``len(image_keys) == model.num_views`` raises inside
+:class:`~apxinf.policies.impls.pi05.Pi05Policy`, and the unnormalizer's own width
+rules live in :mod:`apxinf.processors.normalize`. Duplicating them would mean two
+places to keep in step.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from .presets import RobotPreset, get_robot_preset
+
+__all__ = ["Finding", "FAIL", "WARN", "INFO", "check_checkpoint", "format_findings"]
+
+#: A mismatch that makes the served actions meaningless. Refuse to start.
+FAIL = "FAIL"
+#: A mismatch that is survivable but is very likely not what the operator meant.
+WARN = "WARN"
+#: Context worth printing, not a problem.
+INFO = "INFO"
+
+_ORDER = {FAIL: 0, WARN: 1, INFO: 2}
+
+#: Tokenizer filenames :func:`apxinf.policies.impls.pi05._resolve_tokenizer`
+#: looks for. Kept as a literal rather than imported so this module stays
+#: importable without the CUDA binding that ``pi05`` pulls in.
+TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One check result: its severity, what it looked at, and what to do."""
+
+    level: str
+    check: str
+    detail: str
+    #: What the operator should change. Empty for :data:`INFO`.
+    remedy: str = ""
+
+    def __str__(self) -> str:
+        line = f"[{self.level:4}] {self.check}: {self.detail}"
+        return f"{line}\n         -> {self.remedy}" if self.remedy else line
+
+
+def _width(stats: dict, key: str) -> Optional[int]:
+    """Length of any one of the four stat vectors, or ``None`` if unreadable."""
+    for name in ("q01", "q99", "mean", "std"):
+        value = stats.get(name)
+        if isinstance(value, (list, tuple)):
+            return len(value)
+    return None
+
+
+def _check_norm_stats(
+    model_dir: Path, preset: RobotPreset, *, norm_key: str, discrete_state: bool
+) -> List[Finding]:
+    """The A1 check: are the shipped statistics this robot's statistics?"""
+    path = model_dir / "norm_stats.json"
+    if not path.exists():
+        return [
+            Finding(
+                FAIL,
+                "norm_stats.json",
+                f"missing from {model_dir}",
+                "unnormalization has no statistics to use; ship the file with the checkpoint",
+            )
+        ]
+    try:
+        document = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        return [Finding(FAIL, "norm_stats.json", f"unreadable: {exc}", "fix or re-export the file")]
+
+    stats = document.get("norm_stats", document)
+    findings: List[Finding] = []
+
+    # Width per key against what the preset says the robot is. This is the check
+    # that catches a G1 checkpoint carrying LIBERO statistics: 16-dim robot,
+    # 8/7-dim stats. Both directions are fatal -- too narrow and the unnormalizer
+    # refuses the array outright, too wide and it silently unnormalizes dimensions
+    # the robot does not have.
+    for key, expected in (
+        (norm_key, preset.action_width),
+        ("state", preset.state_dim if discrete_state else None),
+    ):
+        if expected is None:
+            continue
+        entry = stats.get(key)
+        if not isinstance(entry, dict):
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}]",
+                    f"absent; file has {sorted(stats)}",
+                    f"{preset.name} needs {key!r} statistics"
+                    + ("" if key == norm_key else " because state is discretized into the prompt"),
+                )
+            )
+            continue
+        got = _width(entry, key)
+        if got is None:
+            findings.append(
+                Finding(FAIL, f"norm_stats[{key!r}]", "has no vector-valued stat", "re-export"),
+            )
+        elif got != expected:
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}] width",
+                    f"{got}, but preset {preset.name!r} is a {expected}-dim robot",
+                    f"these statistics are not this robot's. Serving them maps the "
+                    f"model's output through the wrong physical range -- the actions "
+                    f"stay in range and stay wrong. Point --model-dir at a checkpoint "
+                    f"whose norm_stats.json is {expected} wide.",
+                )
+            )
+        else:
+            findings.append(Finding(INFO, f"norm_stats[{key!r}] width", f"{got}, matches preset"))
+
+        # pi05 is always quantile-normalized (openpi derives this from the model
+        # type, not from any file: `use_quantile_norm = model_type != PI0`), so
+        # q01/q99 are the stats that actually get used. openpi asserts their
+        # presence; apxinf's Unnormalizer would raise a KeyError instead.
+        if isinstance(entry, dict) and not ("q01" in entry and "q99" in entry):
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}] quantiles",
+                    f"no q01/q99; has {sorted(entry)}",
+                    "pi05 always unnormalizes with quantiles regardless of what any "
+                    "config says (openpi training/config.py: use_quantile_norm = "
+                    "model_type != PI0). mean/std alone cannot serve this checkpoint.",
+                )
+            )
+    return findings
+
+
+def _check_tokenizer(model_dir: Path, tokenizer_path) -> List[Finding]:
+    """The A14 check: is there a tokenizer to load, and is it the *same* one?"""
+    if tokenizer_path is not None:
+        path = Path(tokenizer_path)
+        if not path.exists():
+            return [
+                Finding(FAIL, "tokenizer", f"--tokenizer {path} does not exist", "fix the path")
+            ]
+        return [Finding(INFO, "tokenizer", f"{path} (explicit)")]
+
+    found = [name for name in TOKENIZER_NAMES if (model_dir / name).exists()]
+    if found:
+        return [Finding(INFO, "tokenizer", f"{model_dir / found[0]}")]
+    return [
+        Finding(
+            FAIL,
+            "tokenizer",
+            f"none of {list(TOKENIZER_NAMES)} in {model_dir}",
+            "the checkpoint does not carry its tokenizer. openpi downloads "
+            "paligemma_tokenizer.model at runtime, so a checkpoint exported from it "
+            "will not have one. Copy it into the checkpoint directory or pass "
+            "--tokenizer. Both servers must use the *same* file or their token ids "
+            "are not comparable.",
+        )
+    ]
+
+
+def _check_cameras(preset: RobotPreset, image_keys: Sequence[str]) -> List[Finding]:
+    """Camera count and ordering against the preset's declared view slots."""
+    keys = tuple(image_keys)
+    if keys == preset.image_keys:
+        return [Finding(INFO, "cameras", f"{len(keys)} views, preset keys unchanged")]
+    if len(keys) != preset.num_views:
+        return [
+            Finding(
+                WARN,
+                "cameras",
+                f"serving {len(keys)} views {list(keys)} but preset {preset.name!r} "
+                f"declares {preset.num_views} {list(preset.image_keys)}",
+                "the checkpoint was trained with a fixed number of view slots; pass "
+                "--num-views to load it for fewer, or drop the --image-keys override",
+            )
+        ]
+    return [
+        Finding(
+            WARN,
+            "cameras",
+            f"--image-keys overrides the preset: {list(keys)} instead of "
+            f"{list(preset.image_keys)}",
+            "entry i fills model view slot i, so a reordered tuple silently feeds "
+            "the wrong camera to each slot. Confirm the order matches "
+            f"{[slot for slot, _ in preset.slots]}.",
+        )
+    ]
+
+
+def check_checkpoint(
+    model_dir,
+    robot: str,
+    *,
+    norm_key: str = "actions",
+    discrete_state: Optional[bool] = None,
+    image_keys: Optional[Sequence[str]] = None,
+    action_dim: Optional[int] = None,
+    tokenizer_path=None,
+) -> Tuple[Finding, ...]:
+    """Check a checkpoint directory against the preset that will serve it.
+
+    Takes the *resolved* serving knobs (what the server settled on after applying
+    its overrides), not the raw command line, so what is checked is what will
+    actually run. Returns findings sorted most-severe first; an empty tuple is
+    impossible because passing checks are reported as :data:`INFO`.
+    """
+    model_dir = Path(model_dir)
+    preset = get_robot_preset(robot)
+    discrete = preset.discrete_state if discrete_state is None else bool(discrete_state)
+    keys = preset.image_keys if image_keys is None else tuple(image_keys)
+
+    findings = [
+        *_check_norm_stats(model_dir, preset, norm_key=norm_key, discrete_state=discrete),
+        *_check_tokenizer(model_dir, tokenizer_path),
+        *_check_cameras(preset, keys),
+    ]
+
+    if action_dim is not None and preset.action_width is not None and action_dim != preset.action_width:
+        findings.append(
+            Finding(
+                WARN,
+                "action_dim",
+                f"--action-dim {action_dim} overrides preset {preset.name!r}'s "
+                f"{preset.action_width}",
+                "a width the robot does not have gets truncated or padded somewhere "
+                "downstream without an error. Drop the flag unless the deployed "
+                "client genuinely expects this width.",
+            )
+        )
+    if discrete and not preset.discrete_state:
+        findings.append(
+            Finding(INFO, "discrete_state", "enabled by override; preset default is off")
+        )
+    elif not discrete and preset.discrete_state:
+        findings.append(
+            Finding(
+                WARN,
+                "discrete_state",
+                f"disabled by override, but preset {preset.name!r} discretizes state "
+                "into the prompt",
+                "state is not merely un-discretized, it is *dropped*: the model sees "
+                "no proprioception, and any delta->absolute output step becomes a "
+                "no-op because it has no base to add.",
+            )
+        )
+
+    return tuple(sorted(findings, key=lambda f: _ORDER.get(f.level, 3)))
+
+
+def format_findings(findings: Sequence[Finding], *, include_info: bool = True) -> str:
+    """Render findings for a log or a terminal, most severe first."""
+    shown = [f for f in findings if include_info or f.level != INFO]
+    return "\n".join(str(f) for f in shown)

--- a/python/apxinf/apxinf/robots/preflight.py
+++ b/python/apxinf/apxinf/robots/preflight.py
@@ -14,10 +14,11 @@ it, phrased as a list of :class:`Finding` s rather than an exception, so a calle
 can report all of them at once instead of fixing them one crash at a time.
 
 **What is checked here** is what can be read from the checkpoint *directory* with
-the standard library: ``norm_stats.json`` widths and keys, and the tokenizer
-file. The richer cross-check against openpi's own ``metadata.pt`` (its serialized
-``TrainConfig``: ``adapt_to_pi``, ``use_delta_joint_actions``, the repack wire
-keys, ``discrete_state_input``) needs torch to unpickle and lives in
+the standard library: which layout it is, where its ``norm_stats.json`` actually
+lives, that file's widths and keys, and the tokenizer. Nothing loads a weight and
+nothing imports torch or the CUDA binding, so these checks run before the
+expensive part of startup — and on a laptop. The richer cross-check against the
+preset's own wire keys and delta convention lives in
 ``scripts/openpi_metadata_to_apxinf.py``, which calls this module and adds to it.
 
 **What is deliberately not checked here** is anything already enforced elsewhere:
@@ -35,6 +36,14 @@ from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 from .presets import RobotPreset, get_robot_preset
+from ..checkpoints import (
+    CheckpointError,
+    CheckpointLayout,
+    TOKENIZER_NAMES,
+    detect_checkpoint,
+    has_layout_metadata,
+    require_norm_stats,
+)
 
 __all__ = ["Finding", "FAIL", "WARN", "INFO", "check_checkpoint", "format_findings"]
 
@@ -46,11 +55,6 @@ WARN = "WARN"
 INFO = "INFO"
 
 _ORDER = {FAIL: 0, WARN: 1, INFO: 2}
-
-#: Tokenizer filenames :func:`apxinf.policies.impls.pi05._resolve_tokenizer`
-#: looks for. Kept as a literal rather than imported so this module stays
-#: importable without the CUDA binding that ``pi05`` pulls in.
-TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
 
 
 @dataclass(frozen=True)
@@ -77,27 +81,105 @@ def _width(stats: dict, key: str) -> Optional[int]:
     return None
 
 
-def _check_norm_stats(
-    model_dir: Path, preset: RobotPreset, *, norm_key: str, discrete_state: bool
-) -> List[Finding]:
-    """The A1 check: are the shipped statistics this robot's statistics?"""
-    path = model_dir / "norm_stats.json"
-    if not path.exists():
-        return [
+def _check_layout(layout: CheckpointLayout) -> List[Finding]:
+    """Report what the directory says it is, before anything reads it.
+
+    The layout decides which ``norm_stats.json`` gets used, so an operator who
+    can see the chosen path can spot the wrong-statistics failure by eye — which
+    is the one failure mode this whole module exists for.
+    """
+    findings = [Finding(INFO, "checkpoint layout", f"{layout.format} ({layout.root})")]
+    if layout.asset_id:
+        findings.append(
             Finding(
-                FAIL,
-                "norm_stats.json",
-                f"missing from {model_dir}",
-                "unnormalization has no statistics to use; ship the file with the checkpoint",
+                INFO,
+                "asset_id",
+                f"{layout.asset_id!r} (from {layout.asset_id_source or 'metadata.pt'})",
             )
-        ]
+        )
+    if layout.arch:
+        rendered = ", ".join(f"{k}={v}" for k, v in sorted(layout.arch.items()))
+        findings.append(Finding(INFO, "architecture", f"from metadata.pt: {rendered}"))
+    for note in layout.notes:
+        findings.append(Finding(INFO, "checkpoint layout", note))
+    return findings
+
+
+def _check_norm_stats(
+    model_dir: Path,
+    preset: RobotPreset,
+    *,
+    norm_key: str,
+    discrete_state: bool,
+    layout: Optional[CheckpointLayout] = None,
+    norm_stats=None,
+) -> List[Finding]:
+    """Are the shipped statistics this robot's statistics?
+
+    ``layout`` supplies the resolved path. An openpi export keeps its statistics
+    under ``assets/<asset_id>/``, so reading ``<model_dir>/norm_stats.json``
+    unconditionally is how the wrong file got checked *and* served: whatever a
+    previous run happened to leave in the root. With no layout — a flat directory
+    that declares nothing — ``norm_stats`` still names the file directly, which
+    is what :meth:`Pi05Policy.from_pretrained` does in the same situation.
+    """
+    findings: List[Finding] = []
+    if layout is not None:
+        try:
+            path = require_norm_stats(layout)
+        except CheckpointError as exc:
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    str(exc),
+                    "unnormalization has no statistics to use; ship the file with the "
+                    "checkpoint or point --norm-stats at it",
+                )
+            ]
+        if layout.norm_stats_is_fallback:
+            findings.append(
+                Finding(
+                    WARN,
+                    "norm_stats.json",
+                    f"using the checkpoint root {path} because {layout.norm_stats_tried[0]} "
+                    f"(openpi's path for asset_id={layout.asset_id!r}) does not exist",
+                    "verify these statistics belong to this robot. A file from another "
+                    "run is syntactically valid and unnormalizes silently; the width "
+                    "check below is the only thing that would catch it.",
+                )
+            )
+        else:
+            findings.append(Finding(INFO, "norm_stats.json", str(path)))
+    elif norm_stats is not None:
+        path = Path(norm_stats)
+        if not path.is_file():
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    f"--norm-stats {path} does not exist",
+                    "fix the path",
+                )
+            ]
+        findings.append(Finding(INFO, "norm_stats.json", f"{path} (explicit)"))
+    else:
+        path = model_dir / "norm_stats.json"
+        if not path.exists():
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    f"missing from {model_dir}",
+                    "unnormalization has no statistics to use; ship the file with the checkpoint",
+                )
+            ]
     try:
         document = json.loads(path.read_text())
     except (OSError, ValueError) as exc:
         return [Finding(FAIL, "norm_stats.json", f"unreadable: {exc}", "fix or re-export the file")]
 
     stats = document.get("norm_stats", document)
-    findings: List[Finding] = []
 
     # Width per key against what the preset says the robot is. This is the check
     # that catches a G1 checkpoint carrying LIBERO statistics: 16-dim robot,
@@ -161,7 +243,7 @@ def _check_norm_stats(
 
 
 def _check_tokenizer(model_dir: Path, tokenizer_path) -> List[Finding]:
-    """The A14 check: is there a tokenizer to load, and is it the *same* one?"""
+    """Is there a tokenizer to load, and is it the *same* one both servers use?"""
     if tokenizer_path is not None:
         path = Path(tokenizer_path)
         if not path.exists():
@@ -225,6 +307,9 @@ def check_checkpoint(
     image_keys: Optional[Sequence[str]] = None,
     action_dim: Optional[int] = None,
     tokenizer_path=None,
+    checkpoint_format: Optional[str] = None,
+    asset_id: Optional[str] = None,
+    norm_stats=None,
 ) -> Tuple[Finding, ...]:
     """Check a checkpoint directory against the preset that will serve it.
 
@@ -232,14 +317,57 @@ def check_checkpoint(
     its overrides), not the raw command line, so what is checked is what will
     actually run. Returns findings sorted most-severe first; an empty tuple is
     impossible because passing checks are reported as :data:`INFO`.
+
+    ``checkpoint_format`` / ``asset_id`` / ``norm_stats`` are the same knobs
+    :meth:`~apxinf.policies.impls.pi05.Pi05Policy.from_pretrained` takes, and must
+    be passed through identically — this is a preflight for *that* load, so
+    checking a different file than the one that will be served defeats the point.
     """
     model_dir = Path(model_dir)
     preset = get_robot_preset(robot)
     discrete = preset.discrete_state if discrete_state is None else bool(discrete_state)
     keys = preset.image_keys if image_keys is None else tuple(image_keys)
 
+    # A directory that declares nothing about itself is the hand-assembled flat
+    # layout that predates this check; it still loads, so it is still checked,
+    # just against <model_dir>/norm_stats.json (or --norm-stats, which names one
+    # file rather than asserting a directory shape). A detection failure is
+    # reported rather than raised: preflight's whole contract is to list every
+    # problem. This mirrors Pi05Policy.from_pretrained exactly — a preflight that
+    # resolves a different file than the load would is worse than none.
+    layout: Optional[CheckpointLayout] = None
+    layout_findings: List[Finding] = []
+    if checkpoint_format or asset_id or has_layout_metadata(model_dir):
+        try:
+            layout = detect_checkpoint(
+                model_dir,
+                checkpoint_format=checkpoint_format,
+                asset_id=asset_id,
+                norm_stats=norm_stats,
+            )
+        except CheckpointError as exc:
+            layout_findings.append(
+                Finding(
+                    FAIL,
+                    "checkpoint layout",
+                    str(exc),
+                    "apxinf cannot tell what this directory is, so it cannot tell "
+                    "which files to read; pass --ckpt-format, or fix the directory",
+                )
+            )
+        else:
+            layout_findings.extend(_check_layout(layout))
+
     findings = [
-        *_check_norm_stats(model_dir, preset, norm_key=norm_key, discrete_state=discrete),
+        *layout_findings,
+        *_check_norm_stats(
+            model_dir,
+            preset,
+            norm_key=norm_key,
+            discrete_state=discrete,
+            layout=layout,
+            norm_stats=norm_stats,
+        ),
         *_check_tokenizer(model_dir, tokenizer_path),
         *_check_cameras(preset, keys),
     ]

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -72,6 +72,7 @@ from .. import conventions
 from ..conventions import Convention
 from ..policies.auto import AutoPolicy
 from ..policies.base import VIEW_SLOTS, Policy
+from ..processors.robots.unitree_g1 import G1_ROBOT_DIM
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
@@ -109,6 +110,18 @@ class Embodiment:
     #: Deployable action width. ``None`` keeps the model's full vector — correct
     #: when a robot output step does the truncation itself (G1's 32→16 encode).
     action_dim: Optional[int] = None
+    #: Width of this body's state vector, i.e. how wide ``norm_stats["state"]``
+    #: has to be. A fact about the hardware, so it does not follow
+    #: :attr:`action_dim`: a robot's state and action spaces need not match
+    #: (Franka under LIBERO has 8-dim state and a 7-dim EEF-delta action).
+    #: ``None`` means this body makes no claim and the check is skipped.
+    state_dim: Optional[int] = None
+    #: Width of this body's action vector, i.e. how wide ``norm_stats["actions"]``
+    #: has to be. Distinct from :attr:`action_dim`, which is a *loading* knob
+    #: saying what to trim the model down to: the G1 declares ``action_dim=None``
+    #: because ``UnitreeG1EncodeActions`` owns the truncation, but its actions are
+    #: still 16 wide and its statistics must be. ``None`` skips the check.
+    action_width: Optional[int] = None
     #: Factory that loads the checkpoint and wires this robot's pre/post steps.
     builder: Callable[..., Policy] = _build_generic
     #: Extra keyword arguments the builder always receives.
@@ -119,6 +132,20 @@ class Embodiment:
             raise ValueError(
                 f"Embodiment {self.name!r}: num_cameras={self.num_cameras} is outside "
                 f"1..{len(VIEW_SLOTS)}, the view slots {VIEW_SLOTS} a checkpoint fills"
+            )
+        if (
+            self.action_dim is not None
+            and self.action_width is not None
+            and self.action_dim > self.action_width
+        ):
+            # Trimming is a slice of the statistics, so it cannot ask for more
+            # columns than the body's actions have. Getting this pair backwards
+            # would make the preflight check the wrong width and pass a
+            # checkpoint that the unnormalizer then fails on, mid-serve.
+            raise ValueError(
+                f"Embodiment {self.name!r}: action_dim={self.action_dim} trims wider "
+                f"than action_width={self.action_width}, but action_width is how many "
+                "columns this body's actions (and its norm_stats) have"
             )
 
     @property
@@ -200,6 +227,14 @@ class RobotPreset:
         return self.embodiment.action_dim
 
     @property
+    def state_dim(self) -> Optional[int]:
+        return self.embodiment.state_dim
+
+    @property
+    def action_width(self) -> Optional[int]:
+        return self.embodiment.action_width
+
+    @property
     def builder(self) -> Callable[..., Policy]:
         return self.embodiment.builder
 
@@ -261,18 +296,36 @@ class RobotPreset:
 #: Franka Emika Panda, 7-DoF arm + parallel gripper, 2-camera rig. Its whole port
 #: is a table row: the checkpoint already emits absolute actions at the deployable
 #: width, so no robot pre/post step is needed and the generic builder serves it.
-FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7)
+#: ``state_dim`` is 8 rather than 7 — LIBERO records EEF pose + gripper on the
+#: state side and 6 EEF deltas + gripper on the action side.
+FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7, state_dim=8, action_width=7)
 
 #: Unitree G1 humanoid: dual-arm + 2 dexterous hands, 16 DoF laid out
 #: ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, 3 cameras. ``action_dim``
 #: stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16 truncation
-#: after delta→absolute has seen the full-width action.
+#: after delta→absolute has seen the full-width action; ``action_width`` is still
+#: 16, because that is how wide the body's actions and its statistics are.
 UNITREE_G1_BODY = Embodiment(
     name="unitree_g1",
     num_cameras=3,
     action_dim=None,
+    state_dim=G1_ROBOT_DIM,
+    action_width=G1_ROBOT_DIM,
     builder=build_unitree_g1_policy,
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+    builder_kwargs={
+        "use_delta_joint_actions": True,
+        "adapt_to_pi": True,
+        # openpi parses norm_stats.json into float64 and never demotes it, so its
+        # whole G1 chain — normalize state, discretize it into the prompt,
+        # unnormalize the action — runs in float64. Ours follows the input dtype
+        # (float32) unless told otherwise. The output-side gap is ~2e-7 rad and
+        # harmless, but on the input side the very next thing after normalizing
+        # is a comparison against bin edges 1/128 apart: an element sitting near
+        # an edge lands in a different bin, which changes the prompt text, the
+        # token ids, and the whole rollout. Match openpi rather than explain the
+        # divergence later.
+        "norm_dtype": "float64",
+    },
 )
 
 #: --- deployable pairings -----------------------------------------------------

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -120,6 +120,50 @@ class RobotPreset:
         """Cameras this preset sends; must equal the checkpoint's ``num_views``."""
         return len(self.slots)
 
+    @property
+    def has_robot_steps(self) -> bool:
+        """Whether this preset wires robot-specific pre/post steps.
+
+        ``False`` for a preset the generic builder serves, whose entire contract
+        is its wire keys and action width. A caller that *cannot* run
+        :attr:`builder` — the checkpoint-free synthetic path — uses this to say
+        what it dropped rather than publishing the preset name unqualified.
+        """
+        return self.builder is not _build_generic
+
+    def synthetic_gaps(
+        self, *, discrete_state: bool, served_action_dim: int
+    ) -> Tuple[str, ...]:
+        """What a checkpoint-free (random-weights) server cannot honour here.
+
+        The synthetic path reproduces this preset's wire keys and view count
+        exactly and nothing else: its tokenizer emits a fixed token stream and
+        never reads state, and :attr:`builder` never runs. Each returned string
+        names one gap, for a startup warning — a synthetic server publishing this
+        preset's name unqualified would be the silent embodiment mismatch
+        ``--robot`` exists to prevent.
+        """
+        gaps = []
+        if discrete_state:
+            gaps.append(
+                "discrete_state=True — the synthetic tokenizer ignores state, so the "
+                "served metadata says discrete_state=False"
+            )
+        if self.has_robot_steps:
+            gap = (
+                f"its robot pre/post steps — {self.builder.__name__} never runs, so no "
+                "state decode, delta->absolute or action re-encode is wired"
+            )
+            if self.action_dim is None:
+                # action_dim=None means an output step owns the truncation (G1's
+                # 32->16 encode). Without that step the full model vector ships.
+                gap += (
+                    f"; the served action_dim is the model's full {served_action_dim}, "
+                    "not the width that skipped step would emit"
+                )
+            gaps.append(gap)
+        return tuple(gaps)
+
     def describe(self) -> str:
         """Human-readable slot→wire-key mapping, for ``--help`` and startup logs."""
         rendered = ", ".join(f"{slot}={key}" for slot, key in self.slots)
@@ -204,8 +248,11 @@ def build_robot_policy(
     stack without editing the preset (and without touching the client).
 
     The resulting wire contract is published in the policy ``metadata``
-    (``robot`` / ``image_keys`` / ``state_key`` / ``discrete_state``), which the
-    server pushes on connect, so a client can assert it rather than guess.
+    (``robot`` / ``robot_steps`` / ``image_keys`` / ``state_key`` /
+    ``discrete_state``), which the server pushes on connect, so a client can
+    assert it rather than guess. ``robot_steps`` says whether this robot's
+    pre/post steps are actually wired, so a server that serves the preset's keys
+    without its arithmetic cannot pass for the real thing.
     """
     preset = get_robot_preset(robot)
     keys = tuple(image_keys) if image_keys is not None else preset.image_keys
@@ -221,6 +268,7 @@ def build_robot_policy(
         action_dim=width,
         metadata={
             "robot": preset.name,
+            "robot_steps": preset.has_robot_steps,
             "robot_slots": [list(pair) for pair in zip(VIEW_SLOTS, keys)],
             **(dict(metadata) if metadata else {}),
         },

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -38,6 +38,22 @@ is named for the arm *and* the dataset convention whose keys it implements:
 ``franka_libero``, not ``libero`` (a benchmark, not a robot) and not ``franka``
 (ambiguous). Single-embodiment robots that own their convention need no suffix —
 ``unitree_g1``.
+
+**Two halves, one flag.** That naming rule is an admission, so the dataclasses
+follow it: an :class:`Embodiment` is the body (camera count, action width, which
+pre/post steps its actions need) and a :class:`Convention` is a dataset's
+recording dialect (the wire keys, and whether state was recorded into the
+prompt). Neither knows the other; they vary independently, which is the point —
+the same Franka under DROID's keys is a second :class:`Convention`, not a second
+body, and re-recording the G1 changes no :class:`Embodiment` field.
+
+A :class:`RobotPreset` names one *pairing*, and only the pairing is deployable.
+``--robot`` stays a single flag over that registry rather than becoming
+``--robot`` + ``--convention``: separate flags would let an operator spell a
+combination nobody ever recorded, and a body served under a convention it was not
+recorded on is exactly the silent mismatch this whole mechanism exists to
+prevent. The pairing is validated when the module loads — a convention naming
+three cameras cannot be attached to a two-camera body.
 """
 
 from __future__ import annotations
@@ -52,6 +68,8 @@ from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
     "VIEW_SLOTS",
+    "Embodiment",
+    "Convention",
     "RobotPreset",
     "ROBOT_PRESETS",
     "ROBOT_ALIASES",
@@ -67,69 +85,173 @@ def _build_generic(model_dir, **kwargs) -> Policy:
 
 
 @dataclass(frozen=True)
-class RobotPreset:
-    """One embodiment's serving contract: wire keys + action width + builder."""
+class Embodiment:
+    """A robot body: how many cameras it has, and what its actions mean.
 
-    #: Registry name, used as ``--robot <name>``.
+    Everything here is a fact about hardware. It survives a change of dataset:
+    re-record the G1 under a different key convention and this is unchanged.
+    Nothing here is a string that goes on the network.
+    """
+
+    #: Robot name, used in the served metadata and in preset names.
     name: str
-    #: ``(view slot, wire key)`` pairs in model slot order. The slot name is
-    #: documentation and validation; only the wire key goes on the network.
-    slots: Tuple[Tuple[str, str], ...]
-    #: Wire key of the proprioceptive state vector.
-    state_key: str
-    #: Wire key of the task instruction.
-    prompt_key: str = "prompt"
+    #: Cameras this body carries; must equal the checkpoint's ``num_views``.
+    num_cameras: int
     #: Deployable action width. ``None`` keeps the model's full vector — correct
     #: when a robot output step does the truncation itself (G1's 32→16 encode).
     action_dim: Optional[int] = None
-    #: Whether state is discretized into the prompt. Off means state is *dropped*.
-    discrete_state: bool = False
     #: Factory that loads the checkpoint and wires this robot's pre/post steps.
     builder: Callable[..., Policy] = _build_generic
-    #: One-line description for ``--help`` and the served metadata.
-    summary: str = ""
     #: Extra keyword arguments the builder always receives.
     builder_kwargs: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.slots:
-            raise ValueError(f"RobotPreset {self.name!r}: at least one camera slot is required")
-        if len(self.slots) > len(VIEW_SLOTS):
+        if not 1 <= self.num_cameras <= len(VIEW_SLOTS):
             raise ValueError(
-                f"RobotPreset {self.name!r}: {len(self.slots)} slots exceeds pi05's "
-                f"{len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
+                f"Embodiment {self.name!r}: num_cameras={self.num_cameras} is outside "
+                f"1..{len(VIEW_SLOTS)}, the view slots {VIEW_SLOTS} a checkpoint fills"
             )
-        expected = VIEW_SLOTS[: len(self.slots)]
-        declared = tuple(slot for slot, _ in self.slots)
-        if declared != expected:
+
+    @property
+    def has_robot_steps(self) -> bool:
+        """Whether this body needs pre/post arithmetic beyond naming its keys.
+
+        ``False`` for a body the generic builder serves, whose entire contract is
+        its wire keys and action width. A caller that *cannot* run :attr:`builder`
+        — the checkpoint-free synthetic path — uses this to say what it dropped
+        rather than publishing the preset name unqualified.
+        """
+        return self.builder is not _build_generic
+
+
+@dataclass(frozen=True)
+class Convention:
+    """A dataset's recording convention: what the client calls things.
+
+    Everything here is a string on the network, plus the one routing decision
+    that follows from how the data was recorded. It survives a change of robot:
+    LIBERO's keys describe a Franka today and would describe any arm recorded the
+    same way. Nothing here knows an action width or a camera count.
+    """
+
+    #: Convention name (a dataset or an integrator's dialect).
+    name: str
+    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
+    image_keys: Tuple[str, ...]
+    #: Wire key of the proprioceptive state vector.
+    state_key: str
+    #: Wire key of the task instruction.
+    prompt_key: str = "prompt"
+    #: Whether state is discretized into the prompt. Off means state is *dropped*.
+    discrete_state: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.image_keys:
+            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
+        if len(self.image_keys) > len(VIEW_SLOTS):
             raise ValueError(
-                f"RobotPreset {self.name!r}: slots must be a prefix of {VIEW_SLOTS} in "
-                f"order (a checkpoint fills view slots from 0 up), got {declared}"
+                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
+                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
             )
-        wire = [key for _, key in self.slots]
-        if len(set(wire)) != len(wire):
-            raise ValueError(f"RobotPreset {self.name!r}: duplicate camera wire keys {wire}")
+        if len(set(self.image_keys)) != len(self.image_keys):
+            raise ValueError(
+                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
+            )
+
+    @property
+    def num_cameras(self) -> int:
+        """Cameras this convention names — cross-checked against the body's."""
+        return len(self.image_keys)
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs — the pairing, for logs and review."""
+        return tuple(zip(VIEW_SLOTS, self.image_keys))
+
+
+@dataclass(frozen=True)
+class RobotPreset:
+    """One deployable pairing: a body recorded under a convention.
+
+    The two halves are separable because they vary independently — the same
+    Franka arm under LIBERO's and DROID's keys is one :class:`Embodiment` and two
+    :class:`Convention`\\ s — but they are validated *together*, because only the
+    pair is deployable: a convention naming three cameras cannot serve a two-camera
+    body, and nothing else in the system will notice if it tries.
+
+    This stays one ``--robot`` flag. Splitting the flag too would let an operator
+    spell combinations that were never recorded, which is the silent mismatch the
+    flag exists to prevent; the registry below decides which pairings are real.
+    """
+
+    #: Registry name, used as ``--robot <name>``. Spelled ``<arm>_<convention>``
+    #: when the arm is shared, bare when the body owns its convention.
+    name: str
+    #: The body being served.
+    embodiment: Embodiment
+    #: The key convention its client speaks.
+    convention: Convention
+    #: One-line description for ``--help`` and the served metadata.
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if self.convention.num_cameras != self.embodiment.num_cameras:
+            raise ValueError(
+                f"RobotPreset {self.name!r}: convention {self.convention.name!r} names "
+                f"{self.convention.num_cameras} cameras but embodiment "
+                f"{self.embodiment.name!r} has {self.embodiment.num_cameras}; a "
+                "convention can only be paired with a body it was recorded on"
+            )
+
+    # --- the pairing's flat contract ---------------------------------------
+    #
+    # Delegating properties rather than a rename: this is what the server, the
+    # metadata and the tests read, and which half a field came from is not their
+    # business. They also keep every existing caller working unchanged.
 
     @property
     def image_keys(self) -> Tuple[str, ...]:
         """Camera wire keys in model slot order — what ``ImageStack`` consumes."""
-        return tuple(key for _, key in self.slots)
+        return self.convention.image_keys
+
+    @property
+    def state_key(self) -> str:
+        return self.convention.state_key
+
+    @property
+    def prompt_key(self) -> str:
+        return self.convention.prompt_key
+
+    @property
+    def discrete_state(self) -> bool:
+        return self.convention.discrete_state
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs in model slot order."""
+        return self.convention.slots
+
+    @property
+    def action_dim(self) -> Optional[int]:
+        return self.embodiment.action_dim
+
+    @property
+    def builder(self) -> Callable[..., Policy]:
+        return self.embodiment.builder
+
+    @property
+    def builder_kwargs(self) -> Mapping[str, Any]:
+        return self.embodiment.builder_kwargs
 
     @property
     def num_views(self) -> int:
         """Cameras this preset sends; must equal the checkpoint's ``num_views``."""
-        return len(self.slots)
+        return self.embodiment.num_cameras
 
     @property
     def has_robot_steps(self) -> bool:
-        """Whether this preset wires robot-specific pre/post steps.
-
-        ``False`` for a preset the generic builder serves, whose entire contract
-        is its wire keys and action width. A caller that *cannot* run
-        :attr:`builder` — the checkpoint-free synthetic path — uses this to say
-        what it dropped rather than publishing the preset name unqualified.
-        """
-        return self.builder is not _build_generic
+        """Whether this preset wires robot-specific pre/post steps."""
+        return self.embodiment.has_robot_steps
 
     def synthetic_gaps(
         self, *, discrete_state: bool, served_action_dim: int
@@ -170,35 +292,64 @@ class RobotPreset:
         return f"{self.name}: {rendered}; state={self.state_key}"
 
 
-#: Franka Panda under LIBERO's key convention (the 7-DoF sim benchmark):
-#: 2 cameras, 7-dim action. Mirrors openpi ``LiberoInputs``. State is dropped by
-#: default, matching the numerics of the existing serving link.
+#: --- bodies -----------------------------------------------------------------
+
+#: Franka Emika Panda, 7-DoF arm + parallel gripper, 2-camera rig. Its whole port
+#: is a table row: the checkpoint already emits absolute actions at the deployable
+#: width, so no robot pre/post step is needed and the generic builder serves it.
+FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7)
+
+#: Unitree G1 humanoid: dual-arm + 2 dexterous hands, 16 DoF laid out
+#: ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, 3 cameras. ``action_dim``
+#: stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16 truncation
+#: after delta→absolute has seen the full-width action.
+UNITREE_G1_BODY = Embodiment(
+    name="unitree_g1",
+    num_cameras=3,
+    action_dim=None,
+    builder=build_unitree_g1_policy,
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+#: --- key conventions ---------------------------------------------------------
+
+#: LIBERO's recording convention (the 7-DoF sim benchmark). Mirrors openpi
+#: ``LiberoInputs``: flat ``observation/...`` keys. State is dropped by default,
+#: matching the numerics of the existing serving link.
+LIBERO_KEYS = Convention(
+    name="libero",
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+    discrete_state=False,
+)
+
+#: The ``pi05_UnitreeG1`` fine-tune's convention, from its
+#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``,
+#: a flat ``state``, discretized into the prompt.
+UNITREE_G1_KEYS = Convention(
+    name="unitree_g1",
+    image_keys=tuple(G1_CAMERAS),
+    state_key=G1_STATE_KEY,
+    discrete_state=True,
+)
+
+#: --- deployable pairings -----------------------------------------------------
+
+#: Franka Panda under LIBERO's keys: 2 cameras, 7-dim action.
 FRANKA_LIBERO = RobotPreset(
     name="franka_libero",
-    slots=(
-        ("base_0_rgb", "observation/image"),
-        ("left_wrist_0_rgb", "observation/wrist_image"),
-    ),
-    state_key="observation/state",
-    action_dim=7,
-    discrete_state=False,
+    embodiment=FRANKA,
+    convention=LIBERO_KEYS,
     summary="Franka Panda, LIBERO keys: 2 cameras, 7-dim action (6 EEF deltas + gripper)",
 )
 
-#: Unitree G1 (humanoid, dual-arm + 2 dexterous hands): 3 cameras, 16-dim action.
-#: Mirrors the ``pi05_UnitreeG1`` fine-tune's ``unitreeG1Inputs``/``Outputs``: the
-#: client sends the nested ``obs["images"][...]`` layout and a flat ``"state"``.
-#: ``action_dim`` stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16
-#: truncation after delta→absolute has seen the full-width action.
+#: Unitree G1 under its own convention — a single-embodiment robot that owns its
+#: keys, so body and convention share a name and the preset needs no suffix.
 UNITREE_G1 = RobotPreset(
     name="unitree_g1",
-    slots=tuple(zip(VIEW_SLOTS, G1_CAMERAS)),
-    state_key=G1_STATE_KEY,
-    action_dim=None,
-    discrete_state=True,
-    builder=build_unitree_g1_policy,
+    embodiment=UNITREE_G1_BODY,
+    convention=UNITREE_G1_KEYS,
     summary="Unitree G1: 3 cameras, 16-DoF state, delta joint actions, 32->16 encode",
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
 #: Name -> preset. Add an embodiment here once its steps and factory exist; that

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -11,19 +11,24 @@ launch flag on both sides rather than a code edit on ours:
     openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
     apxinf:  pi05_openpi_websocket_server.py --robot unitree_g1
 
-**Why a table and not a default.** ``Pi05Policy``'s ``_DEFAULT_IMAGE_KEYS`` is
-LIBERO's wire contract. As *the* default it silently applied to every checkpoint,
-so a G1 checkpoint served without extra arguments ran LIBERO's keys, dropped
-state, and skipped the G1 delta→absolute and 32→16 steps — every symptom of a
-"model accuracy problem" with nothing in the logs. A preset makes the embodiment
-an explicit, named choice.
+**Why a table and not a default.** ``Pi05Policy`` used to default ``image_keys``
+to ``("observation/image", "observation/wrist_image")`` — LIBERO's wire contract,
+living in the model layer as *the* default for every checkpoint. A G1 checkpoint
+served without extra arguments therefore ran LIBERO's keys, dropped state, and
+skipped the G1 delta→absolute and 32→16 steps — every symptom of a "model
+accuracy problem" with nothing in the logs. The policy now names its cameras
+after its own :data:`~apxinf.policies.base.VIEW_SLOTS` when the caller names
+none, so no dataset's convention can pass for a model default; a preset makes the
+embodiment an explicit, named choice.
 
 **Why slot names.** ``image_keys`` is order-significant: entry ``i`` is stacked
 into model view slot ``i``, which the checkpoint trained as openpi's
 ``base_0_rgb`` / ``left_wrist_0_rgb`` / ``right_wrist_0_rgb``. A tuple written in
 the wrong order still stacks, still has the right shape, and silently feeds the
 wrong camera to each slot. Pairing every wire key with the slot it fills makes
-that order reviewable instead of positional.
+that order reviewable instead of positional. The slot vocabulary itself is a
+*model* fact, so it is imported from :mod:`apxinf.policies.base` rather than
+restated here.
 
 **Naming rule: ``<arm>_<convention>``.** The arm alone does not determine the
 contract — LIBERO and DROID are both Franka Panda, yet LIBERO sends
@@ -41,7 +46,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 from ..policies.auto import AutoPolicy
-from ..policies.base import Policy
+from ..policies.base import VIEW_SLOTS, Policy
 from ..processors.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY
 from .unitree_g1 import build_unitree_g1_policy
 
@@ -54,11 +59,6 @@ __all__ = [
     "get_robot_preset",
     "build_robot_policy",
 ]
-
-#: pi05 model view slots in order, as named by openpi's ``model.IMAGE_KEYS``.
-#: A checkpoint's ``num_views`` is how many of these its weights were trained on;
-#: the names are openpi's convention, the *order* is baked into the weights.
-VIEW_SLOTS = ("base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb")
 
 
 def _build_generic(model_dir, **kwargs) -> Policy:

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -41,11 +41,14 @@ is named for the arm *and* the dataset convention whose keys it implements:
 
 **Two halves, one flag.** That naming rule is an admission, so the dataclasses
 follow it: an :class:`Embodiment` is the body (camera count, action width, which
-pre/post steps its actions need) and a :class:`Convention` is a dataset's
-recording dialect (the wire keys, and whether state was recorded into the
-prompt). Neither knows the other; they vary independently, which is the point —
-the same Franka under DROID's keys is a second :class:`Convention`, not a second
-body, and re-recording the G1 changes no :class:`Embodiment` field.
+pre/post steps its actions need) and a
+:class:`~apxinf.conventions.Convention` is a dataset's recording dialect (the
+wire keys, and whether state was recorded into the prompt). Neither knows the
+other; they vary independently, which is the point — the same Franka under
+DROID's keys is a second convention, not a second body, and re-recording the G1
+changes no :class:`Embodiment` field. Conventions live in
+:mod:`apxinf.conventions` rather than here, because a dialect is not a robot's
+property: this module imports them, never the reverse.
 
 A :class:`RobotPreset` names one *pairing*, and only the pairing is deployable.
 ``--robot`` stays a single flag over that registry rather than becoming
@@ -54,16 +57,21 @@ combination nobody ever recorded, and a body served under a convention it was no
 recorded on is exactly the silent mismatch this whole mechanism exists to
 prevent. The pairing is validated when the module loads — a convention naming
 three cameras cannot be attached to a two-camera body.
+
+**Registering from outside.** :func:`register_robot_preset` adds an entry from
+another package, so a third-party robot does not have to patch this file to
+become ``--robot <name>``.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
 
+from .. import conventions
+from ..conventions import Convention
 from ..policies.auto import AutoPolicy
 from ..policies.base import VIEW_SLOTS, Policy
-from ..processors.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
@@ -75,6 +83,7 @@ __all__ = [
     "ROBOT_ALIASES",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
 ]
 
@@ -122,51 +131,6 @@ class Embodiment:
         rather than publishing the preset name unqualified.
         """
         return self.builder is not _build_generic
-
-
-@dataclass(frozen=True)
-class Convention:
-    """A dataset's recording convention: what the client calls things.
-
-    Everything here is a string on the network, plus the one routing decision
-    that follows from how the data was recorded. It survives a change of robot:
-    LIBERO's keys describe a Franka today and would describe any arm recorded the
-    same way. Nothing here knows an action width or a camera count.
-    """
-
-    #: Convention name (a dataset or an integrator's dialect).
-    name: str
-    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
-    image_keys: Tuple[str, ...]
-    #: Wire key of the proprioceptive state vector.
-    state_key: str
-    #: Wire key of the task instruction.
-    prompt_key: str = "prompt"
-    #: Whether state is discretized into the prompt. Off means state is *dropped*.
-    discrete_state: bool = False
-
-    def __post_init__(self) -> None:
-        if not self.image_keys:
-            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
-        if len(self.image_keys) > len(VIEW_SLOTS):
-            raise ValueError(
-                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
-                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
-            )
-        if len(set(self.image_keys)) != len(self.image_keys):
-            raise ValueError(
-                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
-            )
-
-    @property
-    def num_cameras(self) -> int:
-        """Cameras this convention names — cross-checked against the body's."""
-        return len(self.image_keys)
-
-    @property
-    def slots(self) -> Tuple[Tuple[str, str], ...]:
-        """``(view slot, wire key)`` pairs — the pairing, for logs and review."""
-        return tuple(zip(VIEW_SLOTS, self.image_keys))
 
 
 @dataclass(frozen=True)
@@ -311,35 +275,13 @@ UNITREE_G1_BODY = Embodiment(
     builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
-#: --- key conventions ---------------------------------------------------------
-
-#: LIBERO's recording convention (the 7-DoF sim benchmark). Mirrors openpi
-#: ``LiberoInputs``: flat ``observation/...`` keys. State is dropped by default,
-#: matching the numerics of the existing serving link.
-LIBERO_KEYS = Convention(
-    name="libero",
-    image_keys=("observation/image", "observation/wrist_image"),
-    state_key="observation/state",
-    discrete_state=False,
-)
-
-#: The ``pi05_UnitreeG1`` fine-tune's convention, from its
-#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``,
-#: a flat ``state``, discretized into the prompt.
-UNITREE_G1_KEYS = Convention(
-    name="unitree_g1",
-    image_keys=tuple(G1_CAMERAS),
-    state_key=G1_STATE_KEY,
-    discrete_state=True,
-)
-
 #: --- deployable pairings -----------------------------------------------------
 
 #: Franka Panda under LIBERO's keys: 2 cameras, 7-dim action.
 FRANKA_LIBERO = RobotPreset(
     name="franka_libero",
     embodiment=FRANKA,
-    convention=LIBERO_KEYS,
+    convention=conventions.LIBERO,
     summary="Franka Panda, LIBERO keys: 2 cameras, 7-dim action (6 EEF deltas + gripper)",
 )
 
@@ -348,12 +290,14 @@ FRANKA_LIBERO = RobotPreset(
 UNITREE_G1 = RobotPreset(
     name="unitree_g1",
     embodiment=UNITREE_G1_BODY,
-    convention=UNITREE_G1_KEYS,
+    convention=conventions.UNITREE_G1,
     summary="Unitree G1: 3 cameras, 16-DoF state, delta joint actions, 32->16 encode",
 )
 
 #: Name -> preset. Add an embodiment here once its steps and factory exist; that
 #: is the whole registration step (openpi's ``training/config.py`` equivalent).
+#: A preset defined outside this package joins the same dict through
+#: :func:`register_robot_preset`.
 ROBOT_PRESETS: Dict[str, RobotPreset] = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1)}
 
 #: Accepted spellings that are not canonical names. ``libero`` names a benchmark
@@ -378,6 +322,56 @@ def get_robot_preset(name: str) -> RobotPreset:
             f"unknown robot preset {name!r}; known: {list(available_robots())}"
             f" (aliases: {list(ROBOT_ALIASES)})"
         ) from None
+
+
+def register_robot_preset(
+    preset: RobotPreset,
+    *,
+    aliases: Iterable[str] = (),
+    replace: bool = False,
+) -> RobotPreset:
+    """Add ``preset`` to the registry and return it, for use at module scope.
+
+    The registry above is this repository's table; a robot that lives in someone
+    else's package should not have to patch it to become ``--robot <name>``.
+    Importing that package is enough::
+
+        MY_ROBOT = register_robot_preset(
+            RobotPreset(name="myarm_mydataset", embodiment=MY_ARM, convention=MY_KEYS),
+            aliases=("myarm",),
+        )
+
+    Re-registering a name is an error unless ``replace=True``: a silent overwrite
+    would change what a launch command already in production resolves to, which
+    is the same class of invisible failure ``--robot`` exists to prevent. An alias
+    may never shadow a canonical name, for the same reason.
+
+    Registration is process-local and not persisted — ``--robot`` on the shipped
+    server only sees presets whose module was imported.
+    """
+    if not isinstance(preset, RobotPreset):
+        raise TypeError(f"expected a RobotPreset, got {type(preset).__name__}")
+    existing = ROBOT_PRESETS.get(preset.name)
+    if existing is not None and not replace:
+        raise ValueError(
+            f"robot preset {preset.name!r} is already registered ({existing.describe()}); "
+            "pass replace=True to override it"
+        )
+    for alias in aliases:
+        if alias in ROBOT_PRESETS:
+            raise ValueError(
+                f"alias {alias!r} for {preset.name!r} is already a canonical preset name; "
+                "an alias that shadows a real preset would silently redirect --robot"
+            )
+        target = ROBOT_ALIASES.get(alias)
+        if target is not None and target != preset.name and not replace:
+            raise ValueError(
+                f"alias {alias!r} already resolves to {target!r}; pass replace=True to move it"
+            )
+    ROBOT_PRESETS[preset.name] = preset
+    for alias in aliases:
+        ROBOT_ALIASES[alias] = preset.name
+    return preset
 
 
 def build_robot_policy(

--- a/python/apxinf/apxinf/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/robots/unitree_g1.py
@@ -8,6 +8,10 @@ no model class, no step inside the model's chain, and no checkpoint layout:
 holds, and :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter` wraps the
 G1 steps around that policy's own pre/post chain.
 
+It knows nothing about the *dataset* either: the wire keys arrive as required
+arguments from a :class:`~apxinf.conventions.Convention`, so the same body serves
+a re-recorded G1 without an edit here.
+
 The nesting is the entire coupling, and it is an ordering rule, not a naming one:
 
     decode G1 state  ->  [ whatever the model does ]  ->  delta->absolute -> 32->16
@@ -38,9 +42,7 @@ from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy, Policy
 from ..processors.base import StepSpec
 from ..processors.robots.unitree_g1 import (
-    G1_CAMERAS,
     G1_ROBOT_DIM,
-    G1_STATE_KEY,
     UnitreeG1AbsoluteActions,
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
@@ -52,10 +54,10 @@ __all__ = ["build_unitree_g1_policy"]
 def build_unitree_g1_policy(
     model_dir,
     *,
+    state_key: str,
+    image_keys: Sequence[str],
     use_delta_joint_actions: bool = True,
     adapt_to_pi: bool = True,
-    state_key: str = G1_STATE_KEY,
-    image_keys: Sequence[str] = G1_CAMERAS,
     discrete_state: bool = True,
     action_dim: Optional[int] = None,
     metadata: Optional[dict] = None,
@@ -89,11 +91,22 @@ def build_unitree_g1_policy(
     (``device`` / ``precision`` / ``checkpoint`` / ``model_type`` / a pre-built
     ``model=`` handle / an injected ``unnormalizer=``, ...).
 
-    Defaults match what an unmodified openpi G1 client sends: the nested
-    ``obs["images"][...]`` cameras, a flat ``"state"``, and state discretized into
-    the prompt. Serving with ``discrete_state=False`` silently drops state, which
-    also makes ``use_delta_joint_actions`` a no-op (a delta cannot be resolved
-    without the current joint positions).
+    ``state_key`` and ``image_keys`` are **required and have no defaults**. They
+    are a recording convention, not a fact about this body: the G1 client's
+    dialect lives in :data:`apxinf.conventions.UNITREE_G1`, and defaulting to it
+    here would rebuild the robot↔dataset coupling one layer up. Pass
+    ``**vars(...)`` of a convention, or let
+    :func:`~apxinf.robots.presets.build_robot_policy` do it from the preset
+    table::
+
+        from apxinf.conventions import UNITREE_G1 as G1_KEYS
+        policy = build_unitree_g1_policy(
+            ckpt, state_key=G1_KEYS.state_key, image_keys=G1_KEYS.image_keys
+        )
+
+    Serving with ``discrete_state=False`` silently drops state, which also makes
+    ``use_delta_joint_actions`` a no-op (a delta cannot be resolved without the
+    current joint positions).
     """
     base = AutoPolicy.from_pretrained(
         model_dir,

--- a/python/apxinf/apxinf/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/robots/unitree_g1.py
@@ -1,15 +1,29 @@
-"""Unitree G1 adapter: wire the G1 steps onto a pi05 policy.
+"""Unitree G1 adapter: wrap the G1 steps around whatever policy the checkpoint is.
 
-Assembles the robot-specific steps in
-:mod:`apxinf.processors.robots.unitree_g1` with a generic
-:class:`~apxinf.policies.impls.pi05.Pi05Policy`. Only the primary serving path
-(3 cameras, ``adapt_to_pi=True``, no fixed-hand override) is wired — that is what
-the shipped ``pi05_UnitreeG1_groundwire`` config uses; the integrator's
-``_NoLeftCam`` / ``fixed_hand`` variants are training-data cleaning knobs, not
-serving paths, so they are intentionally omitted.
+This module is the *robot* half of the robot/model split. It knows the G1 body —
+16 DoF laid out ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, three cameras,
+delta joint actions — and it knows nothing about the model serving it. It names
+no model class, no step inside the model's chain, and no checkpoint layout:
+:class:`~apxinf.policies.auto.AutoPolicy` decides which policy the directory
+holds, and :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter` wraps the
+G1 steps around that policy's own pre/post chain.
+
+The nesting is the entire coupling, and it is an ordering rule, not a naming one:
+
+    decode G1 state  ->  [ whatever the model does ]  ->  delta->absolute -> 32->16
+
+which is openpi's ``data_transforms`` sitting outside its ``model_transforms``.
+Everything else — how the model tokenizes, whether it discretizes state, what its
+steps are called — stays the model's business, so a G1 checkpoint of a different
+architecture serves through this same adapter unchanged.
+
+Only the primary serving path (3 cameras, ``adapt_to_pi=True``, no fixed-hand
+override) is wired — that is what the shipped ``pi05_UnitreeG1_groundwire`` config
+uses; the integrator's ``_NoLeftCam`` / ``fixed_hand`` variants are training-data
+cleaning knobs, not serving paths, so they are intentionally omitted.
 
 .. note::
-   With a stand-in pi05 checkpoint (no real G1 weights / norm_stats) this adapter
+   With a stand-in checkpoint (no real G1 weights / norm_stats) this adapter
    validates *plumbing and shape* (G1 obs -> ``[action_horizon, 16]``), not G1
    action values. Numeric parity needs the integrator's real gripper limits
    **and** the G1 checkpoint/norm_stats; the same adapter code then runs
@@ -18,10 +32,11 @@ serving paths, so they are intentionally omitted.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
-from ..policies.impls.pi05 import Pi05Policy
-from ..processors import Pipeline
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy, Policy
+from ..processors.base import StepSpec
 from ..processors.robots.unitree_g1 import (
     G1_CAMERAS,
     G1_ROBOT_DIM,
@@ -30,7 +45,6 @@ from ..processors.robots.unitree_g1 import (
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
 )
-from ..processors.transforms import Unnormalize
 
 __all__ = ["build_unitree_g1_policy"]
 
@@ -44,29 +58,36 @@ def build_unitree_g1_policy(
     image_keys: Sequence[str] = G1_CAMERAS,
     discrete_state: bool = True,
     action_dim: Optional[int] = None,
-    unnormalizer: Optional[Unnormalize] = None,
     metadata: Optional[dict] = None,
-    **from_pretrained_kwargs: Any,
-) -> Pi05Policy:
-    """Build a :class:`Pi05Policy` wired with the Unitree G1 pre/post adapter.
+    **load_kwargs: Any,
+) -> Policy:
+    """Load ``model_dir`` and wrap the Unitree G1 pre/post adapter around it.
 
-    Loads the checkpoint through the generic :meth:`Pi05Policy.from_pretrained`
-    (full model-width unnormalizer, so the delta->absolute step sees the whole
-    action before the 32->16 robot truncation), then swaps in the G1 pipelines:
+    The checkpoint is loaded through :class:`~apxinf.policies.auto.AutoPolicy`, so
+    the model type comes from ``config.json`` (or an explicit ``model_type=``)
+    rather than from this file. It is loaded at **full model width**
+    (``action_dim=None``) because the delta->absolute step must see the whole
+    action before ``UnitreeG1EncodeActions`` truncates it to 16. The model's own
+    unnormalizer therefore comes from the checkpoint's ``norm_stats["actions"]``
+    at its native width, so a real deployment needs G1 norm_stats at least ``16``
+    wide; pass ``unnormalizer=`` through to inject one instead (e.g. a full-width
+    identity for a shape/plumbing run on a stand-in checkpoint).
 
-    * **input**  — ``[image_stack, g1_decode_state?, tokenize]``; PI0.5 samples
-      its latent internally unless the caller supplies ``noise``
-    * **output** — ``[unnormalize, g1_absolute?, g1_encode]``
+    The resulting chain is the model's own, wrapped:
+
+    * **input**  — ``[g1_decode_state?, <the model's input steps>]``
+    * **output** — ``[<the model's output steps>, g1_absolute?, g1_encode?]``
 
     ``adapt_to_pi=False`` drops the decode/encode conventions (raw robot space);
     ``use_delta_joint_actions=False`` drops the delta->absolute step (the model
     already emits absolute actions). ``action_dim`` is the **deployable** width
-    reported to clients and defaults to :data:`G1_ROBOT_DIM` — the model always
-    runs at full width internally, and ``UnitreeG1EncodeActions`` performs the
-    truncation. By default the unnormalizer comes from the checkpoint's
-    ``norm_stats["actions"]``, so a real deployment needs G1 norm_stats at least
-    ``16`` wide; pass ``unnormalizer=`` to inject one (e.g. a full-width identity
-    for a shape/plumbing test on a stand-in checkpoint).
+    reported to clients: it defaults to :data:`G1_ROBOT_DIM` when ``adapt_to_pi``
+    wires the truncating encode step, and otherwise to whatever the model's own
+    chain emits — a policy must not advertise a width no step produces.
+
+    Extra ``load_kwargs`` reach the concrete policy's ``from_pretrained``
+    (``device`` / ``precision`` / ``checkpoint`` / ``model_type`` / a pre-built
+    ``model=`` handle / an injected ``unnormalizer=``, ...).
 
     Defaults match what an unmodified openpi G1 client sends: the nested
     ``obs["images"][...]`` cameras, a flat ``"state"``, and state discretized into
@@ -74,36 +95,44 @@ def build_unitree_g1_policy(
     also makes ``use_delta_joint_actions`` a no-op (a delta cannot be resolved
     without the current joint positions).
     """
-    base = Pi05Policy.from_pretrained(
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,  # keep full model width; the g1_encode step truncates to 16
         state_key=state_key,
         discrete_state=discrete_state,
-        **from_pretrained_kwargs,
+        **load_kwargs,
     )
-    if unnormalizer is None:
-        unnormalizer = base.output_pipeline["unnormalize"]
-
-    input_pipeline = base.input_pipeline
-    if adapt_to_pi:
-        input_pipeline = input_pipeline.insert_before(
-            "tokenize", ("g1_decode_state", UnitreeG1DecodeState(state_key))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(
+            f"the Unitree G1 adapter has to run its steps around the model's, which "
+            f"{type(base).__name__} (loaded from {model_dir}) does not allow: it has no "
+            "with_adapter(). Give that policy class a ComposablePolicy.with_adapter "
+            "rather than teaching this adapter about its internals."
         )
 
-    output_steps = [("unnormalize", unnormalizer)]
-    if use_delta_joint_actions:
-        output_steps.append(("g1_absolute", UnitreeG1AbsoluteActions(state_key)))
+    before: List[StepSpec] = []
     if adapt_to_pi:
-        output_steps.append(("g1_encode", UnitreeG1EncodeActions()))
-    output_pipeline = Pipeline(output_steps)
+        # Ahead of the model's own steps, so both the (optional) state
+        # discretization and the delta->absolute output step read decoded state.
+        before.append(("g1_decode_state", UnitreeG1DecodeState(state_key)))
 
-    return Pi05Policy(
-        base.model,
-        input_pipeline=input_pipeline,
-        output_pipeline=output_pipeline,
-        image_keys=tuple(image_keys),
-        state_key=state_key,
-        action_dim=G1_ROBOT_DIM if action_dim is None else int(action_dim),
+    after: List[StepSpec] = []
+    if use_delta_joint_actions:
+        after.append(("g1_absolute", UnitreeG1AbsoluteActions(state_key)))
+    if adapt_to_pi:
+        after.append(("g1_encode", UnitreeG1EncodeActions()))
+
+    if action_dim is not None:
+        width: Optional[int] = int(action_dim)
+    elif adapt_to_pi:
+        width = G1_ROBOT_DIM  # g1_encode does the truncation
+    else:
+        width = None  # no truncating step is wired; keep the model chain's width
+
+    return base.with_adapter(
+        before=before,
+        after=after,
+        action_dim=width,
         metadata={"robot": "unitree_g1", **(metadata or {})},
     )

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -325,29 +325,46 @@ wrong is silent. Add one entry to
 contract becomes `--robot <name>`:
 
 ```python
+MY_ROBOT_BODY = Embodiment(                       # the hardware: survives a re-record
+    name="my_robot",
+    num_cameras=2,
+    action_dim=None,                              # None: the encode step trims
+    builder=build_my_robot_policy,
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+MY_ROBOT_KEYS = Convention(                       # the dataset dialect: survives a re-body
+    name="my_dataset",
+    image_keys=("images/cam_high", "images/cam_left_wrist"),  # in model view-slot order
+    state_key="state",
+    discrete_state=True,                          # False *drops* state entirely
+)
+
 MY_ROBOT = RobotPreset(
     name="my_robot",                              # <arm>_<key convention> if the arm is shared
-    slots=(                                       # (model view slot, wire key), in slot order
-        ("base_0_rgb",        "images/cam_high"),
-        ("left_wrist_0_rgb",  "images/cam_left_wrist"),
-    ),
-    state_key="state",
-    action_dim=None,                              # None: the encode step trims
-    discrete_state=True,                          # False *drops* state entirely
-    builder=build_my_robot_policy,
+    embodiment=MY_ROBOT_BODY,
+    convention=MY_ROBOT_KEYS,
     summary="My robot: 2 cameras, 14-DoF state, delta joint actions",
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
 ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 ```
 
-Naming each wire key with the **model view slot** it fills is the point: the
-tuple is order-significant (entry *i* becomes model view slot *i*), and a wrong
-order still stacks, still has the right shape, and silently feeds the wrong
-camera to each slot. The pairing is validated — slots must be a prefix of
-`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb` in order, with no duplicate
-wire keys.
+The two halves are separate because they vary independently: the same arm
+recorded under a second key convention is a new `Convention`, not a new body, and
+re-recording changes no `Embodiment` field. Only the *pairing* is deployable, and
+`--robot` stays one flag over the pairings — separate `--robot`/`--convention`
+flags would let an operator spell a combination nobody ever recorded, which is
+the silent mismatch the flag exists to prevent.
+
+`image_keys` is order-significant: entry *i* becomes model view slot *i*
+(`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb`), and a wrong order still
+stacks, still has the right shape, and silently feeds the wrong camera to each
+slot. `preset.slots` renders the pairing for logs and review; because the slot
+names are *derived* from the list rather than written by hand, a wrong slot order
+is not expressible at all. What is still checked: no duplicate wire keys, no more
+keys than there are view slots, and — on the pairing — the convention's camera
+count against the body's.
 
 Wire keys may be written **flat** (`"observation/image"` — the slash is part of
 the name, as LIBERO and DROID send it) or as a **nested path**

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -247,14 +247,24 @@ Port **placeholder calibration** faithfully as a hook (in G1 the flip mask is al
 Default pi05 pipelines: input `[image_stack, tokenize]`, output
 `[trim, unnormalize]`. Noise is generated inside the runtime unless the caller
 passes it explicitly; a custom host sampler can still be inserted as a pipeline
-step. `Pipeline` offers
-`insert_before/insert_after/replace/override/remove/reorder` (each returns a new
-pipeline). The factory does three things: load full-width → insert decode on the
-input → rewrite the output pipeline:
+step.
+
+`Pipeline` has two families of editing verbs, and picking the wrong one is what
+couples a robot to a model. `insert_before/insert_after/replace/override/remove/
+reorder` address a step **by name**, so they are for a caller who owns that
+chain. A robot adapter does not: its requirement is only "run outside the model's
+steps, in both directions". That is `prepend`/`append`, the two verbs that name
+nothing inside — and a policy exposes them as
+[`ComposablePolicy.with_adapter`](../policies/base.py). Every verb returns a new
+pipeline; none mutate.
+
+So the factory does two things: load full-width through `AutoPolicy`, then wrap.
+It names no model class, so a G1 checkpoint of a different architecture serves
+through the same file unchanged:
 
 ```python
-from ..policies.impls.pi05 import Pi05Policy
-from ..processors import Pipeline
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy
 from ..processors.robots.my_robot import (
     MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions,
     ROBOT_CAMERAS, ROBOT_DIM,
@@ -262,31 +272,29 @@ from ..processors.robots.my_robot import (
 
 def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_pi=True,
                           state_key="observation/state", image_keys=ROBOT_CAMERAS, **kw):
-    base = Pi05Policy.from_pretrained(
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,        # keep full 32 dims; the encode step trims to ROBOT_DIM
         state_key=state_key,
         **kw,
     )
-    input_pipeline = base.input_pipeline
-    if adapt_to_pi:
-        input_pipeline = input_pipeline.insert_before(
-            "tokenize", ("decode_state", MyRobotDecodeState(state_key)))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(f"{type(base).__name__} has no with_adapter(); ...")
 
-    output_steps = [("unnormalize", base.output_pipeline["unnormalize"])]   # full width
+    before = [("decode_state", MyRobotDecodeState(state_key))] if adapt_to_pi else []
+    after = []
     if use_delta_joint_actions:
-        output_steps.append(("absolute", MyRobotAbsoluteActions(state_key)))
+        after.append(("absolute", MyRobotAbsoluteActions(state_key)))
     if adapt_to_pi:
-        output_steps.append(("encode", MyRobotEncodeActions()))
+        after.append(("encode", MyRobotEncodeActions()))
 
-    return Pi05Policy(
-        base.model,
-        input_pipeline=input_pipeline,
-        output_pipeline=Pipeline(output_steps),
-        image_keys=tuple(image_keys),
-        state_key=state_key,
-        action_dim=ROBOT_DIM,
+    return base.with_adapter(
+        before=before,
+        after=after,
+        # Only the width a step you appended actually produces. Without `encode`
+        # there is nothing to claim: inherit the model's own width (None).
+        action_dim=ROBOT_DIM if adapt_to_pi else None,
         metadata={"robot": "my_robot"},
     )
 ```
@@ -294,9 +302,12 @@ def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_p
 Resulting pipelines:
 
 ```
-input : [image_stack, decode_state, tokenize]
-output: [unnormalize, absolute, encode]   # normalized[H,32] -> actions[H,ROBOT_DIM]
+input : [decode_state, image_stack, tokenize]
+output: [trim, unnormalize, absolute, encode]   # normalized[H,32] -> actions[H,ROBOT_DIM]
 ```
+
+`trim` is the model's own step at full width (a no-op when `norm_stats` is as
+wide as the model), so `absolute` still sees the whole action.
 
 ### 5.5 One general framework hook (built in, nothing to change)
 

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -103,8 +103,10 @@ result["policy_timing"]   # {'infer_ms': bare model, 'policy_ms': full policy}
 The metadata **is** the wire contract — assert against `meta["image_keys"]` /
 `meta["state_key"]` instead of hardcoding keys, so a server/client mismatch shows
 up as a failed assertion at startup rather than as degraded accuracy in the
-field. Sending a key the server does not serve raises a `KeyError` naming both
-sides; sending an *extra* key is silently ignored (matching openpi).
+field. A `state_key` of `null` is not a gap: it says the served policy drops
+state, so there is no key to send one under. Sending a key the server does not
+serve raises a `KeyError` naming both sides; sending an *extra* key is silently
+ignored (matching openpi).
 
 **Images are RGB.** Neither this server nor openpi converts colour: an `H×W×3`
 uint8 array is taken as RGB as-is. A client reading frames with OpenCV must
@@ -194,6 +196,7 @@ A working G1 example ships in-tree — copy and adapt it:
 ```
 python/apxinf/apxinf/processors/robots/unitree_g1.py   # robot-specific ProcessorSteps
 python/apxinf/apxinf/robots/unitree_g1.py              # build_unitree_g1_policy factory
+python/apxinf/apxinf/conventions.py                    # the G1 client's wire keys
 ```
 
 ### 5.1 Two landing spots
@@ -202,6 +205,7 @@ python/apxinf/apxinf/robots/unitree_g1.py              # build_unitree_g1_policy
 |---|---|---|
 | **robot-specific step** (pure numpy, per-embodiment, model-agnostic) | `python/apxinf/apxinf/processors/robots/<robot>.py` | `ProcessorStep` subclasses: decode-state / delta→absolute / encode-actions |
 | **assembly factory** (wires the steps onto `Pi05Policy`) | `python/apxinf/apxinf/robots/<robot>.py` | a `build_<robot>_policy(...)` that rewrites the pre/post pipelines after `from_pretrained` |
+| **recording convention** (the wire keys your client sends) | `python/apxinf/apxinf/conventions.py` | a `Convention`; it belongs to the *dataset*, so no step and no factory may hardcode it |
 
 ### 5.2 OpenPI transform → apxinf equivalent (G1 as the sample)
 
@@ -266,12 +270,16 @@ through the same file unchanged:
 from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy
 from ..processors.robots.my_robot import (
-    MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions,
-    ROBOT_CAMERAS, ROBOT_DIM,
+    MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions, ROBOT_DIM,
 )
 
-def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_pi=True,
-                          state_key="observation/state", image_keys=ROBOT_CAMERAS, **kw):
+# state_key / image_keys are **required and have no defaults**: they are a
+# recording convention, not a fact about this body. Defaulting them here would
+# rebuild the robot<->dataset coupling one layer up — the same arm re-recorded
+# under new keys would silently keep serving the old ones. They come from a
+# `Convention` (§5.6), which `build_robot_policy` reads off the preset for you.
+def build_my_robot_policy(model_dir, *, state_key, image_keys,
+                          use_delta_joint_actions=True, adapt_to_pi=True, **kw):
     base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
@@ -333,7 +341,8 @@ MY_ROBOT_BODY = Embodiment(                       # the hardware: survives a re-
     builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
-MY_ROBOT_KEYS = Convention(                       # the dataset dialect: survives a re-body
+# In apxinf/conventions.py — the dataset dialect: survives a re-body.
+MY_ROBOT_KEYS = Convention(
     name="my_dataset",
     image_keys=("images/cam_high", "images/cam_left_wrist"),  # in model view-slot order
     state_key="state",
@@ -352,10 +361,32 @@ ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 
 The two halves are separate because they vary independently: the same arm
 recorded under a second key convention is a new `Convention`, not a new body, and
-re-recording changes no `Embodiment` field. Only the *pairing* is deployable, and
-`--robot` stays one flag over the pairings — separate `--robot`/`--convention`
-flags would let an operator spell a combination nobody ever recorded, which is
-the silent mismatch the flag exists to prevent.
+re-recording changes no `Embodiment` field. That is also why they live in
+different modules — a `Convention` goes in
+[`apxinf/conventions.py`](../conventions.py), which imports no body and no policy
+implementation, so a dialect is never anyone's property. Only the *pairing* is
+deployable, and `--robot` stays one flag over the pairings — separate
+`--robot`/`--convention` flags would let an operator spell a combination nobody
+ever recorded, which is the silent mismatch the flag exists to prevent.
+
+**From outside this repository.** A robot that lives in your own package does not
+have to patch either file. Importing your module is enough:
+
+```python
+from apxinf import Convention, Embodiment, RobotPreset
+from apxinf import register_convention, register_robot_preset
+
+MY_KEYS = register_convention(Convention(name="my_dataset", ...))
+MY_ROBOT = register_robot_preset(
+    RobotPreset(name="myarm_my_dataset", embodiment=MY_ARM, convention=MY_KEYS),
+    aliases=("myarm",),
+)
+```
+
+Re-registering a name needs an explicit `replace=True`, and an alias may never
+shadow a canonical preset name: a silent overwrite would change what a launch
+command already in production resolves to. Registration is process-local, so
+`--robot` only sees presets whose module the server imported.
 
 `image_keys` is order-significant: entry *i* becomes model view slot *i*
 (`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb`), and a wrong order still
@@ -379,8 +410,23 @@ startup, so a client can assert it.
 
 ```python
 from apxinf import build_unitree_g1_policy          # shipped G1 example
-policy = build_unitree_g1_policy("<g1-ckpt>", use_delta_joint_actions=True, adapt_to_pi=True)
+from apxinf.conventions import UNITREE_G1 as G1_KEYS
+
+policy = build_unitree_g1_policy(
+    "<g1-ckpt>",
+    state_key=G1_KEYS.state_key,                    # required: a dataset fact, not a body's
+    image_keys=G1_KEYS.image_keys,
+    use_delta_joint_actions=True,
+    adapt_to_pi=True,
+)
 actions = policy.infer(obs)["actions"]               # [H, 16]
+```
+
+Or let the preset table supply both, which is what the server does:
+
+```python
+from apxinf import build_robot_policy
+policy = build_robot_policy("unitree_g1", "<g1-ckpt>")
 ```
 
 Served the same way, once §5.6 is done:

--- a/python/apxinf/examples/_common.py
+++ b/python/apxinf/examples/_common.py
@@ -24,7 +24,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 
 def synthetic_observation(
     *,
-    image_keys: Sequence[str] = ("observation/image", "observation/wrist_image"),
+    image_keys: Sequence[str],
+    state_key: str = "observation/state",
     height: int = 256,
     width: int = 256,
     state_dim: int = 8,
@@ -36,12 +37,17 @@ def synthetic_observation(
     Random ``uint8`` camera frames (raw ``HWC``; the policy's own resize step
     handles them) plus a float32 state vector and a text prompt. This is only to
     exercise the interface end-to-end — the actions it yields are meaningless.
+
+    ``image_keys`` has no default on purpose: camera wire keys are a dataset's
+    convention, and every caller here can read the real ones off the policy
+    (``policy.image_keys`` / ``policy.state_key``). A helper that guessed them
+    would drift from whatever the policy is actually serving.
     """
     rng = np.random.default_rng(seed)
     observation: Dict[str, Any] = {
         key: rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
         for key in image_keys
     }
-    observation["observation/state"] = rng.standard_normal(state_dim).astype(np.float32)
+    observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
     observation["prompt"] = prompt
     return observation

--- a/python/apxinf/examples/_common.py
+++ b/python/apxinf/examples/_common.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
@@ -25,7 +25,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 def synthetic_observation(
     *,
     image_keys: Sequence[str],
-    state_key: str = "observation/state",
+    state_key: Optional[str] = None,
+    prompt_key: str = "prompt",
     height: int = 256,
     width: int = 256,
     state_dim: int = 8,
@@ -42,12 +43,17 @@ def synthetic_observation(
     convention, and every caller here can read the real ones off the policy
     (``policy.image_keys`` / ``policy.state_key``). A helper that guessed them
     would drift from whatever the policy is actually serving.
+
+    ``state_key`` is ``None`` by default for the same reason, and ``None`` is
+    also what a policy that *drops* state publishes — so no state is put in the
+    dict, which is exactly what such a policy reads.
     """
     rng = np.random.default_rng(seed)
     observation: Dict[str, Any] = {
         key: rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
         for key in image_keys
     }
-    observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
-    observation["prompt"] = prompt
+    if state_key is not None:
+        observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
+    observation[prompt_key] = prompt
     return observation

--- a/python/apxinf/examples/autopolicy_infer.py
+++ b/python/apxinf/examples/autopolicy_infer.py
@@ -44,7 +44,7 @@ def main() -> None:
     try:
         print("dispatched model_type:", policy.metadata.get("model_type"))
 
-        observation = synthetic_observation(image_keys=policy.image_keys)
+        observation = synthetic_observation(image_keys=policy.image_keys, state_key=policy.state_key)
         result = policy.infer(observation)
 
         actions = result["actions"]

--- a/python/apxinf/examples/openpi_client.py
+++ b/python/apxinf/examples/openpi_client.py
@@ -52,9 +52,11 @@ def main() -> None:
 
     observation = synthetic_observation(
         # The wire contract comes from the server, not from a constant here —
-        # hardcoding keys is the mismatch that shows up as "bad accuracy".
+        # hardcoding keys is the mismatch that shows up as "bad accuracy". A
+        # null state_key means the server drops state, so none is sent.
         image_keys=metadata["image_keys"],
         state_key=metadata["state_key"],
+        prompt_key=metadata.get("prompt_key", "prompt"),
         prompt=args.prompt,
     )
     response = client.infer(observation)

--- a/python/apxinf/examples/openpi_client.py
+++ b/python/apxinf/examples/openpi_client.py
@@ -50,7 +50,13 @@ def main() -> None:
     metadata = client.get_server_metadata()
     print("server metadata:", metadata)
 
-    observation = synthetic_observation(prompt=args.prompt)
+    observation = synthetic_observation(
+        # The wire contract comes from the server, not from a constant here —
+        # hardcoding keys is the mismatch that shows up as "bad accuracy".
+        image_keys=metadata["image_keys"],
+        state_key=metadata["state_key"],
+        prompt=args.prompt,
+    )
     response = client.infer(observation)
 
     actions = np.asarray(response["actions"], dtype=np.float32)

--- a/python/apxinf/examples/openpi_server.py
+++ b/python/apxinf/examples/openpi_server.py
@@ -31,6 +31,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--precision", choices=("auto", "fp8", "bf16", "int8"), default="bf16")
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--action-dim", type=int, default=7, help="0 keeps the full vector")
+    parser.add_argument(
+        "--image-keys",
+        default=None,
+        help=(
+            "comma-separated camera wire keys, in model view-slot order. Omitted, "
+            "the policy names them after its own view slots (base_0_rgb, ...) — a "
+            "real deployment states its robot's keys, or uses --robot on "
+            "scripts/pi05_openpi_websocket_server.py, which has the preset table."
+        ),
+    )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     return parser.parse_args()
@@ -45,6 +55,11 @@ def main() -> None:
         device=args.device,
         precision=args.precision,
         action_dim=(args.action_dim or None),
+        image_keys=(
+            tuple(key.strip() for key in args.image_keys.split(",") if key.strip())
+            if args.image_keys
+            else None
+        ),
         # Extra metadata is sent to the client on connect (get_server_metadata).
         metadata={"protocol": "openpi.websocket_policy", "precision": args.precision},
     )

--- a/python/apxinf/examples/pi05policy_infer.py
+++ b/python/apxinf/examples/pi05policy_infer.py
@@ -49,7 +49,7 @@ def main() -> None:
     try:
         print("metadata:", policy.metadata)
 
-        observation = synthetic_observation(image_keys=policy.image_keys)
+        observation = synthetic_observation(image_keys=policy.image_keys, state_key=policy.state_key)
         result = policy.infer(observation)
 
         actions = result["actions"]

--- a/python/apxinf/tests/test_checkpoint_layout.py
+++ b/python/apxinf/tests/test_checkpoint_layout.py
@@ -1,0 +1,401 @@
+"""Checkpoint layout detection: which format, and which files it implies.
+
+Offline and dependency-free — no torch, no CUDA, no real checkpoint. The
+``metadata.pt`` fixtures are built by hand because that is precisely the claim
+under test: ``torch.save``'s modern format is a zip whose ``<archive>/data.pkl``
+member is an ordinary pickle, so the standard library can read one. If that ever
+stops being true these tests fail rather than the field.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pickle
+import zipfile
+from collections import Counter, OrderedDict
+from pathlib import Path
+
+import pytest
+
+from apxinf.checkpoints import (
+    LEROBOT,
+    OPENPI_PYTORCH,
+    CheckpointError,
+    MetadataError,
+    detect_checkpoint,
+    read_metadata_pt,
+    require_norm_stats,
+    resolve_tokenizer,
+    train_config_facts,
+)
+
+STATS = {"actions": {"q01": [-1.0] * 16, "q99": [1.0] * 16}, "state": {"q01": [0.0] * 16, "q99": [1.0] * 16}}
+
+
+def write_metadata_pt(path: Path, payload) -> Path:
+    """Write ``payload`` the way ``torch.save`` does: a zip around one pickle."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("metadata/data.pkl", pickle.dumps(payload, protocol=2))
+        archive.writestr("metadata/version", "3\n")
+    return path
+
+
+def openpi_payload(
+    *,
+    asset_id="groundwire",
+    repo_id=None,
+    images=("cam_high", "cam_left_wrist", "cam_right_wrist"),
+    **model_overrides,
+):
+    """A payload shaped like a real openpi ``TrainConfig`` dump."""
+    model = {
+        "action_dim": 32,
+        "action_horizon": 50,
+        "max_token_len": 200,
+        "discrete_state_input": True,
+        "pi05": True,
+        "paligemma_variant": "gemma_2b",
+        "action_expert_variant": "gemma_300m",
+    }
+    model.update(model_overrides)
+    return {
+        "global_step": 14002,
+        "timestamp": "2025-07-27T17:01:00",
+        "config": {
+            "exp_name": "pi05_UnitreeG1_groundwire",
+            "model": model,
+            "data": {
+                "repo_id": repo_id,
+                "assets": {"assets_dir": "/mnt/a/yehua/yangqi/UnitreeG1/", "asset_id": asset_id},
+                "adapt_to_pi": True,
+                "use_delta_joint_actions": True,
+                "default_prompt": "",
+                "repack_transforms": {
+                    "inputs": [
+                        {
+                            "structure": {
+                                "images": {key: f"observation.images.{key}" for key in images},
+                                "state": "observation.state",
+                            }
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+
+def openpi_dir(root: Path, *, stats_at=None, **kwargs) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model.safetensors").write_bytes(b"")
+    write_metadata_pt(root / "metadata.pt", openpi_payload(**kwargs))
+    if stats_at is not None:
+        target = root / stats_at
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(STATS))
+    return root
+
+
+def lerobot_dir(root: Path, *, stats=True) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model.safetensors").write_bytes(b"")
+    (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 50}))
+    if stats:
+        (root / "norm_stats.json").write_text(json.dumps(STATS))
+    return root
+
+
+# --- the torch-free metadata.pt reader -------------------------------------
+
+
+def test_reads_a_torch_style_zip_without_torch(tmp_path):
+    path = write_metadata_pt(tmp_path / "metadata.pt", openpi_payload())
+    payload = read_metadata_pt(path)
+    assert payload["global_step"] == 14002
+    assert payload["config"]["model"]["action_horizon"] == 50
+
+
+def test_ordered_dict_survives_but_other_classes_are_stubbed(tmp_path):
+    """Container types on the allowlist are real; everything else is inert."""
+    path = write_metadata_pt(
+        tmp_path / "metadata.pt", {"ordered": OrderedDict(a=1), "counter": Counter("aab")}
+    )
+    payload = read_metadata_pt(path)
+    assert payload["ordered"] == OrderedDict(a=1)
+    assert not isinstance(payload["counter"], Counter)
+
+
+def test_builtins_are_not_blanket_allowed():
+    """``builtins.eval`` must not resolve: this parses untrusted checkpoints.
+
+    The allowlist is ``(module, name)`` pairs rather than module names for
+    exactly this reason — ``collections`` and ``builtins`` both contain harmless
+    container types *and* a route to arbitrary execution.
+    """
+    import io
+
+    from apxinf.checkpoints.metadata import _RestrictedUnpickler
+
+    unpickler = _RestrictedUnpickler(io.BytesIO(b""))
+    for module, name in (("builtins", "eval"), ("builtins", "exec"), ("os", "system")):
+        resolved = unpickler.find_class(module, name)
+        assert resolved is not eval and callable(resolved)
+        assert resolved().__class__.__name__ == name  # an inert stub instance
+
+    # The container types that *are* allowed still come back for real.
+    assert unpickler.find_class("collections", "OrderedDict") is OrderedDict
+
+
+def test_non_zip_file_is_reported_not_crashed(tmp_path):
+    path = tmp_path / "metadata.pt"
+    path.write_bytes(b"not a zip at all")
+    with pytest.raises(MetadataError, match="not a zip-format torch archive"):
+        read_metadata_pt(path)
+
+
+def test_missing_config_key_is_reported(tmp_path):
+    path = write_metadata_pt(tmp_path / "metadata.pt", {"global_step": 1})
+    with pytest.raises(MetadataError, match="no 'config' dict"):
+        train_config_facts(read_metadata_pt(path))
+
+
+# --- fact extraction --------------------------------------------------------
+
+
+def test_architecture_is_extracted_in_config_json_vocabulary(tmp_path):
+    facts = train_config_facts(openpi_payload())
+    assert facts["arch"] == {
+        "action_dim": 32,
+        "action_horizon": 50,
+        "max_token_len": 200,
+        "num_views": 3,  # counted from the repack image structure
+        "discrete_state_input": True,
+    }
+    # Upstream openpi does not serialize num_steps, and asserting a value the
+    # checkpoint never stated would present the loader's default as a fact.
+    assert "num_flow_steps" not in facts["arch"]
+
+
+def test_unnamed_cameras_leave_num_views_to_the_loader():
+    """RLinf's shape: a TrainConfig with no repack image structure at all."""
+    facts = train_config_facts(openpi_payload(images=()))
+    assert facts["image_keys"] == ()
+    assert "num_views" not in facts["arch"]
+
+
+def test_fork_specific_num_steps_wins_over_the_default():
+    facts = train_config_facts(openpi_payload(num_steps=5, action_horizon=5))
+    assert facts["arch"]["num_flow_steps"] == 5
+    assert facts["arch"]["action_horizon"] == 5
+
+
+def test_asset_id_comes_from_assets_then_repo_id():
+    explicit = train_config_facts(openpi_payload(asset_id="groundwire", repo_id="x/y"))
+    assert (explicit["asset_id"], explicit["asset_id_source"]) == (
+        "groundwire",
+        "data.assets.asset_id",
+    )
+
+    # openpi: `asset_id = data.assets.asset_id or data.repo_id`.
+    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="RLinf/pick_red"))
+    assert (fallback["asset_id"], fallback["asset_id_source"]) == (
+        "RLinf/pick_red",
+        "data.repo_id",
+    )
+
+
+def test_deployment_facts_are_carried_through():
+    facts = train_config_facts(openpi_payload())
+    assert facts["image_keys"] == ("cam_high", "cam_left_wrist", "cam_right_wrist")
+    assert facts["state_key"] == "observation.state"
+    assert facts["adapt_to_pi"] is True
+    assert facts["use_delta_joint_actions"] is True
+    assert facts["exp_name"] == "pi05_UnitreeG1_groundwire"
+    assert facts["global_step"] == 14002
+
+
+def test_a_pi0_checkpoint_is_refused():
+    with pytest.raises(MetadataError, match="pi05=False"):
+        train_config_facts(openpi_payload(pi05=False))
+
+
+def test_an_unsupported_backbone_is_refused():
+    with pytest.raises(MetadataError, match="paligemma_variant"):
+        train_config_facts(openpi_payload(paligemma_variant="gemma_2b_lora"))
+
+
+# --- format detection -------------------------------------------------------
+
+
+def test_openpi_export_is_detected_from_metadata_pt(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    layout = detect_checkpoint(root)
+    assert layout.format == OPENPI_PYTORCH
+    assert layout.asset_id == "groundwire"
+    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+    assert json.loads(layout.config_json_text())["num_views"] == 3
+
+
+def test_lerobot_directory_is_detected_from_config_json(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt")
+    layout = detect_checkpoint(root)
+    assert layout.format == LEROBOT
+    assert layout.norm_stats == root / "norm_stats.json"
+    # No architecture override: the Rust loader reads config.json itself, which
+    # is what LeRobot checkpoints already did.
+    assert layout.config_json_text() is None
+
+
+def test_metadata_pt_outranks_a_stale_config_json(tmp_path):
+    """The customer's directory shape: real metadata.pt, hand-added config.json."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 10}))
+
+    layout = detect_checkpoint(root)
+    assert layout.format == OPENPI_PYTORCH
+    assert json.loads(layout.config_json_text())["action_horizon"] == 50
+    assert any("config.json is ignored" in note for note in layout.notes)
+
+
+def test_neither_layout_names_both_requirements(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    with pytest.raises(CheckpointError) as excinfo:
+        detect_checkpoint(root)
+    message = str(excinfo.value)
+    assert "metadata.pt" in message and "config.json" in message
+
+
+def test_pinned_format_does_not_fall_back_to_sniffing(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt")
+    with pytest.raises(CheckpointError, match="metadata.pt does not"):
+        detect_checkpoint(root, checkpoint_format=OPENPI_PYTORCH)
+
+
+# --- norm_stats resolution --------------------------------------------------
+
+
+def test_slashed_asset_id_becomes_nested_directories(tmp_path):
+    """RLinf's shape: no asset_id, so openpi falls back to repo_id 'org/name'."""
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        asset_id=None,
+        repo_id="RLinf/pick_red",
+        stats_at="assets/RLinf/pick_red/norm_stats.json",
+    )
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats == root / "assets/RLinf/pick_red/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+
+
+def test_asset_path_without_the_assets_prefix_is_accepted(tmp_path):
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        asset_id=None,
+        repo_id="RLinf/pick_red",
+        stats_at="RLinf/pick_red/norm_stats.json",
+    )
+    assert detect_checkpoint(root).norm_stats == root / "RLinf/pick_red/norm_stats.json"
+
+
+def test_root_fallback_is_used_and_logged(tmp_path, caplog):
+    """The decision: keep reading the root file, but never do it silently."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="norm_stats.json")
+    with caplog.at_level(logging.WARNING, logger="apxinf.checkpoints"):
+        layout = detect_checkpoint(root)
+
+    assert layout.norm_stats == root / "norm_stats.json"
+    assert layout.norm_stats_is_fallback is True
+    message = caplog.text
+    assert "assets/groundwire/norm_stats.json" in message  # the path that missed
+    assert str(root / "norm_stats.json") in message  # the one actually used
+    assert "groundwire" in message  # the asset_id, so the ask is actionable
+
+
+def test_the_asset_path_wins_over_a_root_file(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    (root / "norm_stats.json").write_text(json.dumps(STATS))
+
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+    assert any("is ignored" in note for note in layout.notes)
+
+
+def test_explicit_path_outranks_every_convention(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    elsewhere = tmp_path / "elsewhere" / "norm_stats.json"
+    elsewhere.parent.mkdir()
+    elsewhere.write_text(json.dumps(STATS))
+
+    assert detect_checkpoint(root, norm_stats=elsewhere).norm_stats == elsewhere
+
+
+def test_explicit_asset_id_overrides_metadata(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/other/norm_stats.json")
+    layout = detect_checkpoint(root, asset_id="other")
+    assert layout.norm_stats == root / "assets/other/norm_stats.json"
+    assert layout.asset_id_source == "explicit override"
+
+
+def test_a_traversing_asset_id_is_refused(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", asset_id="../../etc")
+    with pytest.raises(CheckpointError, match="not a usable relative path"):
+        detect_checkpoint(root)
+
+
+def test_missing_stats_is_deferred_not_raised_by_detection(tmp_path):
+    """preflight reports all findings at once, so detection must not crash."""
+    root = openpi_dir(tmp_path / "ckpt")
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats is None
+    assert len(layout.norm_stats_tried) == 3
+
+
+def test_require_norm_stats_names_every_path_and_the_asset_id(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt")
+    with pytest.raises(CheckpointError) as excinfo:
+        require_norm_stats(detect_checkpoint(root))
+    message = str(excinfo.value)
+    for candidate in ("assets/groundwire/norm_stats.json", "groundwire/norm_stats.json"):
+        assert str(root / candidate) in message
+    assert "train_pytorch.py" in message  # where the file comes from
+
+
+def test_lerobot_error_explains_where_lerobot_keeps_statistics(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt", stats=False)
+    with pytest.raises(CheckpointError) as excinfo:
+        require_norm_stats(detect_checkpoint(root))
+    message = str(excinfo.value)
+    assert "normalizer_processor.safetensors" in message
+    assert "meta/stats.json" in message
+
+
+# --- tokenizer --------------------------------------------------------------
+
+
+def test_tokenizer_resolution_order(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    (root / "paligemma_tokenizer.model").write_bytes(b"sp")
+    elsewhere = tmp_path / "shared.model"
+    elsewhere.write_bytes(b"sp")
+
+    assert resolve_tokenizer(root, elsewhere) == elsewhere
+    assert resolve_tokenizer(root, env={"APXINF_TOKENIZER": str(elsewhere)}) == elsewhere
+    assert resolve_tokenizer(root, env={}) == root / "paligemma_tokenizer.model"
+
+
+def test_tokenizer_error_says_where_to_get_the_file(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    with pytest.raises(CheckpointError) as excinfo:
+        resolve_tokenizer(root, env={})
+    message = str(excinfo.value)
+    assert "gs://big_vision/paligemma_tokenizer.model" in message
+    assert "APXINF_TOKENIZER" in message
+    assert str(root / "paligemma_tokenizer.model") in message

--- a/python/apxinf/tests/test_checkpoint_layout.py
+++ b/python/apxinf/tests/test_checkpoint_layout.py
@@ -44,7 +44,7 @@ def write_metadata_pt(path: Path, payload) -> Path:
 
 def openpi_payload(
     *,
-    asset_id="groundwire",
+    asset_id="example-asset",
     repo_id=None,
     images=("cam_high", "cam_left_wrist", "cam_right_wrist"),
     **model_overrides,
@@ -64,11 +64,11 @@ def openpi_payload(
         "global_step": 14002,
         "timestamp": "2025-07-27T17:01:00",
         "config": {
-            "exp_name": "pi05_UnitreeG1_groundwire",
+            "exp_name": "pi05_unitree_g1_example",
             "model": model,
             "data": {
                 "repo_id": repo_id,
-                "assets": {"assets_dir": "/mnt/a/yehua/yangqi/UnitreeG1/", "asset_id": asset_id},
+                "assets": {"assets_dir": "/data/train-assets/", "asset_id": asset_id},
                 "adapt_to_pi": True,
                 "use_delta_joint_actions": True,
                 "default_prompt": "",
@@ -179,7 +179,7 @@ def test_architecture_is_extracted_in_config_json_vocabulary(tmp_path):
 
 
 def test_unnamed_cameras_leave_num_views_to_the_loader():
-    """RLinf's shape: a TrainConfig with no repack image structure at all."""
+    """A TrainConfig whose repack transform names no cameras at all."""
     facts = train_config_facts(openpi_payload(images=()))
     assert facts["image_keys"] == ()
     assert "num_views" not in facts["arch"]
@@ -192,16 +192,16 @@ def test_fork_specific_num_steps_wins_over_the_default():
 
 
 def test_asset_id_comes_from_assets_then_repo_id():
-    explicit = train_config_facts(openpi_payload(asset_id="groundwire", repo_id="x/y"))
+    explicit = train_config_facts(openpi_payload(asset_id="example-asset", repo_id="x/y"))
     assert (explicit["asset_id"], explicit["asset_id_source"]) == (
-        "groundwire",
+        "example-asset",
         "data.assets.asset_id",
     )
 
     # openpi: `asset_id = data.assets.asset_id or data.repo_id`.
-    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="RLinf/pick_red"))
+    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="some-org/some-task"))
     assert (fallback["asset_id"], fallback["asset_id_source"]) == (
-        "RLinf/pick_red",
+        "some-org/some-task",
         "data.repo_id",
     )
 
@@ -212,7 +212,7 @@ def test_deployment_facts_are_carried_through():
     assert facts["state_key"] == "observation.state"
     assert facts["adapt_to_pi"] is True
     assert facts["use_delta_joint_actions"] is True
-    assert facts["exp_name"] == "pi05_UnitreeG1_groundwire"
+    assert facts["exp_name"] == "pi05_unitree_g1_example"
     assert facts["global_step"] == 14002
 
 
@@ -230,11 +230,11 @@ def test_an_unsupported_backbone_is_refused():
 
 
 def test_openpi_export_is_detected_from_metadata_pt(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     layout = detect_checkpoint(root)
     assert layout.format == OPENPI_PYTORCH
-    assert layout.asset_id == "groundwire"
-    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.asset_id == "example-asset"
+    assert layout.norm_stats == root / "assets/example-asset/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
     assert json.loads(layout.config_json_text())["num_views"] == 3
 
@@ -250,8 +250,8 @@ def test_lerobot_directory_is_detected_from_config_json(tmp_path):
 
 
 def test_metadata_pt_outranks_a_stale_config_json(tmp_path):
-    """The customer's directory shape: real metadata.pt, hand-added config.json."""
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    """A shipped directory shape: real metadata.pt, hand-added config.json."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 10}))
 
     layout = detect_checkpoint(root)
@@ -280,15 +280,15 @@ def test_pinned_format_does_not_fall_back_to_sniffing(tmp_path):
 
 
 def test_slashed_asset_id_becomes_nested_directories(tmp_path):
-    """RLinf's shape: no asset_id, so openpi falls back to repo_id 'org/name'."""
+    """No asset_id, so openpi falls back to repo_id, which is 'org/name'."""
     root = openpi_dir(
         tmp_path / "ckpt",
         asset_id=None,
-        repo_id="RLinf/pick_red",
-        stats_at="assets/RLinf/pick_red/norm_stats.json",
+        repo_id="some-org/some-task",
+        stats_at="assets/some-org/some-task/norm_stats.json",
     )
     layout = detect_checkpoint(root)
-    assert layout.norm_stats == root / "assets/RLinf/pick_red/norm_stats.json"
+    assert layout.norm_stats == root / "assets/some-org/some-task/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
 
 
@@ -296,10 +296,10 @@ def test_asset_path_without_the_assets_prefix_is_accepted(tmp_path):
     root = openpi_dir(
         tmp_path / "ckpt",
         asset_id=None,
-        repo_id="RLinf/pick_red",
-        stats_at="RLinf/pick_red/norm_stats.json",
+        repo_id="some-org/some-task",
+        stats_at="some-org/some-task/norm_stats.json",
     )
-    assert detect_checkpoint(root).norm_stats == root / "RLinf/pick_red/norm_stats.json"
+    assert detect_checkpoint(root).norm_stats == root / "some-org/some-task/norm_stats.json"
 
 
 def test_root_fallback_is_used_and_logged(tmp_path, caplog):
@@ -311,23 +311,23 @@ def test_root_fallback_is_used_and_logged(tmp_path, caplog):
     assert layout.norm_stats == root / "norm_stats.json"
     assert layout.norm_stats_is_fallback is True
     message = caplog.text
-    assert "assets/groundwire/norm_stats.json" in message  # the path that missed
+    assert "assets/example-asset/norm_stats.json" in message  # the path that missed
     assert str(root / "norm_stats.json") in message  # the one actually used
-    assert "groundwire" in message  # the asset_id, so the ask is actionable
+    assert "example-asset" in message  # the asset_id, so the ask is actionable
 
 
 def test_the_asset_path_wins_over_a_root_file(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     (root / "norm_stats.json").write_text(json.dumps(STATS))
 
     layout = detect_checkpoint(root)
-    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats == root / "assets/example-asset/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
     assert any("is ignored" in note for note in layout.notes)
 
 
 def test_explicit_path_outranks_every_convention(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     elsewhere = tmp_path / "elsewhere" / "norm_stats.json"
     elsewhere.parent.mkdir()
     elsewhere.write_text(json.dumps(STATS))
@@ -361,7 +361,7 @@ def test_require_norm_stats_names_every_path_and_the_asset_id(tmp_path):
     with pytest.raises(CheckpointError) as excinfo:
         require_norm_stats(detect_checkpoint(root))
     message = str(excinfo.value)
-    for candidate in ("assets/groundwire/norm_stats.json", "groundwire/norm_stats.json"):
+    for candidate in ("assets/example-asset/norm_stats.json", "example-asset/norm_stats.json"):
         assert str(root / candidate) in message
     assert "train_pytorch.py" in message  # where the file comes from
 
@@ -399,3 +399,148 @@ def test_tokenizer_error_says_where_to_get_the_file(tmp_path):
     assert "gs://big_vision/paligemma_tokenizer.model" in message
     assert "APXINF_TOKENIZER" in message
     assert str(root / "paligemma_tokenizer.model") in message
+
+
+# --- the wiring into Pi05Policy.from_pretrained -----------------------------
+#
+# Detection is only worth anything if what it resolves reaches the loader. An
+# openpi export has no config.json, so before this the Rust side fell back to
+# Pi05Config::default() without a word — a checkpoint with a 50-step horizon
+# would have been served at whatever the default happened to be.
+
+
+class _FakeModel:
+    action_horizon = 50
+    action_dim = 32
+    num_views = 3
+    image_size = 224
+    max_token_len = 200
+
+    def reset_sampling(self, seed=None):
+        pass
+
+
+def _load_with_fake_binding(monkeypatch, model_dir, **kwargs):
+    """Run ``from_pretrained`` against a stub binding; return the load kwargs."""
+    import sys
+    import types
+
+    from apxinf.policies.impls import pi05
+
+    captured = {}
+
+    class FakeBindingModel:
+        @staticmethod
+        def load(*args, **load_kwargs):
+            captured.update(load_kwargs)
+            captured["positional"] = args
+            return _FakeModel()
+
+    class FakePipeline:
+        names = []
+
+        def __getitem__(self, name):
+            raise KeyError(name)
+
+    monkeypatch.setitem(sys.modules, "apxinf_py", types.SimpleNamespace(Model=FakeBindingModel))
+    monkeypatch.setattr(pi05, "resolve_pi05_tactics", lambda *a, **k: None)
+    monkeypatch.setattr(pi05, "PromptTokenizer", lambda *a, **k: object())
+    monkeypatch.setattr(
+        pi05.Pi05Policy, "default_pipelines", classmethod(
+            lambda cls, *a, **k: (FakePipeline(), FakePipeline())
+        )
+    )
+    (Path(model_dir) / "paligemma_tokenizer.model").write_bytes(b"sp")
+    pi05.Pi05Policy.from_pretrained(model_dir, device="cuda:0", precision="bf16", **kwargs)
+    return captured
+
+
+def test_metadata_pt_architecture_reaches_the_rust_loader(tmp_path, monkeypatch):
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        stats_at="assets/example-asset/norm_stats.json",
+        action_horizon=50,
+    )
+
+    captured = _load_with_fake_binding(monkeypatch, root, action_dim=16, discrete_state=False)
+
+    config = json.loads(captured["config_json"])
+    assert config["action_horizon"] == 50
+    assert config["action_dim"] == 32
+    assert config["num_views"] == 3
+
+
+def test_a_lerobot_directory_still_lets_the_loader_read_config_json(tmp_path, monkeypatch):
+    """No ``config_json=``: the Rust loader reads config.json itself, as before."""
+    root = lerobot_dir(tmp_path / "ckpt")
+
+    captured = _load_with_fake_binding(monkeypatch, root, action_dim=16, discrete_state=False)
+
+    assert "config_json" not in captured
+
+
+def test_the_asset_path_statistics_are_the_ones_loaded(tmp_path, monkeypatch):
+    """A wrong root file next to correct asset statistics — the delivered shape."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
+    (root / "norm_stats.json").write_text(
+        json.dumps({"actions": {"q01": [-1.0] * 7, "q99": [1.0] * 7}})
+    )
+
+    from apxinf.policies.impls import pi05
+
+    seen = {}
+    original = pi05.Unnormalizer.from_norm_stats
+
+    def spy(*args, **kwargs):
+        seen.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(pi05.Unnormalizer, "from_norm_stats", spy)
+    _load_with_fake_binding(monkeypatch, root, discrete_state=False)
+
+    assert seen["path"] == root / "assets" / "example-asset" / "norm_stats.json"
+
+
+def test_a_flat_directory_loads_with_no_layout_at_all(tmp_path, monkeypatch):
+    """The hand-assembled layout that predates this module must keep working."""
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    (root / "norm_stats.json").write_text(json.dumps(STATS))
+
+    captured = _load_with_fake_binding(monkeypatch, root, discrete_state=False)
+
+    assert "config_json" not in captured
+
+
+def test_explicit_norm_stats_needs_no_layout(tmp_path, monkeypatch):
+    """``--norm-stats`` names one file; it does not assert a directory shape."""
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    elsewhere = tmp_path / "stats.json"
+    elsewhere.write_text(json.dumps(STATS))
+
+    from apxinf.policies.impls import pi05
+
+    seen = {}
+    original = pi05.Unnormalizer.from_norm_stats
+    monkeypatch.setattr(
+        pi05.Unnormalizer,
+        "from_norm_stats",
+        lambda *a, **k: (seen.update(k), original(*a, **k))[1],
+    )
+    _load_with_fake_binding(monkeypatch, root, discrete_state=False, norm_stats=elsewhere)
+
+    assert seen["path"] == elsewhere
+
+
+def test_a_missing_explicit_norm_stats_path_is_refused(tmp_path, monkeypatch):
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+
+    with pytest.raises(CheckpointError, match="does not exist"):
+        _load_with_fake_binding(
+            monkeypatch, root, discrete_state=False, norm_stats=tmp_path / "nope.json"
+        )

--- a/python/apxinf/tests/test_lerobot_adapter.py
+++ b/python/apxinf/tests/test_lerobot_adapter.py
@@ -23,7 +23,12 @@ from apxinf.adapters.lerobot import (
     IdentityProcessor,
     observation_to_apxinf,
 )
-from apxinf.processors import ProcessorStep, PromptTokenizer, Unnormalizer
+from apxinf.processors import (
+    GaussianNoise,
+    ProcessorStep,
+    PromptTokenizer,
+    Unnormalizer,
+)
 
 HORIZON = 10
 MODEL_DIM = 32
@@ -78,6 +83,12 @@ def build_policy() -> Pi05Policy:
         unnormalizer=Unnormalizer(
             q01=[-1.0] * LIBERO_DIM, q99=[1.0] * LIBERO_DIM, dims=LIBERO_DIM, eps=0.0
         ),
+        # Host-side noise, which the mock echoes back as the chunk. The queueing
+        # tests below need two things this gives them: rows that differ from each
+        # other (so "did the queue advance?" is answerable) and an RNG that moves
+        # per call (so "was it re-inferred?" is answerable). Without it the mock
+        # returns a constant chunk and those assertions cannot fail.
+        noise=GaussianNoise(HORIZON, MODEL_DIM, seed=0),
         image_keys=APXINF_KEYS,
     )
     return Pi05Policy(

--- a/python/apxinf/tests/test_normalize_golden.py
+++ b/python/apxinf/tests/test_normalize_golden.py
@@ -19,9 +19,12 @@ def ref_unnormalize(normalized: np.ndarray, q01: np.ndarray, q99: np.ndarray) ->
 
 
 def ref_digitize(state: np.ndarray) -> np.ndarray:
-    # NumPy digitize(state, linspace(-1, 1, 257)[:-1]) - 1, with saturation.
+    # Verbatim from openpi models/tokenizer.py. Note there is NO lower clamp:
+    # digitize returns 0 for v < -1, so the bin is -1 and openpi puts that
+    # straight into the prompt. An earlier version of this helper clipped to
+    # [0, 255], which made the test agree with a wrong implementation.
     edges = np.linspace(-1.0, 1.0, 257)[:-1]
-    return np.clip(np.digitize(state, edges) - 1, 0, 255).astype(np.uint8)
+    return (np.digitize(state, edges) - 1).astype(np.int16)
 
 
 @pytest.fixture
@@ -71,8 +74,36 @@ def test_mean_std_roundtrip():
 
 def test_wrong_last_dim_raises(quantiles):
     q01, q99 = quantiles
+    # Narrower than the stats is a genuine mismatch on both steps...
     with pytest.raises(ValueError):
-        Unnormalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM + 1), dtype=np.float32))
+        Unnormalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM - 1), dtype=np.float32))
+    with pytest.raises(ValueError):
+        Normalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM - 1), dtype=np.float32))
+    # ...and so is a *wider* array on the input side, where openpi's Normalize
+    # would broadcast-fail too. Only Unnormalizer widens; see below.
+    with pytest.raises(ValueError):
+        Normalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM + 1), dtype=np.float32))
+
+
+def test_unnormalize_passes_a_wider_array_s_tail_through(quantiles):
+    """openpi ``Unnormalize._unnormalize_quantile``'s narrow-stats branch.
+
+    A checkpoint's ``norm_stats`` is the robot's width (16 for a Unitree G1)
+    while the model emits its padded width (32), so without this the G1 path
+    cannot serve a real ``norm_stats.json`` at all.
+    """
+    q01, q99 = quantiles
+    pad = 4
+    rng = np.random.default_rng(5)
+    wide = rng.uniform(-1.0, 1.0, size=(3, LIBERO_DIM + pad)).astype(np.float32)
+
+    got = Unnormalizer(q01=q01, q99=q99)(wide)
+
+    assert got.shape == wide.shape
+    # The head is unnormalized exactly as if the tail were not there...
+    np.testing.assert_array_equal(got[:, :LIBERO_DIM], Unnormalizer(q01=q01, q99=q99)(wide[:, :LIBERO_DIM]))
+    # ...and the tail is copied verbatim, not scaled by some implied identity.
+    np.testing.assert_array_equal(got[:, LIBERO_DIM:], wide[:, LIBERO_DIM:])
 
 
 def test_discretize_matches_numpy_digitize():
@@ -81,8 +112,36 @@ def test_discretize_matches_numpy_digitize():
     np.testing.assert_array_equal(discretize_state(state), ref_digitize(state))
 
 
-def test_discretize_saturates_out_of_range():
-    state = np.array([-5.0, -1.0, 0.0, 0.99999, 1.0, 5.0], dtype=np.float32)
+def test_discretize_underflows_signed_and_saturates_high():
+    # Under -1 openpi emits -1, not 0: that token is in the training distribution.
+    state = np.array([-5.0, -1.0000001, -1.0, 0.0, 0.99999, 1.0, 5.0], dtype=np.float64)
     out = discretize_state(state)
-    assert out[0] == 0 and out[-1] == 255
-    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out, ref_digitize(state))
+    np.testing.assert_array_equal(out, [-1, -1, 0, 128, 255, 255, 255])
+    assert out.dtype == np.int16
+
+
+def test_discretize_matches_digitize_on_bin_edges():
+    edges = np.linspace(-1.0, 1.0, 257)[:-1]
+    for probe in (edges, edges - 1e-9, edges + 1e-9):
+        np.testing.assert_array_equal(discretize_state(probe), ref_digitize(probe))
+
+
+def test_discretize_matches_digitize_one_ulp_from_every_edge():
+    """The ±1e-9 probe above is ~10 million ulps wide and misses the real trap.
+
+    ``floor((v + 1.0) * 128.0)`` -- the obvious way to write this -- is not equal
+    to ``digitize``. For a value one ulp below an edge in ``[-1, -0.5)``, adding
+    ``1.0`` moves it into a binade with twice the ulp, the sum rounds *up* onto
+    the edge, and the index comes out one bin high. One bin is a different prompt
+    string, hence different token ids, hence a different rollout.
+    """
+    edges = np.linspace(-1.0, 1.0, 257)[:-1]
+    for probe in (np.nextafter(edges, -np.inf), np.nextafter(edges, np.inf)):
+        np.testing.assert_array_equal(discretize_state(probe), ref_digitize(probe))
+
+    # The one f64 value that the arithmetic form gets wrong, pinned by name.
+    trap = np.nextafter(-0.4921875, -np.inf)
+    assert np.floor((trap + 1.0) * 128.0) == 65, "the trap this test guards"
+    assert discretize_state([trap])[0] == 64
+    np.testing.assert_array_equal(discretize_state([trap]), ref_digitize(np.array([trap])))

--- a/python/apxinf/tests/test_policy_layering.py
+++ b/python/apxinf/tests/test_policy_layering.py
@@ -270,7 +270,9 @@ def test_reorder_independent_pre_steps_is_identical():
 
     model, in_pipe, out_pipe = make_parts()
     reordered = in_pipe.reorder(["tokenize", "image_stack"])
-    policy = Pi05Policy(model, input_pipeline=reordered, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=reordered, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     np.testing.assert_array_equal(policy.infer(obs)["actions"], baseline)
 
 
@@ -286,7 +288,9 @@ def test_insert_passthrough_step_does_not_change_result():
 
     model, in_pipe, out_pipe = make_parts()
     injected = in_pipe.insert_after("image_stack", ("noop", Passthrough()))
-    policy = Pi05Policy(model, input_pipeline=injected, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=injected, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     assert policy.metadata["input_pipeline"] == ["image_stack", "noop", "tokenize"]
     np.testing.assert_array_equal(policy.infer(obs)["actions"], baseline)
 
@@ -298,8 +302,11 @@ def test_explicit_host_sampler_remains_pluggable():
         tokenizer=ConstTokenizer(),
         unnormalizer=make_quantile_unnormalizer(),
         noise=GaussianNoise(HORIZON, MODEL_DIM, seed=7),
+        image_keys=DEFAULT_KEYS,
     )
-    policy = Pi05Policy(model, input_pipeline=in_pipe, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=in_pipe, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     assert policy.metadata["input_pipeline"] == ["image_stack", "tokenize", "sample_noise"]
     result = policy.infer(make_obs())
     assert result["noise"] is not None
@@ -312,7 +319,9 @@ def test_default_vs_explicitly_built_pipeline_are_bit_identical():
     default = build_policy().infer(obs)
 
     model, in_pipe, out_pipe = make_parts()
-    explicit = Pi05Policy(model, input_pipeline=in_pipe, output_pipeline=out_pipe).infer(obs)
+    explicit = Pi05Policy(
+        model, input_pipeline=in_pipe, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    ).infer(obs)
     np.testing.assert_array_equal(default["actions"], explicit["actions"])
     np.testing.assert_array_equal(default["normalized_actions"], explicit["normalized_actions"])
     np.testing.assert_array_equal(default["token_ids"], explicit["token_ids"])

--- a/python/apxinf/tests/test_tactics.py
+++ b/python/apxinf/tests/test_tactics.py
@@ -94,11 +94,16 @@ class Pi05TacticSelectionTest(unittest.TestCase):
             "default_pipelines",
             return_value=(FakePipeline(), FakePipeline()),
         ):
+            # A real (empty) file: the tokenizer path is checked for existence
+            # now, so a typo'd --tokenizer fails at load instead of inside
+            # SentencePiece. PromptTokenizer itself is mocked out here.
+            tokenizer_path = pathlib.Path(model_dir) / "paligemma_tokenizer.model"
+            tokenizer_path.write_bytes(b"")
             pi05.Pi05Policy.from_pretrained(
                 model_dir,
                 device="cuda:0",
                 precision="bf16",
-                tokenizer_path="unused-tokenizer.model",
+                tokenizer_path=str(tokenizer_path),
             )
 
         resolve.assert_called_once_with(

--- a/scripts/eval_libero.py
+++ b/scripts/eval_libero.py
@@ -52,6 +52,13 @@ from PIL import Image
 
 # --- rollout protocol constants (OpenPI's public PI0.5 LIBERO configuration) ---
 LIBERO_ACTION_DIM = 7
+
+#: LIBERO's camera wire keys, in model view-slot order. Stated here because the
+#: policy layer no longer defaults to them: these are a *dataset* convention, and
+#: a default in the model layer silently applied them to every checkpoint. The
+#: same pair is what the ``franka_libero`` preset serves.
+LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+LIBERO_STATE_KEY = "observation/state"
 MAX_STEPS = 520
 WAIT_STEPS = 10
 REPLAN_STEPS = 5
@@ -289,9 +296,9 @@ def _observation(base, wrist, state, prompt) -> dict:
     """The OpenPI LIBERO observation both backends consume, identical on the wire
     and in-process."""
     return {
-        "observation/image": base,
-        "observation/wrist_image": wrist,
-        "observation/state": state,
+        LIBERO_IMAGE_KEYS[0]: base,
+        LIBERO_IMAGE_KEYS[1]: wrist,
+        LIBERO_STATE_KEY: state,
         "prompt": prompt,
     }
 
@@ -377,6 +384,10 @@ class InProcessBackend:
             action_horizon=args.action_horizon,
             seed=args.seed,
             discrete_state=args.discrete_state,
+            # LIBERO's wire keys, stated rather than inherited: the policy layer
+            # holds no dataset's convention as a default.
+            image_keys=LIBERO_IMAGE_KEYS,
+            state_key=LIBERO_STATE_KEY,
             metadata={"precision": args.precision, "policy": "libero"},
         )
         self.metadata = dict(getattr(self._policy, "metadata", {}))

--- a/scripts/eval_libero.py
+++ b/scripts/eval_libero.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import functools
 import json
 import math
 import os
@@ -53,12 +54,10 @@ from PIL import Image
 # --- rollout protocol constants (OpenPI's public PI0.5 LIBERO configuration) ---
 LIBERO_ACTION_DIM = 7
 
-#: LIBERO's camera wire keys, in model view-slot order. Stated here because the
-#: policy layer no longer defaults to them: these are a *dataset* convention, and
-#: a default in the model layer silently applied them to every checkpoint. The
-#: same pair is what the ``franka_libero`` preset serves.
-LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
-LIBERO_STATE_KEY = "observation/state"
+#: The preset whose wire contract this evaluator drives. The keys themselves are
+#: *not* restated here: they are read from the table below, so the evaluator and
+#: the server cannot drift into two different dialects of "LIBERO".
+LIBERO_PRESET = "franka_libero"
 MAX_STEPS = 520
 WAIT_STEPS = 10
 REPLAN_STEPS = 5
@@ -74,6 +73,28 @@ ALL_SUITES = (
 )
 
 LedgerKey = Tuple[str, int, int]  # (suite, task_id, trial_id)
+
+
+def _add_apxinf_to_path() -> None:
+    """Make ``import apxinf`` work from a source checkout, idempotently."""
+    package_dir = pathlib.Path(__file__).resolve().parents[1] / "python" / "apxinf"
+    if package_dir.is_dir() and str(package_dir) not in sys.path:
+        sys.path.insert(0, str(package_dir))
+
+
+@functools.lru_cache(maxsize=1)
+def libero_convention():
+    """LIBERO's wire dialect, read from the preset table rather than restated.
+
+    Both backends send the same observation, so both resolve it here: the keys
+    the evaluator writes are by construction the keys ``--robot franka_libero``
+    serves. Importing ``apxinf`` costs no CUDA (the binding is loaded lazily by
+    ``from_pretrained``), so the websocket backend pays nothing for this.
+    """
+    _add_apxinf_to_path()
+    from apxinf import get_robot_preset
+
+    return get_robot_preset(LIBERO_PRESET).convention
 
 
 # --- LIBERO harness (inlined; was scripts/libero_harness.py) ------------------
@@ -294,12 +315,13 @@ class Backend(Protocol):
 
 def _observation(base, wrist, state, prompt) -> dict:
     """The OpenPI LIBERO observation both backends consume, identical on the wire
-    and in-process."""
+    and in-process. Keys come from the preset table, not from constants here."""
+    convention = libero_convention()
     return {
-        LIBERO_IMAGE_KEYS[0]: base,
-        LIBERO_IMAGE_KEYS[1]: wrist,
-        LIBERO_STATE_KEY: state,
-        "prompt": prompt,
+        convention.image_keys[0]: base,
+        convention.image_keys[1]: wrist,
+        convention.state_key: state,
+        convention.prompt_key: prompt,
     }
 
 
@@ -362,14 +384,12 @@ class InProcessBackend:
     """
 
     def __init__(self, args: argparse.Namespace) -> None:
-        # Lazy: importing apxinf pulls in the CUDA binding; websocket-only users
+        # Lazy: importing apxinf pulls in the policy stack; websocket-only users
         # never pay for it. Make ``import apxinf`` work from a source checkout.
-        repo_root = pathlib.Path(__file__).resolve().parents[1]
-        package_dir = repo_root / "python" / "apxinf"
-        if package_dir.is_dir() and str(package_dir) not in sys.path:
-            sys.path.insert(0, str(package_dir))
+        _add_apxinf_to_path()
         from apxinf import AutoPolicy
 
+        convention = libero_convention()
         self._policy = AutoPolicy.from_pretrained(
             args.model_dir,
             model_type=args.model_type,
@@ -384,10 +404,13 @@ class InProcessBackend:
             action_horizon=args.action_horizon,
             seed=args.seed,
             discrete_state=args.discrete_state,
-            # LIBERO's wire keys, stated rather than inherited: the policy layer
-            # holds no dataset's convention as a default.
-            image_keys=LIBERO_IMAGE_KEYS,
-            state_key=LIBERO_STATE_KEY,
+            # LIBERO's wire keys, read from the ``franka_libero`` preset rather
+            # than restated: the policy layer holds no dataset's convention as a
+            # default, and this evaluator should not become a second source of
+            # truth for what "LIBERO keys" means.
+            image_keys=convention.image_keys,
+            state_key=convention.state_key,
+            prompt_key=convention.prompt_key,
             metadata={"precision": args.precision, "policy": "libero"},
         )
         self.metadata = dict(getattr(self._policy, "metadata", {}))

--- a/scripts/g1_adapter_smoke.py
+++ b/scripts/g1_adapter_smoke.py
@@ -30,7 +30,6 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 
 from apxinf import build_unitree_g1_policy  # noqa: E402
 from apxinf.processors import Unnormalizer  # noqa: E402
-from apxinf.processors.transforms import Unnormalize  # noqa: E402
 from apxinf.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY  # noqa: E402
 
 
@@ -47,20 +46,17 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Full-model-width identity unnormalizer: [50,32] passes through unchanged so
-    # the 32->16 robot truncation and delta->absolute run on the raw model output.
-    identity = None  # built after we know the model width
-
-    # Build once to learn the model width, then rebuild with a matching identity.
-    # (Cheap: model load dominates; we load a single time by peeking metadata.)
+    # Load the handle first so the identity unnormalizer can be built at the
+    # model's own width: [50,32] then passes through unchanged, so delta->absolute
+    # and the 32->16 robot truncation run on the raw model output.
     import apxinf_py
 
     model = apxinf_py.Model.load(
         "pi05", str(args.model_dir / "model.safetensors"), device=args.device, precision=args.precision
     )
     width = model.action_dim
-    identity = Unnormalize(
-        Unnormalizer(mean=np.zeros(width, np.float32), std=np.ones(width, np.float32), mode="mean_std")
+    identity = Unnormalizer(
+        mean=np.zeros(width, np.float32), std=np.ones(width, np.float32), mode="mean_std"
     )
 
     policy = build_unitree_g1_policy(
@@ -69,7 +65,7 @@ def main():
         use_delta_joint_actions=True,
         adapt_to_pi=True,
         state_key=G1_STATE_KEY,
-        unnormalizer=identity,
+        unnormalizer=identity,  # injected into the model's own unnormalize step
         precision=args.precision,
         device=args.device,
         metadata={"config": "pi05_UnitreeG1_groundwire", "note": "stand-in ckpt, shape-only"},

--- a/scripts/g1_adapter_smoke.py
+++ b/scripts/g1_adapter_smoke.py
@@ -29,8 +29,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import build_unitree_g1_policy  # noqa: E402
+from apxinf.conventions import UNITREE_G1 as G1_KEYS  # noqa: E402
 from apxinf.processors import Unnormalizer  # noqa: E402
-from apxinf.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY  # noqa: E402
 
 
 def parse_args():
@@ -64,7 +64,8 @@ def main():
         model=model,  # reuse the already-loaded handle
         use_delta_joint_actions=True,
         adapt_to_pi=True,
-        state_key=G1_STATE_KEY,
+        state_key=G1_KEYS.state_key,
+        image_keys=G1_KEYS.image_keys,
         unnormalizer=identity,  # injected into the model's own unnormalize step
         precision=args.precision,
         device=args.device,
@@ -86,13 +87,13 @@ def main():
     # level under "images", state flat. The policy's image_keys are the paths
     # ("images/cam_high"), which lookup_key walks into this dict.
     groups: dict = {}
-    for key in G1_CAMERAS:
+    for key in G1_KEYS.image_keys:
         group, _, camera = key.partition("/")
         assert camera, f"expected a nested camera path, got {key!r}"
         groups.setdefault(group, {})[camera] = cam()
     observation = dict(groups)
-    observation[G1_STATE_KEY] = rng.standard_normal(16).astype(np.float32)
-    observation["prompt"] = args.prompt
+    observation[G1_KEYS.state_key] = rng.standard_normal(16).astype(np.float32)
+    observation[G1_KEYS.prompt_key] = args.prompt
 
     out = policy.infer(observation)
     actions = np.asarray(out["actions"])

--- a/scripts/openpi_metadata_to_apxinf.py
+++ b/scripts/openpi_metadata_to_apxinf.py
@@ -2,7 +2,7 @@
 """Read an openpi checkpoint's own ``metadata.pt`` and say what apxinf must run.
 
 openpi keeps the serving contract in a Python registry: ``serve_policy.py
---policy.config pi05_UnitreeG1_groundwire`` selects a ``TrainConfig``, and that
+--policy.config <TrainConfig name>`` selects a ``TrainConfig``, and that
 object decides the wire keys, the delta convention, the state handling and the
 action width. When a checkpoint is exported, openpi serializes that
 ``TrainConfig`` into ``metadata.pt`` — so the checkpoint carries its own answer to
@@ -28,11 +28,12 @@ checkpoint. The value here is the assertion, not the transcription.
 
 Usage::
 
-    python scripts/openpi_metadata_to_apxinf.py --model-dir ~/airs/airs-model --robot unitree_g1
+    python scripts/openpi_metadata_to_apxinf.py --model-dir CKPT_DIR --robot unitree_g1
 
 Exit status is 1 when any check is fatal, so it can gate a deployment.
-``metadata.pt`` is optional: without it (or without torch) the checkpoint-
-directory checks still run and the openpi cross-check is reported as skipped.
+``metadata.pt`` is optional: without it the checkpoint-directory checks still run
+and the openpi cross-check is reported as skipped. Nothing here needs torch, CUDA
+or a loaded weight -- it is a seconds-long, laptop-runnable check.
 """
 
 from __future__ import annotations
@@ -47,6 +48,12 @@ _APXINF_PKG = _REPO_ROOT / "python" / "apxinf"
 if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
+from apxinf.checkpoints import (  # noqa: E402
+    FORMATS as CHECKPOINT_FORMATS,
+    MetadataError,
+    read_metadata_pt,
+    repack_structure,
+)
 from apxinf.robots.preflight import (  # noqa: E402
     FAIL,
     INFO,
@@ -65,42 +72,25 @@ from apxinf.robots.presets import (  # noqa: E402
 def load_train_config(model_dir: pathlib.Path):
     """Return openpi's serialized ``TrainConfig`` dict, or ``(None, reason)``.
 
-    ``metadata.pt`` is a torch pickle of nested plain dicts plus a couple of
-    openpi/flax sentinel objects, so unpickling needs those packages importable.
-    Both failure modes -- no file, no torch -- are expected in the field and are
-    reported rather than raised: the directory checks are still worth running.
+    Read through :func:`apxinf.checkpoints.read_metadata_pt`, which parses the
+    torch archive with the standard library alone. That matters here: this script
+    is meant to run on a laptop, before anything heavy is installed, and
+    ``metadata.pt`` is 30 kB of nested dicts — needing torch to see them made the
+    check skippable exactly when it was most useful. A missing or unparseable
+    file is still reported rather than raised, because the directory checks are
+    worth running either way.
     """
     path = model_dir / "metadata.pt"
     if not path.exists():
         return None, f"{path} not present (apxinf does not require it)"
     try:
-        import torch
-    except ImportError:
-        return None, "torch is not installed, so metadata.pt cannot be unpickled"
-    try:
-        # weights_only=False: this is a config object graph, not tensors.
-        payload = torch.load(path, map_location="cpu", weights_only=False)
-    except Exception as exc:  # noqa: BLE001 - any unpickle failure is the same story
-        return None, f"{type(exc).__name__}: {exc} (openpi may need to be importable)"
-    config = payload.get("config") if isinstance(payload, dict) else None
+        payload = read_metadata_pt(path)
+    except MetadataError as exc:
+        return None, str(exc)
+    config = payload.get("config")
     if not isinstance(config, dict):
         return None, f"metadata.pt has no 'config' dict (keys: {sorted(payload)})"
     return config, ""
-
-
-def _repack_structure(data: dict) -> dict:
-    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
-
-    openpi's repack transform is written *inbound*: ``{wire_key: dataset_column}``.
-    Its keys are therefore exactly what the client puts on the network, which is
-    what an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
-    """
-    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
-    for entry in inputs:
-        structure = entry.get("structure") if isinstance(entry, dict) else None
-        if isinstance(structure, dict):
-            return structure
-    return {}
 
 
 def compare_to_preset(config: dict, robot: str) -> list:
@@ -108,7 +98,7 @@ def compare_to_preset(config: dict, robot: str) -> list:
     preset = get_robot_preset(robot)
     model = config.get("model") or {}
     data = config.get("data") or {}
-    structure = _repack_structure(data)
+    structure = repack_structure(data)
     out = []
 
     exp = config.get("exp_name") or config.get("name")
@@ -174,8 +164,9 @@ def compare_to_preset(config: dict, robot: str) -> list:
                     WARN,
                     label,
                     f"metadata.pt says {value}, apxinf's pi05 path assumes {ours}",
-                    "apxinf reads the real value from config.json at load time; this "
-                    "only flags that the assumption baked into the preset is stale",
+                    "apxinf reads the real value from the checkpoint at load time "
+                    "(config.json, or metadata.pt for an openpi export); this only "
+                    "flags that the assumption baked into the preset is stale",
                 )
             )
         else:
@@ -219,7 +210,7 @@ def compare_to_preset(config: dict, robot: str) -> list:
     if prompt is not None:
         out.append(Finding(INFO, "default_prompt", repr(prompt)))
 
-    # --- where the *real* norm_stats live, which is the A1 question.
+    # --- where the *real* norm_stats live, which is the whole question.
     assets = data.get("assets") or {}
     asset_id, assets_dir = assets.get("asset_id"), assets.get("assets_dir")
     if asset_id or assets_dir:
@@ -266,17 +257,28 @@ def describe_launch(config: dict, robot: str, model_dir: pathlib.Path) -> str:
     return " \\\n".join(flags) + "\n\n" + note
 
 
-def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
+def _check_lerobot_config(model_dir: pathlib.Path, robot: str, *, authoritative: bool) -> list:
     """Flag a ``config.json`` that describes a different robot than the weights.
 
-    apxinf loads the model shape from this file, so a stale one is not inert: its
-    ``input_features`` decide ``num_views``. Its ``observation.state`` /
-    ``action`` shapes are not read by apxinf at all, which is exactly why a wrong
-    one survives -- but they are the loudest available signal that the file was
-    copied from a different training run.
+    ``authoritative`` says whether apxinf will actually load the model shape from
+    this file. For a LeRobot directory it will, so a stale ``input_features``
+    silently decides ``num_views``. For an openpi export ``metadata.pt`` wins and
+    the file is inert — but a config.json describing a *different* robot sitting
+    next to the weights is still the loudest available signal that the directory
+    was assembled from more than one training run, which is exactly how a wrong
+    ``norm_stats.json`` gets in.
     """
     path = model_dir / "config.json"
     if not path.exists():
+        if not authoritative:
+            return [
+                Finding(
+                    INFO,
+                    "config.json",
+                    "absent, as an openpi PyTorch export always is; the architecture "
+                    "comes from metadata.pt",
+                )
+            ]
         return [Finding(WARN, "config.json", f"missing from {model_dir}")]
     try:
         config = json.loads(path.read_text())
@@ -290,11 +292,15 @@ def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
     if views and views != preset.num_views:
         out.append(
             Finding(
-                FAIL,
+                FAIL if authoritative else WARN,
                 "config.json num_views",
                 f"{views} VISUAL features, preset {robot!r} sends {preset.num_views}",
                 "apxinf reads the view count from this file, so it decides how many "
-                "camera slots the model has. Pass --num-views to serve fewer.",
+                "camera slots the model has. Pass --num-views to serve fewer."
+                if authoritative
+                else "metadata.pt outranks this file for an openpi export, so this "
+                "does not decide the view count -- but it says the file came from "
+                "another run, so treat everything else in the directory the same way.",
             )
         )
     else:
@@ -342,6 +348,14 @@ def main() -> int:
     )
     parser.add_argument("--norm-key", default="actions")
     parser.add_argument("--tokenizer", type=pathlib.Path, default=None)
+    parser.add_argument(
+        "--ckpt-format",
+        choices=CHECKPOINT_FORMATS,
+        default="auto",
+        help="how to read the directory; must match what the server will be given",
+    )
+    parser.add_argument("--asset-id", default=None)
+    parser.add_argument("--norm-stats", type=pathlib.Path, default=None)
     parser.add_argument("--action-dim", type=int, default=None)
     parser.add_argument(
         "--discrete-state", dest="discrete_state", action="store_true", default=None
@@ -362,9 +376,18 @@ def main() -> int:
             discrete_state=args.discrete_state,
             action_dim=args.action_dim,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
         )
     )
-    findings += _check_lerobot_config(model_dir, args.robot)
+    findings += _check_lerobot_config(
+        model_dir,
+        args.robot,
+        # metadata.pt outranks config.json, so the file only decides the
+        # architecture when there is no metadata.pt to outrank it.
+        authoritative=not (model_dir / "metadata.pt").is_file(),
+    )
 
     config, reason = load_train_config(model_dir)
     if config is None:

--- a/scripts/openpi_metadata_to_apxinf.py
+++ b/scripts/openpi_metadata_to_apxinf.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Read an openpi checkpoint's own ``metadata.pt`` and say what apxinf must run.
+
+openpi keeps the serving contract in a Python registry: ``serve_policy.py
+--policy.config pi05_UnitreeG1_groundwire`` selects a ``TrainConfig``, and that
+object decides the wire keys, the delta convention, the state handling and the
+action width. When a checkpoint is exported, openpi serializes that
+``TrainConfig`` into ``metadata.pt`` — so the checkpoint carries its own answer to
+"how must this be served", and nothing reads it.
+
+apxinf's equivalent is a ``--robot`` preset, which is a *hand* transcription of
+the same facts. This script closes the loop: it reads ``metadata.pt``, prints the
+apxinf launch command it implies, and diffs every field against the preset the
+operator named. Then it runs the checkpoint-directory checks from
+:mod:`apxinf.robots.preflight` (norm_stats widths, tokenizer) on top.
+
+Why this exists: the delivered configuration was a Unitree G1 checkpoint served
+with LIBERO norm_stats and ``--action-dim 7``. Nothing errored. The weights
+loaded, the tokenizer ran, the unnormalizer found quantiles of *some* width, and
+the robot got seven plausible floats per step that meant nothing. Every one of
+those facts contradicts ``metadata.pt``, which says 16-dim G1, three cameras,
+delta joint actions, discretized state. This script prints that contradiction in
+one screen.
+
+It does *not* generate a config file. apxinf's counterpart to ``TrainConfig`` is
+``robots/presets.py`` plus a builder — code, reviewed once, not generated per
+checkpoint. The value here is the assertion, not the transcription.
+
+Usage::
+
+    python scripts/openpi_metadata_to_apxinf.py --model-dir ~/airs/airs-model --robot unitree_g1
+
+Exit status is 1 when any check is fatal, so it can gate a deployment.
+``metadata.pt`` is optional: without it (or without torch) the checkpoint-
+directory checks still run and the openpi cross-check is reported as skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_APXINF_PKG = _REPO_ROOT / "python" / "apxinf"
+if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
+    sys.path.insert(0, str(_APXINF_PKG))
+
+from apxinf.robots.preflight import (  # noqa: E402
+    FAIL,
+    INFO,
+    WARN,
+    Finding,
+    check_checkpoint,
+    format_findings,
+)
+from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_PRESETS,
+    available_robots,
+    get_robot_preset,
+)
+
+
+def load_train_config(model_dir: pathlib.Path):
+    """Return openpi's serialized ``TrainConfig`` dict, or ``(None, reason)``.
+
+    ``metadata.pt`` is a torch pickle of nested plain dicts plus a couple of
+    openpi/flax sentinel objects, so unpickling needs those packages importable.
+    Both failure modes -- no file, no torch -- are expected in the field and are
+    reported rather than raised: the directory checks are still worth running.
+    """
+    path = model_dir / "metadata.pt"
+    if not path.exists():
+        return None, f"{path} not present (apxinf does not require it)"
+    try:
+        import torch
+    except ImportError:
+        return None, "torch is not installed, so metadata.pt cannot be unpickled"
+    try:
+        # weights_only=False: this is a config object graph, not tensors.
+        payload = torch.load(path, map_location="cpu", weights_only=False)
+    except Exception as exc:  # noqa: BLE001 - any unpickle failure is the same story
+        return None, f"{type(exc).__name__}: {exc} (openpi may need to be importable)"
+    config = payload.get("config") if isinstance(payload, dict) else None
+    if not isinstance(config, dict):
+        return None, f"metadata.pt has no 'config' dict (keys: {sorted(payload)})"
+    return config, ""
+
+
+def _repack_structure(data: dict) -> dict:
+    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
+
+    openpi's repack transform is written *inbound*: ``{wire_key: dataset_column}``.
+    Its keys are therefore exactly what the client puts on the network, which is
+    what an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
+    """
+    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
+    for entry in inputs:
+        structure = entry.get("structure") if isinstance(entry, dict) else None
+        if isinstance(structure, dict):
+            return structure
+    return {}
+
+
+def compare_to_preset(config: dict, robot: str) -> list:
+    """Diff openpi's own TrainConfig against the named apxinf preset."""
+    preset = get_robot_preset(robot)
+    model = config.get("model") or {}
+    data = config.get("data") or {}
+    structure = _repack_structure(data)
+    out = []
+
+    exp = config.get("exp_name") or config.get("name")
+    if exp:
+        out.append(Finding(INFO, "metadata.pt", f"exp_name={exp!r}, serving as --robot {robot}"))
+
+    # --- cameras: count and, where openpi names them, the keys themselves.
+    images = structure.get("images")
+    if isinstance(images, dict):
+        openpi_keys = tuple(images)
+        preset_keys = tuple(key.split("/")[-1] for key in preset.image_keys)
+        if openpi_keys == preset_keys:
+            out.append(
+                Finding(INFO, "cameras", f"{len(openpi_keys)} views {list(openpi_keys)}, match")
+            )
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    "cameras",
+                    f"openpi sends {list(openpi_keys)}, preset {robot!r} expects "
+                    f"{list(preset_keys)}",
+                    "camera keys are order-significant -- entry i fills model view "
+                    "slot i. A mismatch either drops a camera or feeds the wrong one "
+                    "to a slot, and neither raises. Fix the preset's slots.",
+                )
+            )
+    else:
+        out.append(Finding(WARN, "cameras", "metadata.pt has no repack image structure"))
+
+    # --- state: is it sent at all, and does apxinf discretize it the same way?
+    discrete = model.get("discrete_state_input")
+    if discrete is not None:
+        if bool(discrete) == preset.discrete_state:
+            out.append(Finding(INFO, "discrete_state", f"{bool(discrete)}, match"))
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    "discrete_state",
+                    f"checkpoint trained with discrete_state_input={bool(discrete)}, "
+                    f"preset {robot!r} serves {preset.discrete_state}",
+                    "with it off the model receives no proprioception at all (state is "
+                    "dropped, not merely left continuous) and any delta->absolute "
+                    "output step silently becomes a no-op",
+                )
+            )
+
+    # --- widths. action_dim here is the *model's* padded width (32); the robot's
+    #     physical width is not in metadata.pt -- it is in the norm_stats, which
+    #     the directory check covers.
+    for field, ours, label in (
+        ("action_dim", 32, "model action width"),
+        ("action_horizon", None, "action horizon"),
+        ("max_token_len", 200, "max token len"),
+    ):
+        value = model.get(field)
+        if value is None:
+            continue
+        if ours is not None and value != ours:
+            out.append(
+                Finding(
+                    WARN,
+                    label,
+                    f"metadata.pt says {value}, apxinf's pi05 path assumes {ours}",
+                    "apxinf reads the real value from config.json at load time; this "
+                    "only flags that the assumption baked into the preset is stale",
+                )
+            )
+        else:
+            out.append(Finding(INFO, label, str(value)))
+
+    # --- the two robot conventions the G1 output chain implements.
+    for field, label, why in (
+        (
+            "adapt_to_pi",
+            "adapt_to_pi",
+            "the joint-flip / gripper decode+encode steps; off means raw robot space",
+        ),
+        (
+            "use_delta_joint_actions",
+            "use_delta_joint_actions",
+            "whether the model emits joint deltas that must have the current state "
+            "added back. Getting this wrong is not subtle in the logs and is "
+            "catastrophic on the robot: absolute targets treated as deltas double "
+            "every joint command.",
+        ),
+    ):
+        value = data.get(field)
+        if value is None:
+            continue
+        wanted = preset.builder_kwargs.get(field)
+        if wanted is None:
+            out.append(Finding(INFO, label, f"metadata.pt={value}; preset does not set it"))
+        elif bool(value) == bool(wanted):
+            out.append(Finding(INFO, label, f"{bool(value)}, match"))
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    label,
+                    f"checkpoint trained with {bool(value)}, preset serves {bool(wanted)}",
+                    why,
+                )
+            )
+
+    prompt = data.get("default_prompt")
+    if prompt is not None:
+        out.append(Finding(INFO, "default_prompt", repr(prompt)))
+
+    # --- where the *real* norm_stats live, which is the A1 question.
+    assets = data.get("assets") or {}
+    asset_id, assets_dir = assets.get("asset_id"), assets.get("assets_dir")
+    if asset_id or assets_dir:
+        out.append(
+            Finding(
+                INFO,
+                "norm_stats source",
+                f"openpi computed them under {assets_dir}{asset_id}/norm_stats.json",
+                "",
+            )
+        )
+
+    # openpi derives the normalization mode from the model type, not from a file:
+    # `use_quantile_norm = model_config.model_type != ModelType.PI0`. pi05 is
+    # therefore always quantile, whatever a LeRobot-style config.json says.
+    if model.get("pi05"):
+        out.append(
+            Finding(INFO, "normalization", "pi05 -> quantile (q01/q99), per openpi's model-type rule")
+        )
+    return out
+
+
+def describe_launch(config: dict, robot: str, model_dir: pathlib.Path) -> str:
+    """The apxinf launch line this checkpoint's own metadata implies."""
+    preset = get_robot_preset(robot)
+    data = config.get("data") or {}
+    model = config.get("model") or {}
+    flags = [
+        "python scripts/pi05_openpi_websocket_server.py",
+        f"  --model-dir {model_dir}",
+        f"  --robot {preset.name}",
+        # bf16 explicitly: --precision auto resolves to int8 on SM87 (Jetson
+        # Orin), which is a different numeric contract than openpi's.
+        "  --precision bf16",
+    ]
+    if model.get("discrete_state_input") and not preset.discrete_state:
+        flags.append("  --discrete-state")
+    note = (
+        f"# metadata.pt: action_horizon={model.get('action_horizon')} "
+        f"adapt_to_pi={data.get('adapt_to_pi')} "
+        f"delta_joints={data.get('use_delta_joint_actions')} "
+        f"discrete_state={model.get('discrete_state_input')}"
+    )
+    return " \\\n".join(flags) + "\n\n" + note
+
+
+def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
+    """Flag a ``config.json`` that describes a different robot than the weights.
+
+    apxinf loads the model shape from this file, so a stale one is not inert: its
+    ``input_features`` decide ``num_views``. Its ``observation.state`` /
+    ``action`` shapes are not read by apxinf at all, which is exactly why a wrong
+    one survives -- but they are the loudest available signal that the file was
+    copied from a different training run.
+    """
+    path = model_dir / "config.json"
+    if not path.exists():
+        return [Finding(WARN, "config.json", f"missing from {model_dir}")]
+    try:
+        config = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        return [Finding(FAIL, "config.json", f"unreadable: {exc}", "fix or re-export")]
+
+    preset = get_robot_preset(robot)
+    out = []
+    features = config.get("input_features") or {}
+    views = sum(1 for f in features.values() if isinstance(f, dict) and f.get("type") == "VISUAL")
+    if views and views != preset.num_views:
+        out.append(
+            Finding(
+                FAIL,
+                "config.json num_views",
+                f"{views} VISUAL features, preset {robot!r} sends {preset.num_views}",
+                "apxinf reads the view count from this file, so it decides how many "
+                "camera slots the model has. Pass --num-views to serve fewer.",
+            )
+        )
+    else:
+        out.append(Finding(INFO, "config.json num_views", str(views)))
+
+    state = (features.get("observation.state") or {}).get("shape")
+    action = ((config.get("output_features") or {}).get("action") or {}).get("shape")
+    for label, shape, expected in (
+        ("observation.state", state, preset.state_dim),
+        ("action", action, preset.action_width),
+    ):
+        if not shape or expected is None:
+            continue
+        got = shape[-1]
+        if got != expected:
+            out.append(
+                Finding(
+                    WARN,
+                    f"config.json {label}",
+                    f"{got}-dim, but preset {robot!r} is a {expected}-dim robot "
+                    f"(repo_id={config.get('repo_id')!r})",
+                    "apxinf does not read these fields, so this cannot break serving "
+                    "on its own -- but a config.json describing a different robot "
+                    "than the weights means the file was copied from another run, "
+                    "and whatever else came with it (norm_stats.json above) is "
+                    "suspect for the same reason",
+                )
+            )
+    return out
+
+
+def main() -> int:
+    robot_help = "\n".join(f"  {p.describe()}" for p in ROBOT_PRESETS.values())
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=f"robot presets (--robot):\n{robot_help}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model-dir", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--robot",
+        default="unitree_g1",
+        choices=available_robots(include_aliases=True),
+        help="the preset the checkpoint would be served under",
+    )
+    parser.add_argument("--norm-key", default="actions")
+    parser.add_argument("--tokenizer", type=pathlib.Path, default=None)
+    parser.add_argument("--action-dim", type=int, default=None)
+    parser.add_argument(
+        "--discrete-state", dest="discrete_state", action="store_true", default=None
+    )
+    parser.add_argument("--no-discrete-state", dest="discrete_state", action="store_false")
+    parser.add_argument("--quiet", action="store_true", help="show only WARN and FAIL")
+    args = parser.parse_args()
+
+    model_dir = args.model_dir
+    if not model_dir.is_dir():
+        parser.error(f"--model-dir {model_dir} is not a directory")
+
+    findings = list(
+        check_checkpoint(
+            model_dir,
+            args.robot,
+            norm_key=args.norm_key,
+            discrete_state=args.discrete_state,
+            action_dim=args.action_dim,
+            tokenizer_path=args.tokenizer,
+        )
+    )
+    findings += _check_lerobot_config(model_dir, args.robot)
+
+    config, reason = load_train_config(model_dir)
+    if config is None:
+        findings.append(
+            Finding(
+                WARN,
+                "metadata.pt",
+                reason,
+                "without it the openpi-side contract (cameras, delta convention, "
+                "discrete state) cannot be cross-checked and has to be trusted",
+            )
+        )
+    else:
+        findings += compare_to_preset(config, args.robot)
+
+    print(f"checkpoint: {model_dir}")
+    print(f"preset:     {get_robot_preset(args.robot).describe()}\n")
+    # Re-sort: check_checkpoint returns sorted, but the metadata.pt and
+    # config.json findings are appended after it. Severity order across the whole
+    # report is what makes it readable at a glance.
+    order = {FAIL: 0, WARN: 1, INFO: 2}
+    findings.sort(key=lambda f: order.get(f.level, 3))
+    print(format_findings(findings, include_info=not args.quiet))
+
+    if config is not None:
+        print("\nimplied launch:\n")
+        print(describe_launch(config, args.robot, model_dir))
+
+    fatal = sum(1 for f in findings if f.level == FAIL)
+    warned = sum(1 for f in findings if f.level == WARN)
+    print(f"\n{fatal} fatal, {warned} warning(s)")
+    return 1 if fatal else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -318,7 +318,10 @@ def main() -> None:
             metadata=metadata,
         )
     # Clients read the served wire contract off this metadata rather than assuming
-    # one: a key mismatch is silent on the wire but visible here.
+    # one: a key mismatch is silent on the wire but visible here. A null state_key
+    # is not a gap — it says this policy drops state, so there is no key to send
+    # one under; rendered as "(dropped)" so the log line cannot read as an omission.
+    served_state_key = policy.metadata["state_key"]
     logging.info(
         "serving robot=%s robot_steps=%s H=%d x D=%d image_keys=%s state=%s "
         "discrete_state=%s",
@@ -327,7 +330,7 @@ def main() -> None:
         policy.metadata["action_horizon"],
         policy.metadata["action_dim"],
         policy.metadata["image_keys"],
-        policy.metadata["state_key"],
+        served_state_key if served_state_key is not None else "(dropped)",
         policy.metadata["discrete_state"],
     )
     server = WebsocketPolicyServer(policy, args.host, args.port)

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -103,7 +103,9 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="serve a checkpoint-free engine with deterministic random weights and "
         "synthetic processors (latency-only; actions are numerically meaningless). "
-        "No --model-dir needed.",
+        "Reproduces --robot's wire keys and view count but not its robot pre/post "
+        "steps, which need a checkpoint; the served metadata says robot_steps=false "
+        "and startup warns per gap. No --model-dir needed.",
     )
     parser.add_argument(
         "--checkpoint",
@@ -234,18 +236,28 @@ def main() -> None:
         # The preset's cameras define the synthetic view count unless --num-views is
         # given explicitly, so --robot alone yields a servable synthetic engine.
         num_views = args.num_views if args.num_views is not None else len(image_keys)
-        # The synthetic tokenizer emits a fixed token stream and never reads state,
-        # so this server cannot reproduce a discrete-state preset. Say so: the
-        # published metadata is the wire contract, and silently serving
-        # discrete_state=False for a preset that declares True is precisely the
-        # mismatch --robot exists to prevent.
-        if discrete_state:
+        # A checkpoint-free engine still serves the preset's *deployable* width, so a
+        # client previews the action shape it will get in production. --action-dim
+        # outranks it (and also sets the synthetic model's own width).
+        model_dim = args.action_dim or 32
+        trim_dim = args.action_dim if args.action_dim is not None else preset.action_dim
+        served_dim = trim_dim or model_dim
+        # The synthetic path reproduces the preset's wire keys and view count and
+        # nothing else: the tokenizer emits a fixed token stream and never reads
+        # state, and preset.builder never runs. The published metadata is the wire
+        # contract, so name every gap and mark robot_steps=False below — silently
+        # serving half an embodiment under its own name is precisely the mismatch
+        # --robot exists to prevent.
+        gaps = preset.synthetic_gaps(
+            discrete_state=discrete_state, served_action_dim=served_dim
+        )
+        if gaps:
             logging.warning(
-                "--random-weights cannot honour %s's discrete_state=True: the "
-                "synthetic tokenizer ignores state, so the served metadata will "
-                "say discrete_state=False. Use a checkpoint to preview the real "
-                "contract.",
+                "--random-weights cannot honour %s: %s. The wire keys and view count "
+                "are real; the action semantics are not. Use a checkpoint to preview "
+                "the full contract.",
                 preset.name,
+                "; ".join(gaps),
             )
         logging.info(
             "serving checkpoint-free %s random-weights engine (views=%d, H=%d, T=%d) "
@@ -262,7 +274,7 @@ def main() -> None:
             num_views=num_views,
             image_size=args.image_size,
             action_horizon=action_horizon,
-            action_dim=(args.action_dim or 32),
+            action_dim=model_dim,
             num_flow_steps=args.num_flow_steps,
             max_token_len=args.max_token_len,
             calibration=calibration,
@@ -272,11 +284,11 @@ def main() -> None:
         policy = Pi05Policy.from_random(
             handle,
             token_count=args.token_count,
-            action_dim=(args.action_dim or None),
+            action_dim=(trim_dim or None),
             seed=args.seed,
             image_keys=image_keys[:num_views],
             state_key=state_key,
-            metadata={**metadata, "robot": preset.name},
+            metadata={**metadata, "robot": preset.name, "robot_steps": False},
         )
     else:
         logging.info(
@@ -308,8 +320,10 @@ def main() -> None:
     # Clients read the served wire contract off this metadata rather than assuming
     # one: a key mismatch is silent on the wire but visible here.
     logging.info(
-        "serving robot=%s H=%d x D=%d image_keys=%s state=%s discrete_state=%s",
+        "serving robot=%s robot_steps=%s H=%d x D=%d image_keys=%s state=%s "
+        "discrete_state=%s",
         policy.metadata.get("robot", preset.name),
+        policy.metadata.get("robot_steps"),
         policy.metadata["action_horizon"],
         policy.metadata["action_dim"],
         policy.metadata["image_keys"],

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -47,6 +47,7 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import Pi05Policy  # noqa: E402
+from apxinf.robots.preflight import FAIL, WARN, check_checkpoint, format_findings  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     available_robots,
@@ -187,6 +188,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--log-level", default="INFO")
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="start even if the checkpoint contradicts the --robot preset. The "
+        "preflight compares norm_stats widths and the tokenizer against the "
+        "preset; every mismatch it reports is one that produces confidently "
+        "wrong actions instead of an error. Use only to reproduce a known-bad "
+        "deployment on purpose.",
+    )
     return parser.parse_args()
 
 
@@ -291,6 +301,34 @@ def main() -> None:
             metadata={**metadata, "robot": preset.name, "robot_steps": False},
         )
     else:
+        # Refuse a checkpoint that contradicts the preset *before* spending a
+        # minute loading 7 GB of weights. A G1 checkpoint served with LIBERO
+        # norm_stats runs to completion and emits actions of the right shape in
+        # the right numeric range that mean nothing -- the only symptom is
+        # "accuracy regressed", which is indistinguishable from a model problem
+        # until someone diffs the two pipelines by hand.
+        findings = check_checkpoint(
+            args.model_dir,
+            preset.name,
+            norm_key=args.norm_key,
+            discrete_state=discrete_state,
+            image_keys=image_keys,
+            action_dim=args.action_dim,
+            tokenizer_path=args.tokenizer,
+        )
+        fatal = [f for f in findings if f.level == FAIL]
+        if fatal and not args.skip_preflight:
+            raise SystemExit(
+                f"preflight: {args.model_dir} does not match --robot {preset.name}\n"
+                + format_findings(findings, include_info=False)
+                + "\n\nPass --skip-preflight to serve it anyway (the actions will be wrong)."
+            )
+        for finding in findings:
+            level = logging.ERROR if finding.level == FAIL else (
+                logging.WARNING if finding.level == WARN else logging.INFO
+            )
+            logging.log(level, "preflight %s", finding)
+
         logging.info(
             "loading %s policy in-process from %s as robot=%s",
             args.precision,

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -47,6 +47,7 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import Pi05Policy  # noqa: E402
+from apxinf.checkpoints import FORMATS as CHECKPOINT_FORMATS  # noqa: E402
 from apxinf.robots.preflight import FAIL, WARN, check_checkpoint, format_findings  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
@@ -115,12 +116,34 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model-type",
-        help="policy model_type; default reads MODEL_DIR/config.json (e.g. pi05)",
+        help="policy model_type; default reads MODEL_DIR/config.json, or metadata.pt "
+        "for an openpi export, which has no config.json (e.g. pi05)",
     )
     parser.add_argument(
         "--tokenizer",
         type=pathlib.Path,
-        help="SentencePiece model (auto-detected under MODEL_DIR by default)",
+        help="SentencePiece model (auto-detected under MODEL_DIR, or APXINF_TOKENIZER)",
+    )
+    parser.add_argument(
+        "--ckpt-format",
+        choices=CHECKPOINT_FORMATS,
+        default="auto",
+        help="how to read MODEL_DIR. 'auto' (default) picks openpi_pytorch when a "
+        "metadata.pt is present and lerobot when a config.json is. Pin it when a "
+        "directory carries both and the wrong one wins.",
+    )
+    parser.add_argument(
+        "--asset-id",
+        default=None,
+        help="override the asset_id the checkpoint names, which is what selects "
+        "assets/<asset_id>/norm_stats.json. For assets reorganized after export.",
+    )
+    parser.add_argument(
+        "--norm-stats",
+        type=pathlib.Path,
+        default=None,
+        help="explicit norm_stats.json, outranking every path convention. Required "
+        "for a LeRobot checkpoint, which ships no such file of its own.",
     )
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument(
@@ -148,8 +171,9 @@ def parse_args() -> argparse.Namespace:
         "--action-horizon",
         type=int,
         default=None,
-        help="chunk length to serve. Default: the checkpoint's config.json value, "
-        "or 50 with --random-weights. An explicit value outranks the checkpoint "
+        help="chunk length to serve. Default: the checkpoint's own value (config.json, "
+        "or metadata.pt for an openpi export), or 50 with --random-weights. An "
+        "explicit value outranks the checkpoint "
         "(the horizon is a sequence length, not a weight dimension).",
     )
     parser.add_argument(
@@ -315,6 +339,9 @@ def main() -> None:
             image_keys=image_keys,
             action_dim=args.action_dim,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
         )
         fatal = [f for f in findings if f.level == FAIL]
         if fatal and not args.skip_preflight:
@@ -350,6 +377,9 @@ def main() -> None:
             calibration=args.calibration,
             tactics=args.tactics,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
             norm_key=args.norm_key,
             action_horizon=args.action_horizon,
             seed=args.seed,

--- a/tests/test_pi05_openpi_websocket.py
+++ b/tests/test_pi05_openpi_websocket.py
@@ -27,6 +27,9 @@ from apxinf.serving.websocket import health_check  # noqa: E402
 HORIZON = 10
 MODEL_DIM = 32
 LIBERO_DIM = 7
+# The wire keys a LIBERO client puts on the socket. The model layer no longer
+# guesses them, so the test has to name them the way a real deployment does.
+LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
 IMAGE_SIZE = 224
 NUM_VIEWS = 2
 
@@ -79,12 +82,16 @@ def build_policy() -> Pi05Policy:
     q99 = q01 + 2
     model = MockModel()
     input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
-        model, tokenizer=ConstTokenizer(), unnormalizer=Unnormalizer(q01=q01, q99=q99)
+        model,
+        tokenizer=ConstTokenizer(),
+        unnormalizer=Unnormalizer(q01=q01, q99=q99),
+        image_keys=LIBERO_IMAGE_KEYS,
     )
     return Pi05Policy(
         model,
         input_pipeline=input_pipeline,
         output_pipeline=output_pipeline,
+        image_keys=LIBERO_IMAGE_KEYS,
         metadata={"precision": "int8", "protocol": "openpi.websocket_policy"},
     )
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import json
 import pathlib
+import pickle
 import sys
 import tempfile
 import unittest
+import zipfile
 
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPOSITORY_ROOT / "python" / "apxinf"))
@@ -63,6 +65,43 @@ class CheckpointFixture:
 
     def write_tokenizer(self, name: str = "paligemma_tokenizer.model") -> "CheckpointFixture":
         (self.path / name).write_bytes(b"not a real sentencepiece model")
+        return self
+
+    def write_weights(self) -> "CheckpointFixture":
+        """An empty ``model.safetensors``; nothing here reads a weight."""
+        (self.path / "model.safetensors").write_bytes(b"")
+        return self
+
+    def write_metadata_pt(self, *, asset_id: str = "example-asset") -> "CheckpointFixture":
+        """Write an openpi-shaped ``metadata.pt`` the way ``torch.save`` does.
+
+        A zip whose ``<archive>/data.pkl`` member is an ordinary pickle — built
+        by hand so these tests need neither torch nor a real checkpoint.
+        """
+        payload = {
+            "global_step": 1,
+            "config": {
+                "exp_name": "pi05_example",
+                "model": {
+                    "action_dim": 32,
+                    "action_horizon": 50,
+                    "max_token_len": 200,
+                    "discrete_state_input": True,
+                    "pi05": True,
+                },
+                "data": {"assets": {"asset_id": asset_id}},
+            },
+        }
+        with zipfile.ZipFile(self.path / "metadata.pt", "w") as archive:
+            archive.writestr("metadata/data.pkl", pickle.dumps(payload, protocol=2))
+            archive.writestr("metadata/version", "3\n")
+        return self
+
+    def write_asset_stats(self, asset_id: str, **entries) -> "CheckpointFixture":
+        """Statistics where openpi actually writes them: ``assets/<asset_id>/``."""
+        target = self.path / "assets" / asset_id / "norm_stats.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({"norm_stats": entries}))
         return self
 
 
@@ -252,6 +291,105 @@ class ReportTest(unittest.TestCase):
 
         self.assertNotIn("[INFO", quiet)
         self.assertIn("[FAIL", quiet)
+
+
+class CheckpointLayoutTest(unittest.TestCase):
+    """An openpi export keeps its statistics under ``assets/<asset_id>/``.
+
+    Reading ``<model_dir>/norm_stats.json`` unconditionally is how a file left
+    behind by an unrelated run got both checked and served. These pin that the
+    preflight now checks the file the loader will actually open.
+    """
+
+    def test_the_asset_path_is_checked_not_the_root_file(self) -> None:
+        # The failure shape: correct statistics where openpi puts them, a
+        # leftover 7-dim LIBERO file in the root. Reading the root one produces
+        # a spurious FAIL here and wrong actions on the robot.
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+        ckpt.write_asset_stats(
+            "example-asset", actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        )
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats["))
+        chosen = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in chosen], [INFO])
+        self.assertIn("assets/example-asset/norm_stats.json", chosen[0].detail)
+
+    def test_the_root_fallback_is_a_warning_not_a_silent_success(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        warned = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in warned], [WARN])
+        # Both paths, so the operator can see what to go and fetch.
+        self.assertIn("assets/example-asset/norm_stats.json", warned[0].detail)
+        self.assertIn(str(ckpt.path / "norm_stats.json"), warned[0].detail)
+
+    def test_absent_statistics_name_every_path_tried(self) -> None:
+        ckpt = CheckpointFixture(self)
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        fatal = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in fatal], [FAIL])
+        self.assertIn("assets/example-asset/norm_stats.json", fatal[0].detail)
+
+    def test_the_layout_and_asset_id_are_reported(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        reported = {f.check: f.detail for f in findings}
+        layout = [f.detail for f in findings if f.check == "checkpoint layout"]
+        self.assertIn("openpi_pytorch", layout[0])
+        self.assertIn("example-asset", reported["asset_id"])
+        # The architecture comes out of metadata.pt, which is the only place an
+        # openpi export states it: no config.json exists to read it from.
+        self.assertIn("action_horizon=50", reported["architecture"])
+
+    def test_a_flat_directory_is_still_checked_the_old_way(self) -> None:
+        """No metadata.pt, no config.json: the hand-assembled layout still loads."""
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats"))
+        self.assertNotIn("checkpoint layout", {f.check for f in findings})
+
+    def test_an_explicit_norm_stats_path_works_without_any_layout(self) -> None:
+        """A flat directory plus --norm-stats: no metadata.pt, no config.json.
+
+        The statistics for a hand-assembled directory often live outside it, so
+        naming the file must not require the directory to declare a layout — and
+        the root file it does have must then be ignored, not checked.
+        """
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+        elsewhere = ckpt.path / "elsewhere.json"
+        elsewhere.write_text(
+            json.dumps({"norm_stats": {"actions": _stats(G1_DIM), "state": _stats(G1_DIM)}})
+        )
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1", norm_stats=elsewhere)
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats"))
+        chosen = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertIn(str(elsewhere), chosen[0].detail)
+
+    def test_a_missing_explicit_norm_stats_path_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(
+            ckpt.path, "unitree_g1", norm_stats=ckpt.path / "nope.json"
+        )
+
+        self.assertEqual(_levels(findings, "norm_stats.json"), [FAIL])
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,258 @@
+"""Startup preflight: does the checkpoint on disk match the preset serving it?
+
+The delivered configuration that motivated :mod:`apxinf.robots.preflight` was a
+Unitree G1 checkpoint (16-DoF, three cameras, delta joint actions) served with a
+LIBERO ``norm_stats.json`` (8-dim state, 7-dim action) and ``--action-dim 7``.
+Every layer accepted it. These tests pin the checks that refuse it, and — just as
+importantly — pin that a *correct* checkpoint produces no fatal finding, so the
+preflight cannot become a thing operators route around with
+``--skip-preflight``.
+
+Runs offline against synthesised checkpoint directories; no CUDA, no weights.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / "python" / "apxinf"))
+
+from apxinf.robots.preflight import (  # noqa: E402
+    FAIL,
+    INFO,
+    WARN,
+    check_checkpoint,
+    format_findings,
+)
+from apxinf.robots.presets import get_robot_preset  # noqa: E402
+
+G1_DIM = 16
+
+
+def _stats(width: int, *, quantiles: bool = True) -> dict:
+    entry = {"mean": [0.0] * width, "std": [1.0] * width}
+    if quantiles:
+        entry["q01"] = [-1.0] * width
+        entry["q99"] = [1.0] * width
+    return entry
+
+
+class CheckpointFixture:
+    """A checkpoint directory with exactly the files the preflight reads."""
+
+    def __init__(self, case: unittest.TestCase, **norm_stats) -> None:
+        self.path = pathlib.Path(tempfile.mkdtemp())
+        case.addCleanup(self._cleanup)
+        if norm_stats:
+            self.write_norm_stats(**norm_stats)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.path, ignore_errors=True)
+
+    def write_norm_stats(self, *, nested: bool = True, **entries) -> "CheckpointFixture":
+        document = {"norm_stats": entries} if nested else entries
+        (self.path / "norm_stats.json").write_text(json.dumps(document))
+        return self
+
+    def write_tokenizer(self, name: str = "paligemma_tokenizer.model") -> "CheckpointFixture":
+        (self.path / name).write_bytes(b"not a real sentencepiece model")
+        return self
+
+
+def _levels(findings, check_prefix: str) -> list:
+    return [f.level for f in findings if f.check.startswith(check_prefix)]
+
+
+class NormStatsWidthTest(unittest.TestCase):
+    """A1: the shipped statistics have to be *this robot's* statistics."""
+
+    def test_libero_stats_under_the_g1_preset_are_fatal(self) -> None:
+        """The exact delivered combination: G1 preset, LIBERO norm_stats."""
+        ckpt = CheckpointFixture(
+            self, actions=_stats(7), state=_stats(8)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        fatal = [f for f in findings if f.level == FAIL]
+        self.assertEqual(len(fatal), 2, format_findings(findings))
+        widths = {f.check for f in fatal}
+        self.assertEqual(
+            widths, {"norm_stats['actions'] width", "norm_stats['state'] width"}
+        )
+        # The remedy has to name the number the operator should be looking for;
+        # "width mismatch" alone sends them to the wrong file.
+        self.assertIn("16", fatal[0].detail + fatal[0].remedy)
+
+    def test_matching_widths_pass(self) -> None:
+        ckpt = CheckpointFixture(
+            self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual([f for f in findings if f.level == FAIL], [], format_findings(findings))
+        self.assertEqual([f for f in findings if f.level == WARN], [])
+
+    def test_libero_preset_checks_its_own_asymmetric_widths(self) -> None:
+        """LIBERO is 8-dim state / 7-dim action; the two are checked separately.
+
+        A single "robot width" field would have to pick one and skip the other,
+        so this pins that the preset carries both.
+        """
+        preset = get_robot_preset("franka_libero")
+        self.assertEqual((preset.state_dim, preset.action_width), (8, 7))
+
+        # LIBERO's default is discrete_state=False, so only "actions" is checked;
+        # turn state injection on and the 8-dim entry has to be there and correct.
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(16)).write_tokenizer()
+        off = check_checkpoint(ckpt.path, "franka_libero")
+        self.assertEqual([f for f in off if f.level == FAIL], [], format_findings(off))
+
+        on = check_checkpoint(ckpt.path, "franka_libero", discrete_state=True)
+        self.assertEqual(_levels(on, "norm_stats['state'] width"), [FAIL])
+
+    def test_flat_norm_stats_layout_is_read_too(self) -> None:
+        """openpi writes ``{"norm_stats": {...}}``; some exports are flat."""
+        ckpt = CheckpointFixture(self)
+        ckpt.write_norm_stats(
+            nested=False, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual([f for f in findings if f.level == FAIL], [], format_findings(findings))
+
+    def test_missing_quantiles_are_fatal_for_pi05(self) -> None:
+        """pi05 always unnormalizes with q01/q99 regardless of any config field."""
+        ckpt = CheckpointFixture(
+            self,
+            actions=_stats(G1_DIM, quantiles=False),
+            state=_stats(G1_DIM),
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "norm_stats['actions'] quantiles"), [FAIL])
+
+    def test_missing_state_entry_is_fatal_only_when_state_is_used(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM)).write_tokenizer()
+
+        used = check_checkpoint(ckpt.path, "unitree_g1")
+        self.assertEqual(_levels(used, "norm_stats['state']"), [FAIL])
+
+        dropped = check_checkpoint(ckpt.path, "unitree_g1", discrete_state=False)
+        self.assertEqual(_levels(dropped, "norm_stats['state']"), [])
+
+    def test_missing_file_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self)
+        ckpt.write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "norm_stats.json"), [FAIL])
+
+
+class TokenizerTest(unittest.TestCase):
+    """A14: openpi downloads its tokenizer at runtime, so exports lack one."""
+
+    def test_absent_tokenizer_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "tokenizer"), [FAIL])
+
+    def test_either_accepted_filename_satisfies_the_check(self) -> None:
+        for name in ("tokenizer.model", "paligemma_tokenizer.model"):
+            with self.subTest(name=name):
+                ckpt = CheckpointFixture(
+                    self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+                ).write_tokenizer(name)
+                findings = check_checkpoint(ckpt.path, "unitree_g1")
+                self.assertEqual(_levels(findings, "tokenizer"), [INFO])
+
+    def test_explicit_path_outranks_the_checkpoint_and_is_itself_checked(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        elsewhere = ckpt.path / "elsewhere.model"
+
+        missing = check_checkpoint(ckpt.path, "unitree_g1", tokenizer_path=elsewhere)
+        self.assertEqual(_levels(missing, "tokenizer"), [FAIL])
+
+        elsewhere.write_bytes(b"x")
+        present = check_checkpoint(ckpt.path, "unitree_g1", tokenizer_path=elsewhere)
+        self.assertEqual(_levels(present, "tokenizer"), [INFO])
+
+
+class OverrideTest(unittest.TestCase):
+    """The flags that turn a correct checkpoint into a wrong deployment."""
+
+    def setUp(self) -> None:
+        self.ckpt = CheckpointFixture(
+            self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+    def test_action_dim_override_that_contradicts_the_robot_warns(self) -> None:
+        """``--action-dim 7`` on a 16-DoF robot: the other half of the delivery."""
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", action_dim=7)
+
+        self.assertEqual(_levels(findings, "action_dim"), [WARN])
+
+    def test_action_dim_matching_the_robot_is_silent(self) -> None:
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", action_dim=G1_DIM)
+
+        self.assertEqual(_levels(findings, "action_dim"), [])
+
+    def test_turning_state_off_on_a_joint_space_robot_warns(self) -> None:
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", discrete_state=False)
+
+        warned = [f for f in findings if f.check == "discrete_state"]
+        self.assertEqual([f.level for f in warned], [WARN])
+        # State is *dropped*, not left continuous — the remedy has to say so,
+        # because "no discrete state" reads like a precision choice.
+        self.assertIn("dropped", warned[0].remedy)
+
+    def test_reordered_camera_keys_warn_even_at_the_right_count(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+        swapped = (preset.image_keys[1], preset.image_keys[0], preset.image_keys[2])
+
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", image_keys=swapped)
+
+        self.assertEqual(_levels(findings, "cameras"), [WARN])
+
+    def test_fewer_cameras_than_the_preset_warns(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", image_keys=preset.image_keys[:2])
+
+        self.assertEqual(_levels(findings, "cameras"), [WARN])
+
+
+class ReportTest(unittest.TestCase):
+    def test_findings_are_sorted_most_severe_first(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1", action_dim=7)
+
+        levels = [f.level for f in findings]
+        self.assertEqual(levels, sorted(levels, key={FAIL: 0, WARN: 1, INFO: 2}.get))
+
+    def test_quiet_rendering_drops_info_but_keeps_problems(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+        quiet = format_findings(findings, include_info=False)
+
+        self.assertNotIn("[INFO", quiet)
+        self.assertIn("[FAIL", quiet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -9,7 +9,10 @@ Three groups:
 * :class:`KeyResolutionTest` — ``lookup_key`` / ``has_key`` / ``set_key``, the
   flat-vs-nested wire layouts (``"observation/image"`` vs
   ``obs["images"]["cam_high"]``).
-* :class:`RobotPresetTest` — the preset table's invariants and overrides.
+* :class:`RobotPresetTest` / :class:`SyntheticContractTest` /
+  :class:`BuildRobotPolicyTest` — the preset table's invariants, its overrides,
+  and the contract it publishes (including what a checkpoint-free server must
+  admit it cannot honour).
 * :class:`UnitreeG1ServingTest` — an **unmodified openpi G1 observation** driven
   through the real websocket transport into a G1-wired policy, asserting camera
   →slot binding, state routing, and the delta→absolute / 32→16 output chain.
@@ -56,6 +59,7 @@ from apxinf.robots.presets import (  # noqa: E402
     VIEW_SLOTS,
     RobotPreset,
     available_robots,
+    build_robot_policy,
     get_robot_preset,
 )
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
@@ -169,6 +173,122 @@ class RobotPresetTest(unittest.TestCase):
             get_robot_preset("g1")
         for name in available_robots(include_aliases=True):
             self.assertIn(name, str(caught.exception))
+
+
+class SyntheticContractTest(unittest.TestCase):
+    """A checkpoint-free server may serve a preset's keys, not its arithmetic.
+
+    ``--random-weights --robot unitree_g1`` runs ``Pi05Policy.from_random``, which
+    never calls ``preset.builder``: the wire keys and view count are real, the
+    action semantics are absent. Publishing the preset name unqualified would be
+    the silent embodiment mismatch ``--robot`` exists to prevent, so every gap is
+    named at startup and ``robot_steps`` goes on the wire.
+    """
+
+    def test_only_a_builder_preset_reports_robot_steps(self) -> None:
+        self.assertFalse(get_robot_preset("franka_libero").has_robot_steps)
+        self.assertTrue(get_robot_preset("unitree_g1").has_robot_steps)
+
+    def test_a_generic_preset_that_drops_state_has_nothing_to_report(self) -> None:
+        preset = get_robot_preset("franka_libero")
+        self.assertEqual(
+            preset.synthetic_gaps(discrete_state=False, served_action_dim=7), ()
+        )
+
+    def test_dropped_state_is_reported_even_for_a_generic_preset(self) -> None:
+        # --discrete-state on franka_libero: the synthetic tokenizer ignores it.
+        preset = get_robot_preset("franka_libero")
+        gaps = preset.synthetic_gaps(discrete_state=True, served_action_dim=7)
+        self.assertEqual(len(gaps), 1)
+        self.assertIn("discrete_state", gaps[0])
+
+    def test_g1_reports_both_its_state_and_its_skipped_steps(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+        gaps = preset.synthetic_gaps(discrete_state=True, served_action_dim=MODEL_DIM)
+        self.assertEqual(len(gaps), 2)
+        joined = " ".join(gaps)
+        self.assertIn("discrete_state", joined)
+        # The gap must name the factory that was skipped and the concrete symptom:
+        # a 32-wide action where the real server truncates to 16.
+        self.assertIn("build_unitree_g1_policy", joined)
+        self.assertIn(str(MODEL_DIM), joined)
+
+    def test_a_preset_whose_builder_owns_no_truncation_omits_the_width_gap(self) -> None:
+        # action_dim set means the width is the preset's, not a skipped step's, so
+        # the synthetic server serves the right one and must not claim otherwise.
+        preset = RobotPreset(
+            name="stub",
+            slots=(("base_0_rgb", "cam"),),
+            state_key="state",
+            action_dim=7,
+            builder=lambda model_dir, **kwargs: None,
+        )
+        gaps = preset.synthetic_gaps(discrete_state=False, served_action_dim=7)
+        self.assertEqual(len(gaps), 1)
+        self.assertNotIn("action_dim", gaps[0])
+
+
+class BuildRobotPolicyTest(unittest.TestCase):
+    """``build_robot_policy`` resolves overrides and publishes the contract."""
+
+    def _register(self, preset: RobotPreset) -> None:
+        ROBOT_PRESETS[preset.name] = preset
+        self.addCleanup(ROBOT_PRESETS.pop, preset.name, None)
+
+    def test_preset_defaults_and_builder_kwargs_reach_the_builder(self) -> None:
+        seen: dict = {}
+        preset = RobotPreset(
+            name="stub_robot",
+            slots=(("base_0_rgb", "cam/high"), ("left_wrist_0_rgb", "cam/wrist")),
+            state_key="joints",
+            action_dim=None,
+            discrete_state=True,
+            builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
+            builder_kwargs={"use_delta_joint_actions": True},
+        )
+        self._register(preset)
+
+        build_robot_policy("stub_robot", "/nowhere", metadata={"precision": "bf16"})
+
+        self.assertEqual(seen["model_dir"], "/nowhere")
+        self.assertEqual(seen["image_keys"], ("cam/high", "cam/wrist"))
+        self.assertEqual(seen["state_key"], "joints")
+        self.assertIsNone(seen["action_dim"])
+        self.assertTrue(seen["discrete_state"])
+        self.assertTrue(seen["use_delta_joint_actions"])
+
+        published = seen["metadata"]
+        self.assertEqual(published["robot"], "stub_robot")
+        # A robot-step preset loaded from a checkpoint gets its arithmetic, so the
+        # flag the synthetic path clears is set here.
+        self.assertTrue(published["robot_steps"])
+        self.assertEqual(
+            published["robot_slots"],
+            [["base_0_rgb", "cam/high"], ["left_wrist_0_rgb", "cam/wrist"]],
+        )
+        self.assertEqual(published["precision"], "bf16")
+
+    def test_overrides_replace_only_the_named_fields(self) -> None:
+        seen: dict = {}
+        preset = RobotPreset(
+            name="stub_generic",
+            slots=(("base_0_rgb", "observation/image"),),
+            state_key="observation/state",
+            action_dim=7,
+            builder=lambda model_dir, **kwargs: seen.update(kwargs),
+        )
+        self._register(preset)
+
+        build_robot_policy(
+            "stub_generic", "/nowhere", image_keys=["rgb/front"], state_key="q"
+        )
+
+        self.assertEqual(seen["image_keys"], ("rgb/front",))
+        self.assertEqual(seen["state_key"], "q")
+        self.assertEqual(seen["action_dim"], 7)
+        # robot_slots reports the *served* keys against the slots they fill, so an
+        # override stays reviewable instead of hiding behind the preset name.
+        self.assertEqual(seen["metadata"]["robot_slots"], [["base_0_rgb", "rgb/front"]])
 
 
 class MockModel:

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -27,9 +27,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import pathlib
 import sys
+import tempfile
 import threading
 import types
 import unittest
@@ -46,7 +48,13 @@ os.environ["no_proxy"] = "127.0.0.1,localhost"
 
 from apxinf import Pi05Policy  # noqa: E402
 from apxinf.policies.base import ComposablePolicy  # noqa: E402
-from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf.processors import (  # noqa: E402
+    Normalizer,
+    Pipeline,
+    ProcessorStep,
+    PromptTokenizer,
+    Unnormalizer,
+)
 from apxinf import conventions as conventions_module  # noqa: E402
 from apxinf.conventions import (  # noqa: E402
     CONVENTIONS,
@@ -1186,6 +1194,157 @@ class StateKeyIsRequiredWhenItIsReadTest(unittest.TestCase):
         )
         self.assertIsNone(stateless.metadata["state_key"])
         self.assertFalse(stateless.metadata["discrete_state"])
+
+
+class NormalizationDtypeTest(unittest.TestCase):
+    """A G1 checkpoint has to be normalized in float64, the way openpi does it.
+
+    openpi parses ``norm_stats.json`` with the stdlib JSON decoder and keeps the
+    result in float64. Subtracting a float64 ``q01`` from a robot's float32 state
+    promotes, so openpi's whole G1 chain -- normalize the state, discretize it
+    into the prompt, unnormalize the action -- runs in float64 whatever the robot
+    sent. Ours follows the input dtype unless told otherwise.
+
+    The gap is ~3e-7. On the output side that is nothing: a joint angle nobody
+    can measure. On the *input* side the very next operation compares the
+    normalized state against bin edges 1/128 apart, so an element sitting near
+    one lands in a different bin, writes a different number into the prompt
+    string, produces different token ids, and sends the rollout somewhere else.
+
+    Under the robot/model split the pin is not something the adapter reaches in
+    and applies -- it is a load flag the body declares (``norm_dtype`` in
+    :attr:`Embodiment.builder_kwargs`) and the model's loader honours. These
+    tests cover that as two links plus the reason it is load-bearing:
+    the preset asks for it, ``from_pretrained`` applies it, and float32 really
+    does cross a bin edge.
+    """
+
+    # --- link 1: the body declares it, and the loader accepts the keyword -----
+
+    def test_the_g1_preset_asks_the_loader_for_float64(self) -> None:
+        captured: dict = {}
+
+        def load(model_dir, *, model_type=None, **kwargs):
+            # Bind against the real signature, as UnitreeG1AdapterTest does: a
+            # flag the preset spells but ``from_pretrained`` does not accept is a
+            # TypeError the first time anyone serves a G1 checkpoint, and a
+            # kwargs-swallowing mock would never show it.
+            inspect.signature(Pi05Policy.from_pretrained).bind(model_dir, **kwargs)
+            captured.update(kwargs)
+            return _StubComposable()
+
+        with mock.patch.object(
+            robot_adapter, "AutoPolicy", types.SimpleNamespace(from_pretrained=load)
+        ):
+            build_robot_policy("unitree_g1", "/nowhere")
+
+        self.assertEqual(captured.get("norm_dtype"), "float64")
+
+    def test_libero_does_not_ask_for_it(self) -> None:
+        # The pin is scoped to the body that needs it. LIBERO's numbers are
+        # unchanged by this work, and a global default would have moved them.
+        self.assertNotIn("norm_dtype", get_robot_preset("franka_libero").builder_kwargs)
+
+    # --- link 2: the loader turns the flag into pinned normalizers ------------
+
+    def _checkpoint(self) -> pathlib.Path:
+        path = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(path, ignore_errors=True))
+        (path / "norm_stats.json").write_text(
+            json.dumps(
+                {
+                    "norm_stats": {
+                        "actions": {
+                            "q01": [-1.0] * MODEL_DIM,
+                            "q99": [1.0] * MODEL_DIM,
+                            "mean": [0.0] * MODEL_DIM,
+                            "std": [1.0] * MODEL_DIM,
+                        },
+                        "state": {
+                            "q01": [-1.0] * G1_ROBOT_DIM,
+                            "q99": [1.0] * G1_ROBOT_DIM,
+                            "mean": [0.0] * G1_ROBOT_DIM,
+                            "std": [1.0] * G1_ROBOT_DIM,
+                        },
+                    }
+                }
+            )
+        )
+        (path / "tokenizer.model").write_bytes(b"not a real sentencepiece model")
+        return path
+
+    def _load(self, **kwargs) -> Pi05Policy:
+        """Run the real ``from_pretrained``, stubbing only the tokenizer.
+
+        Everything the pin touches -- reading norm_stats, building both
+        normalizers, assembling the pipelines -- is the shipped code path. Only
+        SentencePiece is replaced, because it is the one step that needs a real
+        binary model file and it has nothing to do with dtypes.
+        """
+        with mock.patch.object(pi05_module, "PromptTokenizer", lambda *a, **k: RecordingTokenizer()):
+            return Pi05Policy.from_pretrained(
+                self._checkpoint(),
+                model=MockModel(num_views=len(G1_CAMERAS)),
+                discrete_state=True,
+                state_key=G1_STATE_KEY,
+                image_keys=G1_CAMERAS,
+                **kwargs,
+            )
+
+    def test_norm_dtype_pins_both_normalizers(self) -> None:
+        policy = self._load(norm_dtype="float64")
+        self.assertEqual(
+            policy.input_pipeline["tokenize"].state_normalizer.dtype, np.dtype("float64")
+        )
+        self.assertEqual(
+            policy.output_pipeline["unnormalize"].unnormalizer.dtype, np.dtype("float64")
+        )
+
+    def test_the_default_still_follows_the_input(self) -> None:
+        # Without the flag nothing is pinned, so this work changes no numbers for
+        # any checkpoint that does not ask -- which is what keeps LIBERO's
+        # float32 results bit-identical.
+        policy = self._load()
+        self.assertIsNone(policy.input_pipeline["tokenize"].state_normalizer.dtype)
+        self.assertIsNone(policy.output_pipeline["unnormalize"].unnormalizer.dtype)
+
+    # --- why it is load-bearing ----------------------------------------------
+
+    def test_float32_normalization_lands_in_a_different_bin(self) -> None:
+        """The reason for the pin, stated as a number rather than an assertion of faith."""
+        from apxinf.processors import discretize_state
+
+        rng = np.random.default_rng(11)
+        q01 = rng.uniform(-2.6, -0.4, G1_ROBOT_DIM)
+        q99 = q01 + rng.uniform(0.7, 4.1, G1_ROBOT_DIM)
+
+        # States that normalize *onto the bin edges*, by inverting openpi's
+        # normalize. Uniformly sampled states would not show anything: a 3e-7
+        # shift only changes a bin for an element already within 3e-7 of an edge
+        # 1/128 apart, which is a ~4e-5 chance each. That rarity is not safety --
+        # a G1 has 16 joints polled at 30 Hz, so "one in 25000 elements" is a
+        # corrupted prompt every minute or so, on a random joint, with no symptom
+        # other than the rollout going somewhere else.
+        edges = np.linspace(-1.0, 1.0, 257)[:-1]
+        targets = np.resize(edges, (edges.size // G1_ROBOT_DIM, G1_ROBOT_DIM))
+        states = (q01 + (targets + 1.0) / 2.0 * (q99 - q01 + 1e-6)).astype(np.float32)
+
+        pinned = Normalizer(q01=q01, q99=q99, dims=G1_ROBOT_DIM, dtype="float64")
+        loose = Normalizer(q01=q01, q99=q99, dims=G1_ROBOT_DIM)
+
+        wide = np.stack([pinned(s) for s in states])
+        narrow = np.stack([loose(s) for s in states])
+        self.assertEqual(wide.dtype, np.float64)
+        self.assertEqual(narrow.dtype, np.float32, "the unpinned default follows the input")
+
+        # openpi's own arithmetic, for the record: float64 stats promote the state.
+        reference = (states - q01) / (q99 - q01 + 1e-6) * 2.0 - 1.0
+        np.testing.assert_array_equal(wide, reference)
+
+        moved = int((discretize_state(wide) != discretize_state(narrow)).sum())
+        self.assertGreater(
+            moved, 0, "if float32 never crossed a bin edge the pin would be cosmetic"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -65,6 +65,8 @@ from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     VIEW_SLOTS,
+    Convention,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
@@ -158,24 +160,56 @@ class RobotPresetTest(unittest.TestCase):
         # Full model width; UnitreeG1EncodeActions does the 32->16 truncation.
         self.assertIsNone(preset.action_dim)
 
-    def test_slots_must_be_a_prefix_of_the_model_view_slots(self) -> None:
-        # A checkpoint fills view slots from 0 up, so declaring "base + right
-        # wrist" is not expressible and must be rejected at table-definition
-        # time rather than mis-binding a camera at inference time.
-        with self.assertRaises(ValueError):
-            RobotPreset(
-                name="bad",
-                slots=(("base_0_rgb", "a"), ("right_wrist_0_rgb", "b")),
-                state_key="state",
-            )
+    def test_slots_are_derived_in_view_slot_order(self) -> None:
+        # A checkpoint fills view slots from 0 up, so "base + right wrist" is not
+        # expressible. The old table let you *write* the pairs and validated the
+        # order; deriving them removes the failure mode instead of checking it.
+        convention = Convention(
+            name="two_cam", image_keys=("a", "b"), state_key="state"
+        )
+        self.assertEqual(convention.slots, (("base_0_rgb", "a"), ("left_wrist_0_rgb", "b")))
 
     def test_duplicate_camera_keys_are_rejected(self) -> None:
         with self.assertRaises(ValueError):
-            RobotPreset(
+            Convention(name="bad", image_keys=("a", "a"), state_key="state")
+
+    def test_more_cameras_than_view_slots_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            Convention(
                 name="bad",
-                slots=(("base_0_rgb", "a"), ("left_wrist_0_rgb", "a")),
+                image_keys=tuple(f"cam{i}" for i in range(len(VIEW_SLOTS) + 1)),
                 state_key="state",
             )
+
+    def test_a_convention_cannot_be_paired_with_the_wrong_body(self) -> None:
+        # The one check only the pairing can make: a 3-camera dialect against a
+        # 2-camera body would stack the wrong number of views, and nothing
+        # downstream distinguishes that from a checkpoint mismatch.
+        with self.assertRaises(ValueError) as caught:
+            RobotPreset(
+                name="mismatched",
+                embodiment=Embodiment(name="two_cam_body", num_cameras=2),
+                convention=Convention(
+                    name="three_cam", image_keys=("a", "b", "c"), state_key="state"
+                ),
+            )
+        message = str(caught.exception)
+        self.assertIn("three_cam", message)
+        self.assertIn("two_cam_body", message)
+
+    def test_the_two_halves_vary_independently(self) -> None:
+        # The reason for the split: a second key convention on the same body is a
+        # new Convention, not a new body. Re-pairing must need no builder edit.
+        franka = get_robot_preset("franka_libero").embodiment
+        droid_like = Convention(
+            name="droid_like",
+            image_keys=("observation/exterior_image_1_left", "observation/wrist_image_left"),
+            state_key="observation/joint_position",
+        )
+        repaired = RobotPreset(name="franka_droid_like", embodiment=franka, convention=droid_like)
+        self.assertEqual(repaired.image_keys, droid_like.image_keys)
+        self.assertEqual(repaired.action_dim, 7)
+        self.assertIs(repaired.builder, get_robot_preset("franka_libero").builder)
 
     def test_unknown_robot_names_the_known_ones(self) -> None:
         with self.assertRaises(KeyError) as caught:
@@ -227,10 +261,13 @@ class SyntheticContractTest(unittest.TestCase):
         # the synthetic server serves the right one and must not claim otherwise.
         preset = RobotPreset(
             name="stub",
-            slots=(("base_0_rgb", "cam"),),
-            state_key="state",
-            action_dim=7,
-            builder=lambda model_dir, **kwargs: None,
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=1,
+                action_dim=7,
+                builder=lambda model_dir, **kwargs: None,
+            ),
+            convention=Convention(name="stub_keys", image_keys=("cam",), state_key="state"),
         )
         gaps = preset.synthetic_gaps(discrete_state=False, served_action_dim=7)
         self.assertEqual(len(gaps), 1)
@@ -248,12 +285,19 @@ class BuildRobotPolicyTest(unittest.TestCase):
         seen: dict = {}
         preset = RobotPreset(
             name="stub_robot",
-            slots=(("base_0_rgb", "cam/high"), ("left_wrist_0_rgb", "cam/wrist")),
-            state_key="joints",
-            action_dim=None,
-            discrete_state=True,
-            builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
-            builder_kwargs={"use_delta_joint_actions": True},
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=2,
+                action_dim=None,
+                builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
+                builder_kwargs={"use_delta_joint_actions": True},
+            ),
+            convention=Convention(
+                name="stub_keys",
+                image_keys=("cam/high", "cam/wrist"),
+                state_key="joints",
+                discrete_state=True,
+            ),
         )
         self._register(preset)
 
@@ -281,10 +325,17 @@ class BuildRobotPolicyTest(unittest.TestCase):
         seen: dict = {}
         preset = RobotPreset(
             name="stub_generic",
-            slots=(("base_0_rgb", "observation/image"),),
-            state_key="observation/state",
-            action_dim=7,
-            builder=lambda model_dir, **kwargs: seen.update(kwargs),
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=1,
+                action_dim=7,
+                builder=lambda model_dir, **kwargs: seen.update(kwargs),
+            ),
+            convention=Convention(
+                name="stub_keys",
+                image_keys=("observation/image",),
+                state_key="observation/state",
+            ),
         )
         self._register(preset)
 

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -47,15 +47,29 @@ os.environ["no_proxy"] = "127.0.0.1,localhost"
 from apxinf import Pi05Policy  # noqa: E402
 from apxinf.policies.base import ComposablePolicy  # noqa: E402
 from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf import conventions as conventions_module  # noqa: E402
+from apxinf.conventions import (  # noqa: E402
+    CONVENTIONS,
+    LIBERO as LIBERO_CONVENTION,
+    UNITREE_G1 as G1_CONVENTION,
+    Convention,
+    available_conventions,
+    get_convention,
+    register_convention,
+)
 from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
-    G1_CAMERAS,
     G1_ROBOT_DIM,
-    G1_STATE_KEY,
     UnitreeG1AbsoluteActions,
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
 )
+
+# The G1 client's wire keys are a recording convention, not a fact about the
+# body, so the tests read them from the convention the preset pairs with.
+G1_CAMERAS = G1_CONVENTION.image_keys
+G1_STATE_KEY = G1_CONVENTION.state_key
 from apxinf.processors.transforms import (  # noqa: E402
+    Tokenize,
     has_key,
     lookup_key,
     set_key,
@@ -63,14 +77,15 @@ from apxinf.processors.transforms import (  # noqa: E402
 from apxinf.policies.impls import pi05 as pi05_module  # noqa: E402
 from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_ALIASES,
     ROBOT_PRESETS,
     VIEW_SLOTS,
-    Convention,
     Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from apxinf.robots.unitree_g1 import build_unitree_g1_policy  # noqa: E402
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
@@ -628,10 +643,25 @@ class UnitreeG1AdapterTest(unittest.TestCase):
         # Advertising 16 regardless would publish a width no step produces.
         stub = _StubComposable()
         with self._patched_loader({}, stub):
-            build_unitree_g1_policy("/nowhere", adapt_to_pi=False)
+            build_unitree_g1_policy(
+                "/nowhere",
+                state_key=G1_STATE_KEY,
+                image_keys=G1_CAMERAS,
+                adapt_to_pi=False,
+            )
         self.assertEqual(stub.wrapped["before"], [])
         self.assertEqual(stub.wrapped["after"], ["g1_absolute"])
         self.assertIsNone(stub.wrapped["action_dim"])
+
+    def test_the_wire_keys_are_required_arguments(self) -> None:
+        # They are a recording convention, not a fact about this body. A default
+        # here would rebuild the robot<->dataset coupling one layer up: the same
+        # G1 re-recorded under different keys would silently serve the old ones.
+        with self._patched_loader({}, _StubComposable()):
+            with self.assertRaises(TypeError):
+                build_unitree_g1_policy("/nowhere", image_keys=G1_CAMERAS)
+            with self.assertRaises(TypeError):
+                build_unitree_g1_policy("/nowhere", state_key=G1_STATE_KEY)
 
     def test_a_policy_that_cannot_be_wrapped_is_named_in_the_error(self) -> None:
         class Unwrappable:
@@ -639,7 +669,9 @@ class UnitreeG1AdapterTest(unittest.TestCase):
 
         with self._patched_loader({}, Unwrappable()):
             with self.assertRaises(TypeError) as caught:
-                build_unitree_g1_policy("/nowhere")
+                build_unitree_g1_policy(
+                    "/nowhere", state_key=G1_STATE_KEY, image_keys=G1_CAMERAS
+                )
         message = str(caught.exception)
         self.assertIn("Unwrappable", message)
         self.assertIn("with_adapter", message)
@@ -663,13 +695,20 @@ class ModelLayerHoldsNoWireKeysTest(unittest.TestCase):
 
     def _policy(self, num_views: int) -> Pi05Policy:
         model = MockModel(num_views=num_views)
+        # A state key has to be named because RecordingTokenizer discretizes
+        # state; these tests are about the *camera* fallback, so it is a neutral
+        # spelling rather than any dataset's.
         input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
             model,
             tokenizer=RecordingTokenizer(),
             unnormalizer=_identity_unnormalizer(),
+            state_key="state",
         )
         return Pi05Policy(
-            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+            model,
+            input_pipeline=input_pipeline,
+            output_pipeline=output_pipeline,
+            state_key="state",
         )
 
     def test_unnamed_cameras_fall_back_to_the_models_own_slots(self) -> None:
@@ -917,6 +956,236 @@ class ImageSlotOrderTest(unittest.TestCase):
                 "/nonexistent", model=MockModel(num_views=3), num_views=2
             )
         self.assertIn("pass num_views to the load call", str(caught.exception))
+
+
+class ConventionsAreTheirOwnLayerTest(unittest.TestCase):
+    """A recording dialect is not a robot's property, so it has its own module.
+
+    The G1's wire keys used to live in ``processors/robots/unitree_g1.py`` — a
+    *dataset* fact defined inside a *body*'s processing steps, so re-recording the
+    same robot meant editing its steps. They now live in :mod:`apxinf.conventions`,
+    which depends on neither a body nor a policy implementation.
+    """
+
+    def test_the_shipped_conventions_are_registered_under_their_names(self) -> None:
+        self.assertIs(get_convention("libero"), LIBERO_CONVENTION)
+        self.assertIs(get_convention("unitree_g1"), G1_CONVENTION)
+        for name in ("libero", "unitree_g1"):
+            self.assertIn(name, available_conventions())
+
+    def test_a_preset_reuses_the_convention_object_rather_than_restating_it(self) -> None:
+        # If a preset copied the keys instead, the two could drift and only a
+        # client would notice — on the wire, silently.
+        self.assertIs(get_robot_preset("unitree_g1").convention, G1_CONVENTION)
+        self.assertIs(get_robot_preset("franka_libero").convention, LIBERO_CONVENTION)
+
+    def test_the_g1_steps_no_longer_hold_the_g1s_wire_keys(self) -> None:
+        # The regression to catch: a body's processing steps naming a dataset's
+        # keys again. Checked on the module's exports, not by grepping prose.
+        from apxinf.processors.robots import unitree_g1 as g1_steps
+
+        self.assertFalse(hasattr(g1_steps, "G1_CAMERAS"))
+        self.assertFalse(hasattr(g1_steps, "G1_STATE_KEY"))
+        for step in (UnitreeG1DecodeState, UnitreeG1AbsoluteActions):
+            with self.subTest(step=step.__name__):
+                default = inspect.signature(step).parameters["state_key"].default
+                self.assertIs(default, inspect.Parameter.empty)
+
+    def test_conventions_import_no_body_and_no_policy_implementation(self) -> None:
+        # The layering rule: a dialect may read the model's VIEW_SLOTS vocabulary
+        # and nothing else. Anything more and the third axis is coupled again.
+        source = pathlib.Path(conventions_module.__file__).read_text()
+        for forbidden in ("Embodiment", "RobotPreset", "Pi05Policy", "AutoPolicy"):
+            with self.subTest(name=forbidden):
+                self.assertNotIn(f"import {forbidden}", source)
+                self.assertNotIn(f"{forbidden}(", source)
+
+
+class RegistrationFromOutsideTest(unittest.TestCase):
+    """A third-party robot or dialect must not have to patch our files.
+
+    Both registries are process-local dicts, so each test restores them; the
+    point under test is the guard rails, not the mutation.
+    """
+
+    def setUp(self) -> None:
+        self._presets = dict(ROBOT_PRESETS)
+        self._aliases = dict(ROBOT_ALIASES)
+        self._conventions = dict(CONVENTIONS)
+
+    def tearDown(self) -> None:
+        ROBOT_PRESETS.clear()
+        ROBOT_PRESETS.update(self._presets)
+        ROBOT_ALIASES.clear()
+        ROBOT_ALIASES.update(self._aliases)
+        CONVENTIONS.clear()
+        CONVENTIONS.update(self._conventions)
+
+    def _preset(self, name: str = "myarm_mydataset") -> RobotPreset:
+        return RobotPreset(
+            name=name,
+            embodiment=Embodiment(name="myarm", num_cameras=1, action_dim=6),
+            convention=Convention(name="mydataset", image_keys=("rgb",), state_key="q"),
+        )
+
+    def test_a_registered_preset_is_reachable_as_a_robot_flag(self) -> None:
+        preset = register_robot_preset(self._preset(), aliases=("myarm",))
+        self.assertIs(get_robot_preset("myarm_mydataset"), preset)
+        self.assertIs(get_robot_preset("myarm"), preset)
+        self.assertIn("myarm_mydataset", available_robots())
+        self.assertIn("myarm", available_robots(include_aliases=True))
+
+    def test_re_registering_a_name_needs_an_explicit_replace(self) -> None:
+        # A silent overwrite would change what a launch command already in
+        # production resolves to — the invisible failure --robot exists to prevent.
+        register_robot_preset(self._preset())
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset())
+        self.assertIn("replace=True", str(caught.exception))
+        replacement = self._preset()
+        self.assertIs(
+            register_robot_preset(replacement, replace=True),
+            get_robot_preset("myarm_mydataset"),
+        )
+
+    def test_an_alias_may_never_shadow_a_canonical_preset(self) -> None:
+        # Even with replace=True: an alias winning over a real preset would
+        # silently redirect a --robot spelling that already names something.
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset(), aliases=("unitree_g1",), replace=True)
+        self.assertIn("unitree_g1", str(caught.exception))
+        self.assertIs(get_robot_preset("unitree_g1").embodiment.builder, build_unitree_g1_policy)
+
+    def test_moving_an_existing_alias_needs_an_explicit_replace(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset(), aliases=("libero",))
+        self.assertIn("franka_libero", str(caught.exception))
+        self.assertIs(get_robot_preset("libero"), get_robot_preset("franka_libero"))
+        register_robot_preset(self._preset(), aliases=("libero",), replace=True)
+        self.assertEqual(get_robot_preset("libero").name, "myarm_mydataset")
+
+    def test_a_failed_registration_leaves_both_tables_untouched(self) -> None:
+        # The alias check runs before either dict is written, so a rejected call
+        # cannot half-register a preset under its canonical name.
+        with self.assertRaises(ValueError):
+            register_robot_preset(self._preset(), aliases=("unitree_g1",))
+        self.assertNotIn("myarm_mydataset", ROBOT_PRESETS)
+
+    def test_registering_something_that_is_not_a_preset_is_a_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            register_robot_preset(Convention(name="x", image_keys=("a",), state_key="q"))
+
+    def test_a_registered_convention_pairs_with_a_shipped_body(self) -> None:
+        droid_like = register_convention(
+            Convention(
+                name="franka_droid_like",
+                image_keys=("observation/exterior_image_1_left", "observation/wrist_image_left"),
+                state_key="observation/joint_position",
+            )
+        )
+        self.assertIs(get_convention("franka_droid_like"), droid_like)
+        # The payoff of the split: a new dialect on an existing body needs no
+        # new Embodiment, no builder, and no edit to either shipped module.
+        preset = RobotPreset(
+            name="franka_droid_like",
+            embodiment=get_robot_preset("franka_libero").embodiment,
+            convention=droid_like,
+        )
+        self.assertEqual(preset.action_dim, 7)
+        self.assertEqual(preset.state_key, "observation/joint_position")
+
+    def test_re_registering_a_convention_needs_an_explicit_replace(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            register_convention(
+                Convention(name="libero", image_keys=("a", "b"), state_key="q")
+            )
+        self.assertIn("replace=True", str(caught.exception))
+        self.assertIs(get_convention("libero"), LIBERO_CONVENTION)
+
+    def test_registering_something_that_is_not_a_convention_is_a_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            register_convention(Embodiment(name="myarm", num_cameras=1))
+
+
+class StateKeyIsRequiredWhenItIsReadTest(unittest.TestCase):
+    """``state_key`` has no default, and is demanded exactly when state is read.
+
+    The model layer used to default it to LIBERO's ``observation/state``, the same
+    dataset-in-the-model coupling the camera keys had. Dropping the default leaves
+    an asymmetry with ``image_keys``: a wrong camera key raises ``KeyError`` on the
+    first inference, but a missing state key is silent — the tokenizer just
+    injects nothing and the policy publishes ``state_key=null`` while proprioception
+    quietly disappears. So it is required whenever the chain discretizes state, and
+    allowed to stay ``None`` only when state is deliberately dropped.
+    """
+
+    def test_the_model_layer_defaults_no_state_key(self) -> None:
+        # Asserted on the signatures, not by grepping the source, so the prose
+        # explaining the old LIBERO default does not trip the check.
+        for func in (
+            pi05_module.Pi05Policy.__init__,
+            pi05_module.Pi05Policy.default_pipelines,
+            pi05_module.Pi05Policy.from_pretrained,
+            pi05_module.Pi05Policy.from_random,
+            Tokenize.__init__,
+        ):
+            with self.subTest(entry_point=func.__qualname__):
+                self.assertIsNone(inspect.signature(func).parameters["state_key"].default)
+
+    def test_a_discretizing_tokenizer_without_a_key_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            Tokenize(RecordingTokenizer(), None, None)
+        self.assertIn("state_key", str(caught.exception))
+
+    def test_a_dropping_tokenizer_without_a_key_is_fine(self) -> None:
+        # discrete_state=False means state is dropped on purpose; demanding a key
+        # for a value nothing reads would be noise.
+        tokenizer = RecordingTokenizer()
+        tokenizer.discrete_state = False
+        self.assertIsNone(Tokenize(tokenizer, None, None).state_key)
+
+    def test_a_policy_whose_chain_reads_state_is_rejected_without_a_key(self) -> None:
+        model = MockModel(num_views=2)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+            state_key="state",
+        )
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy(
+                model,
+                input_pipeline=input_pipeline,
+                output_pipeline=output_pipeline,
+                state_key=None,
+            )
+        self.assertIn("state_key", str(caught.exception))
+
+    def test_from_pretrained_refuses_discrete_state_without_a_key(self) -> None:
+        # Checked before the checkpoint is touched, so the message can name the
+        # flags the caller actually passed rather than failing deep in a load.
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy.from_pretrained("/nonexistent", discrete_state=True)
+        message = str(caught.exception)
+        self.assertIn("state_key", message)
+        self.assertIn("discrete_state=False", message)
+
+    def test_the_published_contract_may_say_no_state_key(self) -> None:
+        # A policy that drops state has no state key to publish, and null is the
+        # honest answer — a client reading metadata sees that state is unused.
+        policy = build_g1_mock_policy()
+        self.assertEqual(policy.metadata["state_key"], G1_STATE_KEY)
+        tokenizer = RecordingTokenizer()
+        tokenizer.discrete_state = False
+        model = MockModel(num_views=2)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model, tokenizer=tokenizer, unnormalizer=_identity_unnormalizer()
+        )
+        stateless = Pi05Policy(
+            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+        )
+        self.assertIsNone(stateless.metadata["state_key"])
+        self.assertFalse(stateless.metadata["discrete_state"])
 
 
 if __name__ == "__main__":

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -60,6 +60,7 @@ from apxinf.processors.transforms import (  # noqa: E402
     lookup_key,
     set_key,
 )
+from apxinf.policies.impls import pi05 as pi05_module  # noqa: E402
 from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
@@ -597,6 +598,76 @@ class UnitreeG1AdapterTest(unittest.TestCase):
         # A concrete policy reappearing here is the regression to catch.
         source = pathlib.Path(robot_adapter.__file__).read_text()
         self.assertNotIn("Pi05Policy", source)
+
+
+class ModelLayerHoldsNoWireKeysTest(unittest.TestCase):
+    """The policy layer must not carry any dataset's wire contract.
+
+    ``Pi05Policy`` used to default ``image_keys`` to LIBERO's
+    ``observation/image`` / ``observation/wrist_image``. As *the* default those
+    two keys silently applied to every checkpoint, so a G1 checkpoint served bare
+    ran LIBERO's contract and looked like an accuracy problem. The fallback is
+    now the model's own view slots, which cannot masquerade as anyone's keys.
+    """
+
+    def _policy(self, num_views: int) -> Pi05Policy:
+        model = MockModel(num_views=num_views)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+        )
+        return Pi05Policy(
+            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+        )
+
+    def test_unnamed_cameras_fall_back_to_the_models_own_slots(self) -> None:
+        policy = self._policy(2)
+        self.assertEqual(policy.image_keys, VIEW_SLOTS[:2])
+        # Same list in the published contract, so a client reading metadata sees
+        # exactly what the ImageStack step resolves.
+        self.assertEqual(policy.metadata["image_keys"], list(VIEW_SLOTS[:2]))
+
+    def test_the_fallback_is_not_any_datasets_convention(self) -> None:
+        policy = self._policy(2)
+        for key in ("observation/image", "observation/wrist_image", "images/cam_high"):
+            self.assertNotIn(key, policy.image_keys)
+
+    def test_a_libero_client_against_the_fallback_fails_loudly(self) -> None:
+        # The point of dropping the default: a mismatch is an error naming both
+        # sides, not a silent run on the wrong cameras.
+        policy = self._policy(2)
+        observation = {
+            "observation/image": np.zeros((IMAGE_SIZE, IMAGE_SIZE, 3), np.uint8),
+            "observation/wrist_image": np.zeros((IMAGE_SIZE, IMAGE_SIZE, 3), np.uint8),
+            "prompt": "pick up the block",
+        }
+        with self.assertRaises(KeyError) as caught:
+            policy.infer(observation)
+        message = str(caught.exception)
+        self.assertIn(VIEW_SLOTS[0], message)
+
+    def test_the_fallback_stays_total_beyond_the_declared_slots(self) -> None:
+        # default_pipelines requires len(image_keys) == model.num_views, so the
+        # fallback has to name *every* view a model claims, slots or not.
+        policy = self._policy(len(VIEW_SLOTS) + 1)
+        self.assertEqual(len(policy.image_keys), len(VIEW_SLOTS) + 1)
+        self.assertEqual(policy.image_keys[: len(VIEW_SLOTS)], VIEW_SLOTS)
+        self.assertEqual(len(set(policy.image_keys)), len(policy.image_keys))
+
+    def test_no_constructor_defaults_a_camera_key(self) -> None:
+        # Asserted on the signatures rather than by grepping the source, so the
+        # prose explaining the old LIBERO default does not trip the check. Every
+        # entry point that takes image_keys must leave them unnamed.
+        for func in (
+            pi05_module.Pi05Policy.__init__,
+            pi05_module.Pi05Policy.default_pipelines,
+            pi05_module.Pi05Policy.from_pretrained,
+            pi05_module.Pi05Policy.from_random,
+        ):
+            with self.subTest(entry_point=func.__qualname__):
+                default = inspect.signature(func).parameters["image_keys"].default
+                self.assertIsNone(default)
 
 
 class RunningServer:

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -4,7 +4,7 @@ Covers the layer that decides *which keys a client must send*, which is where a
 deployment silently degrades rather than fails: a checkpoint served under the
 wrong embodiment still returns well-shaped actions.
 
-Three groups:
+Four groups:
 
 * :class:`KeyResolutionTest` — ``lookup_key`` / ``has_key`` / ``set_key``, the
   flat-vs-nested wire layouts (``"observation/image"`` vs
@@ -13,6 +13,9 @@ Three groups:
   :class:`BuildRobotPolicyTest` — the preset table's invariants, its overrides,
   and the contract it publishes (including what a checkpoint-free server must
   admit it cannot honour).
+* :class:`PipelineCompositionTest` / :class:`PolicyCompositionTest` /
+  :class:`UnitreeG1AdapterTest` — the robot/model seam: a robot's steps wrap a
+  model's chain from outside, without either layer naming the other.
 * :class:`UnitreeG1ServingTest` — an **unmodified openpi G1 observation** driven
   through the real websocket transport into a G1-wired policy, asserting camera
   →slot binding, state routing, and the delta→absolute / 32→16 output chain.
@@ -23,11 +26,14 @@ Runs offline against a mock model; no CUDA, no checkpoint.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import pathlib
 import sys
 import threading
+import types
 import unittest
+from unittest import mock
 
 import numpy as np
 from openpi_client import websocket_client_policy
@@ -39,7 +45,8 @@ os.environ["NO_PROXY"] = "127.0.0.1,localhost"
 os.environ["no_proxy"] = "127.0.0.1,localhost"
 
 from apxinf import Pi05Policy  # noqa: E402
-from apxinf.processors import Pipeline, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf.policies.base import ComposablePolicy  # noqa: E402
+from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
 from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
     G1_CAMERAS,
     G1_ROBOT_DIM,
@@ -49,11 +56,11 @@ from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
     UnitreeG1EncodeActions,
 )
 from apxinf.processors.transforms import (  # noqa: E402
-    Unnormalize,
     has_key,
     lookup_key,
     set_key,
 )
+from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     VIEW_SLOTS,
@@ -62,6 +69,7 @@ from apxinf.robots.presets import (  # noqa: E402
     build_robot_policy,
     get_robot_preset,
 )
+from apxinf.robots.unitree_g1 import build_unitree_g1_policy  # noqa: E402
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
 from apxinf.serving.websocket import health_check  # noqa: E402
 
@@ -291,6 +299,47 @@ class BuildRobotPolicyTest(unittest.TestCase):
         self.assertEqual(seen["metadata"]["robot_slots"], [["base_0_rgb", "rgb/front"]])
 
 
+class _Tag(ProcessorStep):
+    """Trivial step: append its own label to the flowing list."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __call__(self, value):
+        return list(value) + [self.label]
+
+
+class PipelineCompositionTest(unittest.TestCase):
+    """``prepend``/``append``: the only editing verbs that name no inner step.
+
+    Every other verb (``insert_before``, ``replace``, ...) needs a step name, so
+    an *outer* layer using them has to know the inner chain's private vocabulary.
+    A robot adapter's requirement is only "run outside the model's steps", and
+    these two say exactly that.
+    """
+
+    def _chain(self) -> Pipeline:
+        return Pipeline([("a", _Tag("a")), ("b", _Tag("b"))])
+
+    def test_wrapping_runs_outside_the_existing_steps_in_order(self) -> None:
+        chain = self._chain().prepend(("pre1", _Tag("pre1")), ("pre2", _Tag("pre2")))
+        chain = chain.append(("post1", _Tag("post1")), ("post2", _Tag("post2")))
+        self.assertEqual(chain([]), ["pre1", "pre2", "a", "b", "post1", "post2"])
+
+    def test_the_original_pipeline_is_untouched(self) -> None:
+        original = self._chain()
+        original.prepend(("pre", _Tag("pre")))
+        original.append(("post", _Tag("post")))
+        self.assertEqual(original.names, ["a", "b"])
+
+    def test_a_colliding_name_is_rejected_rather_than_shadowing(self) -> None:
+        # A wrapper that silently replaced an inner step would be the worst
+        # possible failure: the model's chain quietly loses a step.
+        with self.assertRaises(ValueError) as caught:
+            self._chain().prepend(("b", _Tag("b2")))
+        self.assertIn("'b'", str(caught.exception))
+
+
 class MockModel:
     """In-process ``BareModel`` stand-in returning a constant normalized action."""
 
@@ -326,9 +375,9 @@ class RecordingTokenizer(PromptTokenizer):
 def build_g1_mock_policy() -> Pi05Policy:
     """A G1-wired policy over a mock model: the real pipelines, no checkpoint.
 
-    Mirrors ``build_unitree_g1_policy`` but injects the model and an identity
-    unnormalizer, so the assertions isolate the adapter's arithmetic from
-    checkpoint norm_stats.
+    Takes the same route ``build_unitree_g1_policy`` does — a stock policy, then
+    ``with_adapter`` — but injects the model and an identity unnormalizer, so the
+    assertions isolate the adapter's arithmetic from checkpoint norm_stats.
     """
     model = MockModel(num_views=len(G1_CAMERAS))
     tokenizer = RecordingTokenizer()
@@ -342,27 +391,212 @@ def build_g1_mock_policy() -> Pi05Policy:
         image_keys=G1_CAMERAS,
         state_key=G1_STATE_KEY,
     )
-    input_pipeline = input_pipeline.insert_before(
-        "tokenize", ("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))
-    )
-    output_pipeline = Pipeline(
-        [
-            ("unnormalize", Unnormalize(identity)),
-            ("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY)),
-            ("g1_encode", UnitreeG1EncodeActions()),
-        ]
-    )
-    policy = Pi05Policy(
+    base = Pi05Policy(
         model,
         input_pipeline=input_pipeline,
         output_pipeline=output_pipeline,
         image_keys=G1_CAMERAS,
         state_key=G1_STATE_KEY,
+        metadata={"protocol": "openpi.websocket_policy"},
+    )
+    policy = base.with_adapter(
+        before=[("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))],
+        after=[
+            ("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY)),
+            ("g1_encode", UnitreeG1EncodeActions()),
+        ],
         action_dim=G1_ROBOT_DIM,
-        metadata={"robot": "unitree_g1", "protocol": "openpi.websocket_policy"},
+        metadata={"robot": "unitree_g1"},
     )
     policy.tokenizer = tokenizer
     return policy
+
+
+def _identity_unnormalizer() -> Unnormalizer:
+    return Unnormalizer(
+        q01=[-1.0] * MODEL_DIM, q99=[1.0] * MODEL_DIM, dims=MODEL_DIM, eps=0.0
+    )
+
+
+class PolicyCompositionTest(unittest.TestCase):
+    """``Pi05Policy.with_adapter``: the seam a robot adapter wraps.
+
+    Its contract is nesting — ``before`` outside the model's whole input chain,
+    ``after`` outside its whole output chain — plus republishing what the wrapped
+    policy actually serves. Getting the second part wrong is the failure this
+    layer exists to prevent: a policy advertising an ``action_dim`` its steps do
+    not emit degrades silently on the wire.
+    """
+
+    def _base(self) -> Pi05Policy:
+        model = MockModel(num_views=len(G1_CAMERAS))
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+            image_keys=G1_CAMERAS,
+            state_key=G1_STATE_KEY,
+        )
+        return Pi05Policy(
+            model,
+            input_pipeline=input_pipeline,
+            output_pipeline=output_pipeline,
+            image_keys=G1_CAMERAS,
+            state_key=G1_STATE_KEY,
+            metadata={"protocol": "openpi.websocket_policy"},
+        )
+
+    def test_steps_land_outside_the_model_chain_in_both_directions(self) -> None:
+        base = self._base()
+        wrapped = base.with_adapter(
+            before=[("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))],
+            after=[("g1_encode", UnitreeG1EncodeActions())],
+            action_dim=G1_ROBOT_DIM,
+        )
+        self.assertEqual(wrapped.input_pipeline.names[0], "g1_decode_state")
+        self.assertEqual(wrapped.output_pipeline.names[-1], "g1_encode")
+        # The model's own steps keep their order and their names; the wrapper
+        # never had to learn what they are.
+        self.assertEqual(wrapped.input_pipeline.names[1:], base.input_pipeline.names)
+        self.assertEqual(wrapped.output_pipeline.names[:-1], base.output_pipeline.names)
+
+    def test_the_original_policy_is_not_mutated(self) -> None:
+        base = self._base()
+        base.with_adapter(
+            after=[("g1_encode", UnitreeG1EncodeActions())], action_dim=G1_ROBOT_DIM
+        )
+        self.assertNotIn("g1_encode", base.output_pipeline.names)
+        self.assertEqual(base.action_dim, MODEL_DIM)
+
+    def test_the_published_contract_describes_the_wrapped_chain(self) -> None:
+        wrapped = self._base().with_adapter(
+            after=[("g1_encode", UnitreeG1EncodeActions())],
+            action_dim=G1_ROBOT_DIM,
+            metadata={"robot": "unitree_g1"},
+        )
+        # The derived half is recomputed: inheriting the pre-adapter action_dim
+        # would publish a width no step in this chain produces.
+        self.assertEqual(wrapped.metadata["action_dim"], G1_ROBOT_DIM)
+        self.assertIn("g1_encode", wrapped.metadata["output_pipeline"])
+        # The caller's half is carried forward and extended.
+        self.assertEqual(wrapped.metadata["protocol"], "openpi.websocket_policy")
+        self.assertEqual(wrapped.metadata["robot"], "unitree_g1")
+
+    def test_an_unchanged_width_is_inherited(self) -> None:
+        # An appended step that does not narrow the action needs no declaration.
+        wrapped = self._base().with_adapter(
+            after=[("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY))]
+        )
+        self.assertEqual(wrapped.action_dim, MODEL_DIM)
+
+    def test_the_model_handle_is_shared_not_reloaded(self) -> None:
+        # Rewiring, not a second load: two handles on one GPU allocation would
+        # double the checkpoint's memory and make close() order matter.
+        base = self._base()
+        self.assertIs(base.with_adapter().model, base.model)
+
+    def test_a_wrapper_cannot_shadow_a_step_it_does_not_own(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            self._base().with_adapter(
+                before=[("tokenize", UnitreeG1DecodeState(G1_STATE_KEY))]
+            )
+        self.assertIn("tokenize", str(caught.exception))
+
+    def test_pi05_satisfies_the_composable_contract(self) -> None:
+        self.assertIsInstance(self._base(), ComposablePolicy)
+
+
+class _StubComposable:
+    """Minimal ``ComposablePolicy``: records what an adapter wrapped it with."""
+
+    def __init__(self) -> None:
+        self.wrapped: dict = {}
+
+    def with_adapter(self, *, before=(), after=(), action_dim=None, metadata=None):
+        self.wrapped = {
+            "before": [name for name, _ in before],
+            "after": [name for name, _ in after],
+            "action_dim": action_dim,
+            "metadata": dict(metadata or {}),
+        }
+        return self
+
+
+class UnitreeG1AdapterTest(unittest.TestCase):
+    """The G1 builder wraps a policy it never names, and hands load flags on.
+
+    These run against a stub loader, so they assert the *adapter's* behaviour
+    without a checkpoint: which steps it wraps, on which side, what width it
+    claims, and — the bug this split removes — that every keyword it forwards is
+    one the real loading path accepts.
+    """
+
+    def _patched_loader(self, captured: dict, policy):
+        def load(model_dir, *, model_type=None, **kwargs):
+            # Mirror AutoPolicy's real split: it consumes model_type itself and
+            # forwards the rest to a concrete from_pretrained that has **no**
+            # **kwargs. Binding against that signature reproduces the TypeError
+            # serving would raise, which is why this stub is not a bare Mock.
+            inspect.signature(Pi05Policy.from_pretrained).bind(model_dir, **kwargs)
+            captured.update(kwargs, model_dir=model_dir, model_type=model_type)
+            return policy
+
+        return mock.patch.object(
+            robot_adapter, "AutoPolicy", types.SimpleNamespace(from_pretrained=load)
+        )
+
+    def test_server_load_flags_reach_the_concrete_loader(self) -> None:
+        # --model-type travels server -> build_robot_policy -> this builder. It
+        # is AutoPolicy's argument, not the concrete policy's, so a builder that
+        # forwards it blindly raises TypeError the moment anyone serves a G1
+        # checkpoint. Only binding the real signature catches that.
+        captured: dict = {}
+        with self._patched_loader(captured, _StubComposable()):
+            build_robot_policy(
+                "unitree_g1", "/nowhere", model_type="pi05", precision="bf16"
+            )
+        self.assertEqual(captured["model_type"], "pi05")
+        self.assertEqual(captured["precision"], "bf16")
+        self.assertEqual(captured["state_key"], G1_STATE_KEY)
+        # Loaded at full model width: delta->absolute must see the whole action
+        # before g1_encode truncates it to 16.
+        self.assertIsNone(captured["action_dim"])
+
+    def test_the_g1_steps_wrap_the_model_chain_from_outside(self) -> None:
+        stub = _StubComposable()
+        with self._patched_loader({}, stub):
+            build_robot_policy("unitree_g1", "/nowhere")
+        self.assertEqual(stub.wrapped["before"], ["g1_decode_state"])
+        self.assertEqual(stub.wrapped["after"], ["g1_absolute", "g1_encode"])
+        self.assertEqual(stub.wrapped["action_dim"], G1_ROBOT_DIM)
+        self.assertEqual(stub.wrapped["metadata"]["robot"], "unitree_g1")
+
+    def test_without_the_truncating_step_no_width_is_claimed(self) -> None:
+        # adapt_to_pi=False drops g1_encode, so nothing narrows the action to 16.
+        # Advertising 16 regardless would publish a width no step produces.
+        stub = _StubComposable()
+        with self._patched_loader({}, stub):
+            build_unitree_g1_policy("/nowhere", adapt_to_pi=False)
+        self.assertEqual(stub.wrapped["before"], [])
+        self.assertEqual(stub.wrapped["after"], ["g1_absolute"])
+        self.assertIsNone(stub.wrapped["action_dim"])
+
+    def test_a_policy_that_cannot_be_wrapped_is_named_in_the_error(self) -> None:
+        class Unwrappable:
+            pass
+
+        with self._patched_loader({}, Unwrappable()):
+            with self.assertRaises(TypeError) as caught:
+                build_unitree_g1_policy("/nowhere")
+        message = str(caught.exception)
+        self.assertIn("Unwrappable", message)
+        self.assertIn("with_adapter", message)
+
+    def test_the_adapter_names_no_model_class(self) -> None:
+        # The whole point of the split: this module knows a body, not a model.
+        # A concrete policy reappearing here is the regression to catch.
+        source = pathlib.Path(robot_adapter.__file__).read_text()
+        self.assertNotIn("Pi05Policy", source)
 
 
 class RunningServer:


### PR DESCRIPTION
## Experimental workflow scope

This Draft PR validates the GR00T N1.7 porting workflow on ApxInf. It is intentionally review-first and is not presented as a completed public model integration.

Reference tuple:

- NVIDIA Isaac-GR00T source: `51d4c89f72fda44cbf77285c6a8114b52676b8a1`
- checkpoint: `nvidia/GR00T-N1.7-LIBERO`, revision `2ea293aa...`, `libero_10`
- precision/profile: BF16, batch 1, two temporal frames, four denoise steps
- targets: Jetson AGX Thor (`sm_110`) and Jetson AGX Orin (`sm_87`)
- release gates: Thor <= 80.4 ms / >= 12.4 Hz; Orin <= 150.9 ms / >= 6.6 Hz

## What changes

- adds an isolated `gr00t_n17` VLA runtime and registry entry;
- adds a target-built TensorRT engine-bundle contract and optional native TensorRT adapter;
- keeps ViT, language backbone, state/action encoders, DiT, decoder, BF16 casts, row scatter, normalization, concatenation, and Euler updates on CUDA;
- reuses fixed TensorRT output buffers across requests and denoise steps;
- adds selective SafeTensors loading for the four retained glue weights;
- extends the model-neutral VLA observation with optional normalized state and embodiment id.

No checkpoint, engine, reference checkout, captured tensor, private adapter, replay script, credential, or host address is included.

## Evidence collected outside the repository

Private reproducibility evidence is retained in the GR00T N1.7 private port workspace on Thor.

- deterministic step 0: max abs `0.046875`, relative L2 `0.00398123`, cosine `0.99999207`;
- deterministic step 10: max abs `0.015625`, relative L2 `0.00224334`, cosine `0.99999748`;
- Thor release run, 50 iterations: `74.799 ms`, `13.369 Hz`;
- steady-state model computation remains device-resident; D2H is limited to the explicit public output boundary.

## Validation

- [x] current-worktree-only implementation; no other branch used as reference
- [x] `git diff --check`
- [x] `scripts/check_model_family_boundaries.sh`
- [x] Thor deterministic end-to-end reference comparison
- [x] Thor published NVIDIA performance gate
- [ ] latest cleanup-only Thor CUDA rebuild (running when Draft was opened)
- [ ] Orin build, numerical comparison, and performance gate
- [ ] Python raw-observation preprocessing/policy integration
- [ ] CUDA Graph capture/replay parity (the current `prepare` path binds a fixed spec but remains eager)

## Known deployment constraints

TensorRT plans are target-built artifacts and are deliberately excluded. Thor and Orin require separate engine builds because their TensorRT/CUDA/SM environments differ. The local-machine relay to Orin is verified, but measured transfer throughput is about `0.4 MB/s`, so moving the approximately `6.7 GB` validation payload this way takes several hours.
