### PR TITLE
Port GR00T N1.7 to native ApxInf CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ Reported latency is P50 over 30 samples after 10 warm-up iterations
 import numpy as np
 from apxinf import AutoPolicy
 
-policy = AutoPolicy.from_pretrained("<path-to-model>", precision="bf16", action_dim=7)
+# image_keys / state_key are the wire contract — the policy holds no dataset's
+# convention as a default, so state the ones your client actually sends. These
+# are LIBERO's; `--robot <preset>` on the server does this for you from a table.
+policy = AutoPolicy.from_pretrained(
+    "<path-to-model>",
+    precision="bf16",
+    action_dim=7,
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+)
 
 result = policy.infer({
     "observation/image":       np.zeros((256, 256, 3), np.uint8),

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ from apxinf import AutoPolicy
 
 # image_keys / state_key are the wire contract — the policy holds no dataset's
 # convention as a default, so state the ones your client actually sends. These
-# are LIBERO's; `--robot <preset>` on the server does this for you from a table.
+# are LIBERO's (`apxinf.conventions.LIBERO`); `--robot <preset>` on the server,
+# or `build_robot_policy(...)` in code, does this for you from a table.
 policy = AutoPolicy.from_pretrained(
     "<path-to-model>",
     precision="bf16",

--- a/crates/apxinf-cuda/adapters/fa2_adapter.cu
+++ b/crates/apxinf-cuda/adapters/fa2_adapter.cu
@@ -6,11 +6,11 @@
 extern "C" int apxinf_static_fa2_bf16(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
-    int query_heads, int kv_heads, int head_dim, float softmax_scale,
+    int query_heads, int kv_heads, int head_dim, float softmax_scale, bool causal,
     cudaStream_t stream) {
   return apxinf::cuda::cutlass_ops::fa2_bf16(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
-      query_heads, kv_heads, head_dim, softmax_scale, stream);
+      query_heads, kv_heads, head_dim, softmax_scale, causal, stream);
 }
 
 #if defined(APXINF_FA2_SM80)

--- a/crates/apxinf-cuda/adapters/static_bf16_adapter.cu
+++ b/crates/apxinf-cuda/adapters/static_bf16_adapter.cu
@@ -44,6 +44,21 @@ extern "C" cudaError_t apxinf_static_rgb_u8_to_patches_bf16(
   return cudaGetLastError();
 }
 
+extern "C" cudaError_t apxinf_static_groot_rgb_u8_to_patches_bf16(
+    const void* images, void* patches, int views, int layout,
+    cudaStream_t stream) {
+  if (views <= 0 || (layout != 0 && layout != 1)) return cudaErrorInvalidValue;
+  const int64_t count = static_cast<int64_t>(views) * 256 * 1536;
+  if (layout == 0) {
+    groot_rgb_u8_to_patches_bf16_kernel<true><<<blocks_for(count), kThreads, 0, stream>>>(
+        static_cast<const uint8_t*>(images), static_cast<__nv_bfloat16*>(patches), views);
+  } else {
+    groot_rgb_u8_to_patches_bf16_kernel<false><<<blocks_for(count), kThreads, 0, stream>>>(
+        static_cast<const uint8_t*>(images), static_cast<__nv_bfloat16*>(patches), views);
+  }
+  return cudaGetLastError();
+}
+
 extern "C" cudaError_t apxinf_static_bias_activation_bf16(
     const void* input, const void* bias, void* output,
     int rows, int cols, int activation, cudaStream_t stream) {
@@ -81,11 +96,13 @@ extern "C" cudaError_t apxinf_static_bias_activation_bf16(
 
 extern "C" cudaError_t apxinf_static_embedding_bf16(
     const void* table, const void* ids, void* output,
-    int tokens, int width, int vocab_size, cudaStream_t stream) {
+    int tokens, int width, int vocab_size, bool scale_by_sqrt_width,
+    cudaStream_t stream) {
   const int64_t count = static_cast<int64_t>(tokens) * width;
   embedding_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
       static_cast<const __nv_bfloat16*>(table), static_cast<const uint32_t*>(ids),
-      static_cast<__nv_bfloat16*>(output), tokens, width, vocab_size);
+      static_cast<__nv_bfloat16*>(output), tokens, width, vocab_size,
+      scale_by_sqrt_width);
   return cudaGetLastError();
 }
 
@@ -108,6 +125,34 @@ extern "C" cudaError_t apxinf_static_euler_update_bf16(
       static_cast<const __nv_bfloat16*>(state),
       static_cast<const __nv_bfloat16*>(velocity),
       static_cast<__nv_bfloat16*>(output), count, dt);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gather_rows_bf16(
+    const void* input, const void* rows, void* output,
+    int input_rows, int output_rows, int cols, cudaStream_t stream) {
+  if (input_rows <= 0 || output_rows <= 0 || cols <= 0) return cudaErrorInvalidValue;
+  const int64_t count = static_cast<int64_t>(output_rows) * cols;
+  gather_rows_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<const uint32_t*>(rows),
+      static_cast<__nv_bfloat16*>(output), count, cols);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_scatter_rows_bf16(
+    const void* base, const void* updates, const void* rows, void* output,
+    int base_rows, int update_rows, int cols, bool add, cudaStream_t stream) {
+  if (base_rows <= 0 || update_rows <= 0 || cols <= 0) return cudaErrorInvalidValue;
+  cudaError_t status = cudaMemcpyAsync(
+      output, base, static_cast<size_t>(base_rows) * cols * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToDevice, stream);
+  if (status != cudaSuccess) return status;
+  const int64_t count = static_cast<int64_t>(update_rows) * cols;
+  scatter_rows_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(updates),
+      static_cast<const uint32_t*>(rows),
+      static_cast<__nv_bfloat16*>(output), count, cols, add);
   return cudaGetLastError();
 }
 
@@ -210,6 +255,16 @@ extern "C" cudaError_t apxinf_static_ada_rms_norm_bf16(
   return cudaGetLastError();
 }
 
+extern "C" cudaError_t apxinf_static_ada_layer_norm_bf16(
+    const void* input, const void* style, void* output,
+    int rows, int cols, float eps, bool shift_first, cudaStream_t stream) {
+  ada_layer_norm_bf16_kernel<<<rows, kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<const __nv_bfloat16*>(style),
+      static_cast<__nv_bfloat16*>(output), rows, cols, eps, shift_first);
+  return cudaGetLastError();
+}
+
 extern "C" cudaError_t apxinf_static_ada_gate_residual_bf16(
     const void* projection, const void* residual, const void* style,
     void* output, int rows, int cols, cudaStream_t stream) {
@@ -288,6 +343,33 @@ extern "C" cudaError_t apxinf_static_mha_bf16(
       static_cast<const __nv_bfloat16*>(k),
       static_cast<const __nv_bfloat16*>(v),
       static_cast<__nv_bfloat16*>(output), tokens_per_batch, heads, head_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_cross_mha_bf16(
+    const void* q, const void* k, const void* v, void* output,
+    int query_tokens, int key_tokens, int heads, int head_dim,
+    cudaStream_t stream) {
+  dim3 grid(query_tokens, heads, 1);
+  const size_t shared = static_cast<size_t>(key_tokens + 8) * sizeof(float);
+  cross_mha_bf16_kernel<<<grid, kThreads, shared, stream>>>(
+      static_cast<const __nv_bfloat16*>(q),
+      static_cast<const __nv_bfloat16*>(k),
+      static_cast<const __nv_bfloat16*>(v),
+      static_cast<__nv_bfloat16*>(output), query_tokens, key_tokens,
+      heads, head_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_causal_gqa_bf16(
+    const void* q, const void* k, const void* v, void* output,
+    int tokens, int q_heads, int kv_heads, int head_dim, cudaStream_t stream) {
+  const int threads = 128;
+  const size_t shared = static_cast<size_t>(tokens + threads / 32) * sizeof(float);
+  causal_gqa_bf16_kernel<<<dim3(tokens, q_heads), threads, shared, stream>>>(
+      static_cast<const __nv_bfloat16*>(q), static_cast<const __nv_bfloat16*>(k),
+      static_cast<const __nv_bfloat16*>(v), static_cast<__nv_bfloat16*>(output),
+      tokens, q_heads, kv_heads, head_dim);
   return cudaGetLastError();
 }
 

--- a/crates/apxinf-cuda/build.rs
+++ b/crates/apxinf-cuda/build.rs
@@ -114,6 +114,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(apxinf_cutlass_bf16_sm89)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_cutlass_int8_sm80)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_sm80)");
+    println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_bf16)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_f16_sm100)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_direct_e4m3_sm100)");
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH");
@@ -287,7 +288,8 @@ fn main() {
             let cutlass_fmha = std::path::Path::new(&adapters_dir).join("cutlass_fmha_adapter.cu");
             let cutlass_gemm = std::path::Path::new(&adapters_dir).join("cutlass_fp8_adapter.cu");
             let cutlass_bf16 = std::path::Path::new(&adapters_dir).join("cutlass_bf16_adapter.cu");
-            let cutlass_bf16_sm89 = std::path::Path::new(&adapters_dir).join("cutlass_bf16_sm89_adapter.cu");
+            let cutlass_bf16_sm89 =
+                std::path::Path::new(&adapters_dir).join("cutlass_bf16_sm89_adapter.cu");
             let cutlass_int8 = std::path::Path::new(&adapters_dir).join("cutlass_w8a8_adapter.cu");
             let mut cutlass_includes = Vec::new();
             if cutlass_arch.as_deref().is_some_and(is_cutlass_sm100_family) {
@@ -386,6 +388,7 @@ fn main() {
             let fa2_sm80 = nvcc_arch.as_deref().is_some_and(is_fa2_sm80_family);
             let fa2_f16_sm100 = nvcc_arch.as_deref().is_some_and(is_cutlass_sm100_family);
             if fa2_sm80 || fa2_f16_sm100 {
+                println!("cargo:rustc-cfg=apxinf_fa2_bf16");
                 let fa2_hdim96 = fa2_root.join("flash_attn/flash_fwd_hdim96_bf16_sm80.cu");
                 let fa2_hdim256 = fa2_root.join("flash_attn/flash_fwd_hdim256_bf16_sm80.cu");
                 let fa2_f16_hdim96 = fa2_root.join("flash_attn/flash_fwd_hdim96_fp16.cu");

--- a/crates/apxinf-cuda/kernels/custom/activation.cuh
+++ b/crates/apxinf-cuda/kernels/custom/activation.cuh
@@ -251,6 +251,7 @@ __global__ void bias_activation_bf16_kernel(
     if (bias != nullptr) value += __bfloat162float(bias[index % cols]);
     if (activation == 1) value = gelu_tanh(value);
     if (activation == 2) value = value / (1.0f + expf(-value));
+    if (activation == 3) value = fmaxf(value, 0.0f);
     output[index] = __float2bfloat16(value);
   }
 }
@@ -283,6 +284,10 @@ __global__ void bias_activation_bf16_packed2_kernel(
     if (activation == 2) {
       first = first / (1.0f + expf(-first));
       second = second / (1.0f + expf(-second));
+    }
+    if (activation == 3) {
+      first = fmaxf(first, 0.0f);
+      second = fmaxf(second, 0.0f);
     }
     output2[pair_index] = __floats2bfloat162_rn(first, second);
   }
@@ -321,6 +326,10 @@ __global__ void bias_activation_bf16_packed4_kernel(
 #pragma unroll
       for (int i = 0; i < 4; ++i)
         values[i] = values[i] / (1.0f + expf(-values[i]));
+    }
+    if (activation == 3) {
+#pragma unroll
+      for (int i = 0; i < 4; ++i) values[i] = fmaxf(values[i], 0.0f);
     }
     output4[quad_index] = Bf16x4{
         __floats2bfloat162_rn(values[0], values[1]),

--- a/crates/apxinf-cuda/kernels/custom/attention.cuh
+++ b/crates/apxinf-cuda/kernels/custom/attention.cuh
@@ -871,5 +871,115 @@ __global__ void mha_bf16_kernel(
   }
 }
 
+__global__ void cross_mha_bf16_kernel(
+    const __nv_bfloat16* q, const __nv_bfloat16* k,
+    const __nv_bfloat16* v, __nv_bfloat16* output,
+    int query_tokens, int key_tokens, int heads, int head_dim) {
+  extern __shared__ float shared[];
+  float* scores = shared;
+  float* warp_sums = scores + key_tokens;
+  const int query = blockIdx.x;
+  const int head = blockIdx.y;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps = blockDim.x >> 5;
+  const __nv_bfloat16* query_ptr = q + (query * heads + head) * head_dim;
+  const float scale = rsqrtf(static_cast<float>(head_dim));
+  for (int token = 0; token < key_tokens; ++token) {
+    const __nv_bfloat16* key = k + (static_cast<int64_t>(token) * heads + head) * head_dim;
+    float dot = tid < head_dim
+        ? __bfloat162float(query_ptr[tid]) * __bfloat162float(key[tid])
+        : 0.0f;
+    dot = warp_sum(dot);
+    if (lane == 0) warp_sums[warp] = dot;
+    __syncthreads();
+    if (warp == 0) {
+      float total = lane < warps ? warp_sums[lane] : 0.0f;
+      total = warp_sum(total);
+      if (lane == 0) scores[token] = total * scale;
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float maximum = -3.402823466e+38F;
+    for (int token = 0; token < key_tokens; ++token)
+      maximum = fmaxf(maximum, scores[token]);
+    float denominator = 0.0f;
+    for (int token = 0; token < key_tokens; ++token) {
+      scores[token] = expf(scores[token] - maximum);
+      denominator += scores[token];
+    }
+    for (int token = 0; token < key_tokens; ++token)
+      scores[token] /= denominator;
+  }
+  __syncthreads();
+  if (tid < head_dim) {
+    float accumulator = 0.0f;
+    for (int token = 0; token < key_tokens; ++token) {
+      const __nv_bfloat16* value =
+          v + (static_cast<int64_t>(token) * heads + head) * head_dim;
+      accumulator += scores[token] * __bfloat162float(value[tid]);
+    }
+    output[(query * heads + head) * head_dim + tid] =
+        __float2bfloat16(accumulator);
+  }
+}
 
-
+// Fixed-shape causal GQA used by multimodal prefill. Q is
+// [tokens,q_heads,head_dim], K/V are [tokens,kv_heads,head_dim].
+__global__ void causal_gqa_bf16_kernel(
+    const __nv_bfloat16* q, const __nv_bfloat16* k,
+    const __nv_bfloat16* v, __nv_bfloat16* output,
+    int tokens, int q_heads, int kv_heads, int head_dim) {
+  extern __shared__ float shared[];
+  float* scores = shared;
+  float* warp_sums = scores + tokens;
+  const int query = blockIdx.x;
+  const int q_head = blockIdx.y;
+  const int kv_head = q_head / (q_heads / kv_heads);
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps = blockDim.x >> 5;
+  const __nv_bfloat16* query_ptr =
+      q + (static_cast<int64_t>(query) * q_heads + q_head) * head_dim;
+  const float scale = rsqrtf(static_cast<float>(head_dim));
+  for (int token = 0; token <= query; ++token) {
+    const __nv_bfloat16* key =
+        k + (static_cast<int64_t>(token) * kv_heads + kv_head) * head_dim;
+    float dot = tid < head_dim
+        ? __bfloat162float(query_ptr[tid]) * __bfloat162float(key[tid]) : 0.0f;
+    dot = warp_sum(dot);
+    if (lane == 0) warp_sums[warp] = dot;
+    __syncthreads();
+    if (warp == 0) {
+      float total = lane < warps ? warp_sums[lane] : 0.0f;
+      total = warp_sum(total);
+      if (lane == 0) scores[token] = total * scale;
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float maximum = -3.402823466e+38F;
+    for (int token = 0; token <= query; ++token)
+      maximum = fmaxf(maximum, scores[token]);
+    float denominator = 0.0f;
+    for (int token = 0; token <= query; ++token) {
+      scores[token] = expf(scores[token] - maximum);
+      denominator += scores[token];
+    }
+    for (int token = 0; token <= query; ++token) scores[token] /= denominator;
+  }
+  __syncthreads();
+  if (tid < head_dim) {
+    float accumulator = 0.0f;
+    for (int token = 0; token <= query; ++token) {
+      const __nv_bfloat16* value =
+          v + (static_cast<int64_t>(token) * kv_heads + kv_head) * head_dim;
+      accumulator += scores[token] * __bfloat162float(value[tid]);
+    }
+    output[(static_cast<int64_t>(query) * q_heads + q_head) * head_dim + tid] =
+        __float2bfloat16(accumulator);
+  }
+}

--- a/crates/apxinf-cuda/kernels/custom/elementwise.cuh
+++ b/crates/apxinf-cuda/kernels/custom/elementwise.cuh
@@ -181,4 +181,32 @@ __global__ void bias_position_bf16_kernel(
   }
 }
 
+__global__ void gather_rows_bf16_kernel(
+    const __nv_bfloat16* input, const uint32_t* rows,
+    __nv_bfloat16* output, int64_t count, int cols) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const int output_row = static_cast<int>(index / cols);
+    const int col = static_cast<int>(index % cols);
+    output[index] = input[static_cast<int64_t>(rows[output_row]) * cols + col];
+  }
+}
 
+__global__ void scatter_rows_bf16_kernel(
+    const __nv_bfloat16* updates, const uint32_t* rows,
+    __nv_bfloat16* output, int64_t count, int cols, bool add) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const int update_row = static_cast<int>(index / cols);
+    const int col = static_cast<int>(index % cols);
+    const int64_t output_index = static_cast<int64_t>(rows[update_row]) * cols + col;
+    if (add) {
+      output[output_index] = __float2bfloat16(
+          __bfloat162float(output[output_index]) + __bfloat162float(updates[index]));
+    } else {
+      output[output_index] = updates[index];
+    }
+  }
+}

--- a/crates/apxinf-cuda/kernels/custom/embedding.cuh
+++ b/crates/apxinf-cuda/kernels/custom/embedding.cuh
@@ -57,9 +57,10 @@ __global__ void embedding_f16_kernel(
 
 __global__ void embedding_bf16_kernel(
     const __nv_bfloat16* table, const uint32_t* ids, __nv_bfloat16* output,
-    int tokens, int width, int vocab_size) {
+    int tokens, int width, int vocab_size, bool scale_by_sqrt_width) {
   const int64_t count = static_cast<int64_t>(tokens) * width;
-  const float normalizer = sqrtf(static_cast<float>(width));
+  const float normalizer = scale_by_sqrt_width
+      ? sqrtf(static_cast<float>(width)) : 1.0f;
   int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   for (; index < count; index += stride) {
@@ -72,6 +73,5 @@ __global__ void embedding_bf16_kernel(
         : __float2bfloat16(0.0f);
   }
 }
-
 
 

--- a/crates/apxinf-cuda/kernels/custom/normalization.cuh
+++ b/crates/apxinf-cuda/kernels/custom/normalization.cuh
@@ -255,5 +255,28 @@ __global__ void ada_rms_norm_bf16_kernel(
   }
 }
 
-
+__global__ void ada_layer_norm_bf16_kernel(
+    const __nv_bfloat16* input, const __nv_bfloat16* style,
+    __nv_bfloat16* output, int rows, int cols, float eps, bool shift_first) {
+  __shared__ float scratch[8];
+  const int row = blockIdx.x;
+  float sum = 0.0f;
+  for (int col = threadIdx.x; col < cols; col += blockDim.x)
+    sum += __bfloat162float(input[static_cast<int64_t>(row) * cols + col]);
+  const float mean = block_sum(sum, scratch) / cols;
+  float variance_sum = 0.0f;
+  for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+    const float centered =
+        __bfloat162float(input[static_cast<int64_t>(row) * cols + col]) - mean;
+    variance_sum += centered * centered;
+  }
+  const float inverse_std = rsqrtf(block_sum(variance_sum, scratch) / cols + eps);
+  for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+    const int64_t index = static_cast<int64_t>(row) * cols + col;
+    const float normalized = (__bfloat162float(input[index]) - mean) * inverse_std;
+    const float scale = __bfloat162float(style[(shift_first ? cols : 0) + col]);
+    const float shift = __bfloat162float(style[(shift_first ? 0 : cols) + col]);
+    output[index] = __float2bfloat16(normalized * (1.0f + scale) + shift);
+  }
+}
 

--- a/crates/apxinf-cuda/kernels/custom/preprocess.cuh
+++ b/crates/apxinf-cuda/kernels/custom/preprocess.cuh
@@ -96,5 +96,44 @@ __global__ void rgb_u8_to_patches_bf16_kernel(
   }
 }
 
+// GR00T N1.7 stacks two identical temporal frames inside each 16x16 patch.
+// Patch rows follow [coarse_y, coarse_x, sub_y, sub_x], while features follow
+// [channel, time, patch_y, patch_x].
+template <bool kNhwc>
+__global__ void groot_rgb_u8_to_patches_bf16_kernel(
+    const uint8_t* images, __nv_bfloat16* patches, int views) {
+  constexpr int image_size = 256;
+  constexpr int patch_size = 16;
+  constexpr int patches_per_view = 256;
+  constexpr int patch_width = 1536;
+  const int64_t count = static_cast<int64_t>(views) * patches_per_view * patch_width;
+  int64_t output_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; output_index < count; output_index += stride) {
+    int feature = static_cast<int>(output_index % patch_width);
+    int patch = static_cast<int>((output_index / patch_width) % patches_per_view);
+    const int view = static_cast<int>(output_index / (patch_width * patches_per_view));
+    const int dx = feature % patch_size;
+    feature /= patch_size;
+    const int dy = feature % patch_size;
+    feature /= patch_size;
+    feature /= 2;  // The temporal dimension contains two copies of the same frame.
+    const int channel = feature;
+    const int sub_x = patch % 2;
+    patch /= 2;
+    const int sub_y = patch % 2;
+    patch /= 2;
+    const int coarse_x = patch % 8;
+    const int coarse_y = patch / 8;
+    const int x = (coarse_x * 2 + sub_x) * patch_size + dx;
+    const int y = (coarse_y * 2 + sub_y) * patch_size + dy;
+    const int64_t input_index = kNhwc
+        ? ((static_cast<int64_t>(view) * image_size + y) * image_size + x) * 3 + channel
+        : ((static_cast<int64_t>(view) * 3 + channel) * image_size + y) * image_size + x;
+    const float normalized =
+        (static_cast<float>(images[input_index]) / 255.0f) * 2.0f - 1.0f;
+    patches[output_index] = __float2bfloat16(normalized);
+  }
+}
 
 

--- a/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim256_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim256_bf16_sm80.cu
@@ -11,4 +11,9 @@ void run_mha_fwd_<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cud
     run_mha_fwd_hdim256<cutlass::bfloat16_t, false>(params, stream);
 }
 
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::bfloat16_t, true>(params, stream);
+}
+
 } // namespace FLASH_NAMESPACE

--- a/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim96_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim96_bf16_sm80.cu
@@ -11,4 +11,9 @@ void run_mha_fwd_<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cuda
     run_mha_fwd_hdim96<cutlass::bfloat16_t, false>(params, stream);
 }
 
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::bfloat16_t, true>(params, stream);
+}
+
 } // namespace FLASH_NAMESPACE

--- a/crates/apxinf-cuda/kernels/cutlass/fa2_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2_bf16_sm80.cu
@@ -33,7 +33,7 @@ void fill_params(FLASH_NAMESPACE::Flash_fwd_params& params, bool is_bf16,
                  const void* q, const void* k, const void* v, void* output,
                  void* softmax_lse, int batch, int query_tokens,
                  int key_tokens, int query_heads, int kv_heads, int head_dim,
-                 float softmax_scale) {
+                 float softmax_scale, bool causal) {
   params = {};
   params.is_bf16 = is_bf16;
   params.q_ptr = const_cast<void*>(q);
@@ -75,7 +75,7 @@ void fill_params(FLASH_NAMESPACE::Flash_fwd_params& params, bool is_bf16,
   params.p_dropout_in_uint8_t = 255;
   params.rp_dropout = 1.0f;
 
-  params.is_causal = false;
+  params.is_causal = causal;
   params.window_size_left = -1;
   params.window_size_right = -1;
   params.is_seqlens_k_cumulative = true;
@@ -143,7 +143,7 @@ int setup_splitkv(FLASH_NAMESPACE::Flash_fwd_params& params,
 
 namespace apxinf::cuda::cutlass_ops {
 
-template <typename Element>
+template <typename Element, bool IsCausal>
 int fa2(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
@@ -159,11 +159,11 @@ int fa2(
   FLASH_NAMESPACE::Flash_fwd_params params;
   fill_params(params, std::is_same<Element, cutlass::bfloat16_t>::value,
               q, k, v, output, softmax_lse, batch, query_tokens,
-              key_tokens, query_heads, kv_heads, head_dim, softmax_scale);
+              key_tokens, query_heads, kv_heads, head_dim, softmax_scale, IsCausal);
   if (head_dim <= 96) {
-    FLASH_NAMESPACE::run_mha_fwd_<Element, 96, false>(params, stream);
+    FLASH_NAMESPACE::run_mha_fwd_<Element, 96, IsCausal>(params, stream);
   } else {
-    FLASH_NAMESPACE::run_mha_fwd_<Element, 256, false>(params, stream);
+    FLASH_NAMESPACE::run_mha_fwd_<Element, 256, IsCausal>(params, stream);
   }
   return static_cast<int>(cudaSuccess);
 }
@@ -186,7 +186,7 @@ int fa2_splitkv(
   FLASH_NAMESPACE::Flash_fwd_params params;
   fill_params(params, std::is_same<Element, cutlass::bfloat16_t>::value,
               q, k, v, output, softmax_lse, batch, query_tokens,
-              key_tokens, query_heads, kv_heads, head_dim, softmax_scale);
+              key_tokens, query_heads, kv_heads, head_dim, softmax_scale, false);
   const int num_splits =
       setup_splitkv(params, softmax_lse_accum, o_accum, num_sms, query_tokens,
                     key_tokens, head_dim, batch, query_heads);
@@ -211,9 +211,14 @@ int fa2_splitkv(
 int fa2_bf16(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
-    int query_heads, int kv_heads, int head_dim, float softmax_scale,
+    int query_heads, int kv_heads, int head_dim, float softmax_scale, bool causal,
     cudaStream_t stream) {
-  return fa2<cutlass::bfloat16_t>(
+  if (causal) {
+    return fa2<cutlass::bfloat16_t, true>(
+        q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
+        query_heads, kv_heads, head_dim, softmax_scale, stream);
+  }
+  return fa2<cutlass::bfloat16_t, false>(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
       query_heads, kv_heads, head_dim, softmax_scale, stream);
 }
@@ -236,7 +241,7 @@ int fa2_f16(
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
     int query_heads, int kv_heads, int head_dim, float softmax_scale,
     cudaStream_t stream) {
-  return fa2<cutlass::half_t>(
+  return fa2<cutlass::half_t, false>(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
       query_heads, kv_heads, head_dim, softmax_scale, stream);
 }

--- a/crates/apxinf-cuda/src/backend.rs
+++ b/crates/apxinf-cuda/src/backend.rs
@@ -208,7 +208,7 @@ impl Backend for CudaBackend {
             }
         }
         let out_bytes = rows * total_cols * elem;
-        let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+        let out_buf = crate::workspace::output_buffer(&self.ctx, out_bytes)?;
         let dst_pitch = total_cols * elem;
         let mut col_offset = 0usize;
         for t in tensors {

--- a/crates/apxinf-cuda/src/ffi/custom.rs
+++ b/crates/apxinf-cuda/src/ffi/custom.rs
@@ -338,8 +338,15 @@ extern "C" {
         layout: i32,
         stream: cudaStream_t,
     ) -> cudaError_t;
+    pub fn apxinf_static_groot_rgb_u8_to_patches_bf16(
+        images: *const c_void,
+        patches: *mut c_void,
+        views: i32,
+        layout: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
     /// BF16 bias/activation epilogue. `activation`: 0=identity, 1=GELU-tanh,
-    /// 2=SiLU.
+    /// 2=SiLU, 3=ReLU.
     pub fn apxinf_static_bias_activation_bf16(
         input: *const c_void,
         bias: *const c_void,
@@ -356,6 +363,7 @@ extern "C" {
         tokens: i32,
         width: i32,
         vocab_size: i32,
+        scale_by_sqrt_width: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
     pub fn apxinf_static_concat_rows_bf16(
@@ -373,6 +381,26 @@ extern "C" {
         output: *mut c_void,
         count: i64,
         dt: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_gather_rows_bf16(
+        input: *const c_void,
+        rows: *const c_void,
+        output: *mut c_void,
+        input_rows: i32,
+        output_rows: i32,
+        cols: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_scatter_rows_bf16(
+        base: *const c_void,
+        updates: *const c_void,
+        rows: *const c_void,
+        output: *mut c_void,
+        base_rows: i32,
+        update_rows: i32,
+        cols: i32,
+        add: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
     pub fn apxinf_static_geglu_bf16(
@@ -444,6 +472,16 @@ extern "C" {
         eps: f32,
         stream: cudaStream_t,
     ) -> cudaError_t;
+    pub fn apxinf_static_ada_layer_norm_bf16(
+        input: *const c_void,
+        style: *const c_void,
+        output: *mut c_void,
+        rows: i32,
+        cols: i32,
+        eps: f32,
+        shift_first: bool,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
     pub fn apxinf_static_ada_gate_residual_bf16(
         projection: *const c_void,
         residual: *const c_void,
@@ -509,6 +547,28 @@ extern "C" {
         tokens_per_batch: i32,
         batches: i32,
         heads: i32,
+        head_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_cross_mha_bf16(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        output: *mut c_void,
+        query_tokens: i32,
+        key_tokens: i32,
+        heads: i32,
+        head_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_causal_gqa_bf16(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        output: *mut c_void,
+        tokens: i32,
+        q_heads: i32,
+        kv_heads: i32,
         head_dim: i32,
         stream: cudaStream_t,
     ) -> cudaError_t;

--- a/crates/apxinf-cuda/src/ffi/fa2.rs
+++ b/crates/apxinf-cuda/src/ffi/fa2.rs
@@ -39,7 +39,7 @@ extern "C" {
         stream: cudaStream_t,
     ) -> cudaError_t;
 
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     pub fn apxinf_static_fa2_bf16(
         q: *const c_void,
         k: *const c_void,
@@ -53,6 +53,7 @@ extern "C" {
         kv_heads: i32,
         head_dim: i32,
         softmax_scale: f32,
+        causal: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
 

--- a/crates/apxinf-cuda/src/kernels/activation.rs
+++ b/crates/apxinf-cuda/src/kernels/activation.rs
@@ -9,6 +9,7 @@ use super::contracts::{
 use crate::buffer::CudaBuffer;
 use crate::context::CudaContext;
 use crate::ffi;
+use crate::workspace::output_buffer;
 
 /// Allocation-free SiLU into caller-owned decode storage.
 pub fn silu_into(
@@ -87,7 +88,7 @@ pub fn silu(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     let count = input.numel() as u32;
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -117,7 +118,7 @@ pub fn gelu_tanh(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     }
     let device_id = ctx.device_id();
     let count = input.numel() as u32;
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res =
             ffi::apxinf_gelu_tanh_bf16(gpu_ptr(input)?, out_buf.ptr(), count, ctx.stream().handle());
@@ -166,6 +167,11 @@ pub fn bias_gelu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>)
 
 pub fn bias_silu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>) -> Result<Tensor> {
     bias_activation(ctx, input, value, 2)
+}
+
+/// Broadcast-add an optional BF16 bias and apply ReLU on device.
+pub fn bias_relu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>) -> Result<Tensor> {
+    bias_activation(ctx, input, value, 3)
 }
 
 pub fn geglu_bf16(ctx: &CudaContext, gate_up: &Tensor) -> Result<Tensor> {

--- a/crates/apxinf-cuda/src/kernels/attention.rs
+++ b/crates/apxinf-cuda/src/kernels/attention.rs
@@ -335,7 +335,7 @@ pub fn softmax(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     let cols = *dims.last().unwrap();
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -539,7 +539,7 @@ pub fn split_qkv_bias_bf16(
     })
 }
 
-#[cfg(apxinf_fa2_sm80)]
+#[cfg(apxinf_fa2_bf16)]
 #[allow(clippy::too_many_arguments)]
 fn fa2_attention(
     ctx: &CudaContext,
@@ -552,6 +552,7 @@ fn fa2_attention(
     query_heads: usize,
     kv_heads: usize,
     head_dim: usize,
+    causal: bool,
 ) -> Result<Tensor> {
     let output = output_buffer(ctx, q.size_in_bytes())?;
     let lse_elements = batches
@@ -580,6 +581,7 @@ fn fa2_attention(
             kv_heads as i32,
             head_dim as i32,
             (head_dim as f32).sqrt().recip(),
+            causal,
             ctx.stream().handle(),
         ))
         .map_err(Error::Cuda)?;
@@ -603,10 +605,7 @@ fn fa2_splitkv_enabled(
     if std::env::var_os("APXINF_DISABLE_FA2_SPLITKV").is_some() {
         return false;
     }
-    query_tokens <= 64
-        && key_tokens > query_tokens
-        && query_heads > kv_heads
-        && head_dim == 256
+    query_tokens <= 64 && key_tokens > query_tokens && query_heads > kv_heads && head_dim == 256
 }
 
 #[cfg(apxinf_fa2_sm80)]
@@ -749,24 +748,25 @@ pub fn mqa_bf16(
             "static inference BF16 MQA shape mismatch".into(),
         ));
     }
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     {
+        #[cfg(apxinf_fa2_sm80)]
         if fa2_splitkv_enabled(q_shape[0], key_tokens, q_shape[1], 1, q_shape[2]) {
             return fa2_attention_splitkv(
                 ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2],
             );
         }
         return fa2_attention(
-            ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2],
+            ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2], false,
         );
     }
-    #[cfg(apxinf_cutlass_fmha)]
+    #[cfg(all(apxinf_cutlass_fmha, not(apxinf_fa2_bf16)))]
     {
         return cublas_mqa_bf16(ctx, q, k, v, key_tokens);
     }
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     let output = output_buffer(ctx, q.size_in_bytes())?;
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     unsafe {
         ffi::check_cuda(ffi::apxinf_static_mqa_bf16(
             gpu_ptr(q)?,
@@ -781,7 +781,7 @@ pub fn mqa_bf16(
         ))
         .map_err(Error::Cuda)?;
     }
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     Ok(make_gpu_tensor(
         q.shape().clone(),
         DType::BF16,
@@ -812,7 +812,7 @@ pub fn mha_bf16(
             "static inference BF16 MHA shape mismatch".into(),
         ));
     }
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     {
         return fa2_attention(
             ctx,
@@ -825,9 +825,10 @@ pub fn mha_bf16(
             shape[1],
             shape[1],
             shape[2],
+            false,
         );
     }
-    #[cfg(apxinf_cutlass_fmha)]
+    #[cfg(all(apxinf_cutlass_fmha, not(apxinf_fa2_bf16)))]
     if tokens_per_batch == 256 && shape[1] == 16 && shape[2] == 72 {
         let output = output_buffer(ctx, q.size_in_bytes())?;
         unsafe {
@@ -878,9 +879,9 @@ pub fn mha_bf16(
             ));
         }
     }
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
     let output = output_buffer(ctx, q.size_in_bytes())?;
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
     unsafe {
         ffi::check_cuda(ffi::apxinf_static_mha_bf16(
             gpu_ptr(q)?,
@@ -895,7 +896,100 @@ pub fn mha_bf16(
         ))
         .map_err(Error::Cuda)?;
     }
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
+    Ok(make_gpu_tensor(
+        q.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Non-causal BF16 multi-head cross attention with distinct query/key lengths.
+pub fn cross_mha_bf16(ctx: &CudaContext, q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+    let q_shape = q.shape().dims();
+    let k_shape = k.shape().dims();
+    if [q, k, v]
+        .into_iter()
+        .any(|tensor| tensor.dtype() != DType::BF16)
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape() != k.shape()
+        || q_shape[1..] != k_shape[1..]
+        || q_shape[2] > 256
+        || q_shape[0] == 0
+        || k_shape[0] == 0
+    {
+        return Err(Error::Other(
+            "static inference BF16 cross-MHA shape mismatch".into(),
+        ));
+    }
+    #[cfg(apxinf_fa2_bf16)]
+    {
+        return fa2_attention(
+            ctx, q, k, v, 1, q_shape[0], k_shape[0], q_shape[1], k_shape[1], q_shape[2], false,
+        );
+    }
+    #[cfg(not(apxinf_fa2_bf16))]
+    let output = output_buffer(ctx, q.size_in_bytes())?;
+    #[cfg(not(apxinf_fa2_bf16))]
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_cross_mha_bf16(
+            gpu_ptr(q)?,
+            gpu_ptr(k)?,
+            gpu_ptr(v)?,
+            output.ptr(),
+            q_shape[0] as i32,
+            k_shape[0] as i32,
+            q_shape[1] as i32,
+            q_shape[2] as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    #[cfg(not(apxinf_fa2_bf16))]
+    Ok(make_gpu_tensor(
+        q.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Causal BF16 grouped-query attention for a complete prefill sequence.
+pub fn causal_gqa_bf16(ctx: &CudaContext, q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+    let q_shape = q.shape().dims();
+    let k_shape = k.shape().dims();
+    if [q, k, v]
+        .into_iter()
+        .any(|tensor| tensor.dtype() != DType::BF16)
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape() != k.shape()
+        || q_shape[0] != k_shape[0]
+        || q_shape[2] != k_shape[2]
+        || q_shape[1] % k_shape[1] != 0
+        || q_shape[2] > 256
+    {
+        return Err(Error::Other(
+            "static inference BF16 causal GQA shape mismatch".into(),
+        ));
+    }
+    let output = output_buffer(ctx, q.size_in_bytes())?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_causal_gqa_bf16(
+            gpu_ptr(q)?,
+            gpu_ptr(k)?,
+            gpu_ptr(v)?,
+            output.ptr(),
+            q_shape[0] as i32,
+            q_shape[1] as i32,
+            k_shape[1] as i32,
+            q_shape[2] as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
     Ok(make_gpu_tensor(
         q.shape().clone(),
         DType::BF16,

--- a/crates/apxinf-cuda/src/kernels/elementwise.rs
+++ b/crates/apxinf-cuda/src/kernels/elementwise.rs
@@ -105,7 +105,7 @@ pub fn add_bias(ctx: &CudaContext, input: &Tensor, bias: &Tensor) -> Result<Tens
     } else {
         dims[dims.len() - 1]
     };
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res = ffi::apxinf_add_bias_bf16(
             gpu_ptr(input)?,
@@ -130,7 +130,7 @@ pub fn add(ctx: &CudaContext, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     let count = a.numel() as u32;
 
     let out_bytes = a.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match a.dtype() {
@@ -167,7 +167,7 @@ pub fn mul(ctx: &CudaContext, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     let count = a.numel() as u32;
 
     let out_bytes = a.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match a.dtype() {
@@ -290,6 +290,116 @@ pub fn euler_update_bf16(
     }
     Ok(make_gpu_tensor(
         state.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Stable device-side u32 row indices for graph-captured gather/scatter.
+pub struct RowIndices {
+    buffer: CudaBuffer,
+    len: usize,
+    max: u32,
+}
+
+impl RowIndices {
+    pub fn new(device_id: usize, rows: &[u32]) -> Result<Self> {
+        if rows.is_empty() {
+            return Err(Error::Other("row indices cannot be empty".into()));
+        }
+        let mut sorted = rows.to_vec();
+        sorted.sort_unstable();
+        if sorted.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(Error::Other("row indices must be unique".into()));
+        }
+        let bytes = bytemuck::cast_slice(rows);
+        let buffer = CudaBuffer::alloc(bytes.len(), device_id).map_err(Error::Cuda)?;
+        buffer.copy_from_host(bytes).map_err(Error::Cuda)?;
+        Ok(Self {
+            buffer,
+            len: rows.len(),
+            max: *sorted.last().unwrap(),
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+pub fn gather_rows_bf16(ctx: &CudaContext, input: &Tensor, rows: &RowIndices) -> Result<Tensor> {
+    let (input_rows, cols) = matrix_shape(input, "BF16 gather rows")?;
+    if input.dtype() != DType::BF16
+        || rows.buffer.device() != ctx.device_id()
+        || rows.max as usize >= input_rows
+    {
+        return Err(Error::Other(
+            "BF16 gather rows dtype/device mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, rows.len, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_gather_rows_bf16(
+            gpu_ptr(input)?,
+            rows.buffer.ptr(),
+            output.ptr(),
+            input_rows as i32,
+            rows.len as i32,
+            cols as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows.len, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+pub fn scatter_rows_bf16(
+    ctx: &CudaContext,
+    base: &Tensor,
+    updates: &Tensor,
+    rows: &RowIndices,
+    add: bool,
+) -> Result<Tensor> {
+    let (base_rows, cols) = matrix_shape(base, "BF16 scatter rows base")?;
+    let (update_rows, update_cols) = matrix_shape(updates, "BF16 scatter rows updates")?;
+    if base.dtype() != DType::BF16
+        || updates.dtype() != DType::BF16
+        || update_rows != rows.len
+        || update_cols != cols
+        || rows.buffer.device() != ctx.device_id()
+        || rows.max as usize >= base_rows
+    {
+        return Err(Error::Other(
+            "BF16 scatter rows shape/dtype/device mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, base_rows, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_scatter_rows_bf16(
+            gpu_ptr(base)?,
+            gpu_ptr(updates)?,
+            rows.buffer.ptr(),
+            output.ptr(),
+            base_rows as i32,
+            update_rows as i32,
+            cols as i32,
+            add,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(make_gpu_tensor(
+        Shape::new(vec![base_rows, cols]),
         DType::BF16,
         ctx.device_id(),
         output,

--- a/crates/apxinf-cuda/src/kernels/embedding.rs
+++ b/crates/apxinf-cuda/src/kernels/embedding.rs
@@ -114,6 +114,26 @@ pub fn lookup_bf16(
     ids: &CudaBuffer,
     tokens: usize,
 ) -> Result<Tensor> {
+    lookup_bf16_impl(ctx, table, ids, tokens, true)
+}
+
+/// Raw BF16 embedding lookup without model-specific input scaling.
+pub fn lookup_unscaled_bf16(
+    ctx: &CudaContext,
+    table: &Tensor,
+    ids: &CudaBuffer,
+    tokens: usize,
+) -> Result<Tensor> {
+    lookup_bf16_impl(ctx, table, ids, tokens, false)
+}
+
+fn lookup_bf16_impl(
+    ctx: &CudaContext,
+    table: &Tensor,
+    ids: &CudaBuffer,
+    tokens: usize,
+    scale_by_sqrt_width: bool,
+) -> Result<Tensor> {
     let dims = table.shape().dims();
     if table.dtype() != DType::BF16 || dims.len() != 2 || ids.len() < tokens * 4 || tokens == 0 {
         return Err(Error::Other(
@@ -129,6 +149,7 @@ pub fn lookup_bf16(
             tokens as i32,
             dims[1] as i32,
             dims[0] as i32,
+            scale_by_sqrt_width,
             ctx.stream().handle(),
         ))
         .map_err(Error::Cuda)?;

--- a/crates/apxinf-cuda/src/kernels/gemm/mod.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/mod.rs
@@ -8,6 +8,7 @@ use super::contracts::{checked_bytes, require_buffers, require_finite};
 use crate::buffer::CudaBuffer;
 use crate::context::CudaContext;
 use crate::cublas::CublasTranspose;
+use crate::workspace::output_buffer;
 
 pub use bf16::{
     autotune_cublaslt_bf16, gemm_bf16 as bf16, gemm_bf16_geglu_fused as bf16_geglu_fused,
@@ -48,11 +49,10 @@ pub fn matmul(ctx: &CudaContext, activation: &Tensor, weight: &Tensor) -> Result
     let m = activation.shape().dims()[activation.ndim() - 2];
     let k = activation.shape().dims()[activation.ndim() - 1];
     let n = weight.shape().dims()[weight.ndim() - 1];
-    let output = CudaBuffer::alloc_zeros(
+    let output = output_buffer(
+        ctx,
         output_shape.numel() * activation.dtype().size_in_bytes(),
-        ctx.device_id(),
-    )
-    .map_err(Error::Cuda)?;
+    )?;
     let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
     let weight_buffer = CudaBuffer::from_tensor(weight).map_err(Error::Cuda)?;
     ctx.cublas()

--- a/crates/apxinf-cuda/src/kernels/norm.rs
+++ b/crates/apxinf-cuda/src/kernels/norm.rs
@@ -285,6 +285,43 @@ pub fn adaptive_rms_bf16(
     }
     Ok(matrix_tensor(ctx, rows, cols, output))
 }
+
+/// Affine-free LayerNorm followed by timestep shift/scale.
+/// `style` is `[2 * cols]` or `[1, 2 * cols]`, broadcast across rows and laid
+/// out as `(scale, shift)` unless `shift_first` is set.
+pub fn adaptive_layer_bf16(
+    ctx: &CudaContext,
+    input: &Tensor,
+    style: &Tensor,
+    eps: f32,
+    shift_first: bool,
+) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(input, "AdaLayerNorm")?;
+    let style_dims = style.shape().dims();
+    if input.dtype() != DType::BF16
+        || style.dtype() != DType::BF16
+        || (style_dims != [2 * cols] && style_dims != [1, 2 * cols])
+    {
+        return Err(Error::Other(
+            "static inference BF16 AdaLayerNorm shape mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, rows, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_ada_layer_norm_bf16(
+            gpu_ptr(input)?,
+            gpu_ptr(style)?,
+            output.ptr(),
+            rows as i32,
+            cols as i32,
+            eps,
+            shift_first,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(matrix_tensor(ctx, rows, cols, output))
+}
 pub fn rms_quant_f16_e4m3(
     ctx: &CudaContext,
     input: &Tensor,

--- a/crates/apxinf-cuda/src/kernels/preprocess.rs
+++ b/crates/apxinf-cuda/src/kernels/preprocess.rs
@@ -80,6 +80,37 @@ pub fn rgb_u8_to_patches_bf16(
         .map_err(Error::Cuda)
     }
 }
+
+/// GR00T N1.7 two-frame patch packing from already resized 256x256 RGB views.
+pub fn groot_rgb_u8_to_patches_bf16(
+    ctx: &CudaContext,
+    images: &CudaBuffer,
+    patches: &Tensor,
+    views: usize,
+    layout: ImageLayout,
+) -> Result<()> {
+    let expected_bytes = views * 256 * 256 * 3;
+    if views == 0
+        || images.device() != ctx.device_id()
+        || images.len() != expected_bytes
+        || patches.dtype() != DType::BF16
+        || patches.shape().dims() != [views * 256, 1536]
+    {
+        return Err(Error::Other(
+            "GR00T BF16 raw image/preprocessed patch mismatch".into(),
+        ));
+    }
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_groot_rgb_u8_to_patches_bf16(
+            images.ptr(),
+            gpu_ptr(patches)?,
+            views as i32,
+            layout.kernel_value(),
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)
+    }
+}
 /// Fused static inference image preprocessing for an already resized RGB image batch.
 ///
 /// The input is `uint8` NHWC or NCHW. The output is patch-major E4M3 with

--- a/crates/apxinf-cuda/src/kernels/rope.rs
+++ b/crates/apxinf-cuda/src/kernels/rope.rs
@@ -10,6 +10,7 @@ use super::contracts::{
 use crate::buffer::{CudaBuffer, CudaDeviceAddress};
 use crate::context::CudaContext;
 use crate::ffi;
+use crate::workspace::output_buffer;
 
 /// Apply RoPE into caller-owned storage using a device-resident position.
 #[allow(clippy::too_many_arguments)]
@@ -169,7 +170,7 @@ pub fn apply(
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -226,7 +227,7 @@ pub fn apply_mrope(
     let dims = input.shape().dims();
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     if input.dtype() != DType::BF16 {
         return Err(Error::Other("rope_mrope: only BF16 supported".into()));
@@ -272,7 +273,7 @@ pub fn apply_vision_2d(
     let device_id = ctx.device_id();
     let dims = input.shape().dims();
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res = ffi::apxinf_rope_vision_2d_bf16(
             gpu_ptr(input)?,

--- a/crates/apxinf-model/src/builtin.rs
+++ b/crates/apxinf-model/src/builtin.rs
@@ -20,6 +20,8 @@ pub fn register_builtin_models() {
 
     #[cfg(feature = "cuda")]
     crate::pi05::register_builtin();
+    #[cfg(feature = "cuda")]
+    crate::gr00t_n17::register_builtin();
 }
 fn load_llama(
     path: &Path,

--- a/crates/apxinf-model/src/gr00t_n17/action_executor.rs
+++ b/crates/apxinf-model/src/gr00t_n17/action_executor.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use apxinf_core::{Backend, Error, Result, Tensor};
+use apxinf_cuda::kernels::{activation, attention, elementwise, gemm, norm};
+use apxinf_cuda::{CudaBackend, CudaContext};
+use half::bf16;
+
+use super::{
+    AttentionWeights, CategoryMlpWeights, FeedForwardWeights, GrootN17ActionWeights,
+    GrootN17Config, LayerNormWeights, LinearWeights,
+};
+
+struct StepConditioning {
+    action_time: Tensor,
+    block_styles: Vec<Tensor>,
+    final_style: Tensor,
+}
+
+pub struct GrootN17ActionExecutor {
+    config: Arc<GrootN17Config>,
+    weights: Arc<GrootN17ActionWeights>,
+    conditions: Vec<StepConditioning>,
+    unit_norm: LayerNormWeights,
+    action_rows: elementwise::RowIndices,
+}
+
+impl GrootN17ActionExecutor {
+    pub fn new(
+        config: Arc<GrootN17Config>,
+        weights: Arc<GrootN17ActionWeights>,
+        backend: &dyn Backend,
+        cuda: &CudaBackend,
+    ) -> Result<Self> {
+        let width = config.action_width();
+        let unit_norm = LayerNormWeights {
+            weight: backend.to_device(&Tensor::from_bf16(
+                vec![width],
+                &vec![bf16::from_f32(1.0); width],
+            )?)?,
+            bias: backend.to_device(&Tensor::from_bf16(
+                vec![width],
+                &vec![bf16::from_f32(0.0); width],
+            )?)?,
+        };
+        let action_rows = elementwise::RowIndices::new(
+            cuda.device_id(),
+            &(1..=config.action_horizon as u32).collect::<Vec<_>>(),
+        )?;
+        let mut conditions = Vec::with_capacity(config.num_inference_timesteps);
+        for timestep in config.timestep_values() {
+            let action_time = backend.to_device(&action_time_embedding(
+                timestep,
+                config.action_horizon,
+                width,
+            )?)?;
+            let timestep_input = backend.to_device(&dit_time_embedding(timestep, 256)?)?;
+            let temb = linear(cuda.context(), &timestep_input, &weights.timestep_in)?;
+            let temb = activation::bias_silu_bf16(
+                cuda.context(),
+                &temb,
+                weights.timestep_in.bias.as_ref(),
+            )?;
+            let temb = linear_bias(cuda.context(), &temb, &weights.timestep_out)?;
+            let activated_temb = activation::silu(cuda.context(), &temb)?;
+            let mut block_styles = Vec::with_capacity(weights.dit_blocks.len());
+            for block in &weights.dit_blocks {
+                block_styles.push(linear_bias(
+                    cuda.context(),
+                    &activated_temb,
+                    &block.ada_norm,
+                )?);
+            }
+            let final_style =
+                linear_bias(cuda.context(), &activated_temb, &weights.final_condition)?;
+            conditions.push(StepConditioning {
+                action_time,
+                block_styles,
+                final_style,
+            });
+        }
+        backend.synchronize()?;
+        Ok(Self {
+            config,
+            weights,
+            conditions,
+            unit_norm,
+            action_rows,
+        })
+    }
+
+    pub fn refine_backbone(&self, ctx: &CudaContext, features: &Tensor) -> Result<Tensor> {
+        let mut hidden = norm::layer_bf16(
+            ctx,
+            features,
+            &self.weights.vlln.weight,
+            &self.weights.vlln.bias,
+            1e-5,
+        )?;
+        for block in &self.weights.vl_blocks {
+            hidden = self.vl_block(ctx, &hidden, block)?;
+        }
+        Ok(hidden)
+    }
+
+    pub fn infer(
+        &self,
+        ctx: &CudaContext,
+        refined_backbone: &Tensor,
+        state: &Tensor,
+        initial_noise: &Tensor,
+        text_rows: &elementwise::RowIndices,
+        image_rows: &elementwise::RowIndices,
+        backend: &dyn Backend,
+    ) -> Result<Tensor> {
+        let state_features = category_mlp(ctx, state, &self.weights.state_encoder)?;
+        let text_features = elementwise::gather_rows_bf16(ctx, refined_backbone, text_rows)?;
+        let image_features = elementwise::gather_rows_bf16(ctx, refined_backbone, image_rows)?;
+
+        let mut cross_kv = Vec::with_capacity(self.weights.dit_blocks.len());
+        for (index, block) in self.weights.dit_blocks.iter().enumerate() {
+            if index % 2 == 1 {
+                cross_kv.push(None);
+                continue;
+            }
+            let encoder = if index % 4 == 0 {
+                &text_features
+            } else {
+                &image_features
+            };
+            let key = linear_bias(ctx, encoder, &block.attention.k)?.reshape(vec![
+                encoder.shape().dims()[0],
+                self.config.diffusion_model_cfg.num_attention_heads,
+                self.config.diffusion_model_cfg.attention_head_dim,
+            ])?;
+            let value = linear_bias(ctx, encoder, &block.attention.v)?.reshape(vec![
+                encoder.shape().dims()[0],
+                self.config.diffusion_model_cfg.num_attention_heads,
+                self.config.diffusion_model_cfg.attention_head_dim,
+            ])?;
+            cross_kv.push(Some((key, value)));
+        }
+
+        let mut actions = initial_noise.clone();
+        for condition in &self.conditions {
+            let action_base = linear_bias(ctx, &actions, &self.weights.action_encoder.w1)?;
+            let encoded = backend.concat_2d(&[&action_base, &condition.action_time])?;
+            let encoded = linear(ctx, &encoded, &self.weights.action_encoder.w2)?;
+            let encoded = activation::bias_silu_bf16(
+                ctx,
+                &encoded,
+                self.weights.action_encoder.w2.bias.as_ref(),
+            )?;
+            let action_features = linear_bias(ctx, &encoded, &self.weights.action_encoder.w3)?;
+            let action_features =
+                backend.add(&action_features, &self.weights.position_embedding)?;
+            let mut hidden = elementwise::concat_rows_bf16(ctx, &state_features, &action_features)?;
+
+            for (index, block) in self.weights.dit_blocks.iter().enumerate() {
+                let normalized = norm::adaptive_layer_bf16(
+                    ctx,
+                    &hidden,
+                    &condition.block_styles[index],
+                    1e-5,
+                    false,
+                )?;
+                let query = linear_bias(ctx, &normalized, &block.attention.q)?.reshape(vec![
+                    hidden.shape().dims()[0],
+                    self.config.diffusion_model_cfg.num_attention_heads,
+                    self.config.diffusion_model_cfg.attention_head_dim,
+                ])?;
+                let attended = if let Some((key, value)) = &cross_kv[index] {
+                    attention::cross_mha_bf16(ctx, &query, key, value)?
+                } else {
+                    let key = linear_bias(ctx, &normalized, &block.attention.k)?.reshape(vec![
+                        hidden.shape().dims()[0],
+                        self.config.diffusion_model_cfg.num_attention_heads,
+                        self.config.diffusion_model_cfg.attention_head_dim,
+                    ])?;
+                    let value =
+                        linear_bias(ctx, &normalized, &block.attention.v)?.reshape(vec![
+                            hidden.shape().dims()[0],
+                            self.config.diffusion_model_cfg.num_attention_heads,
+                            self.config.diffusion_model_cfg.attention_head_dim,
+                        ])?;
+                    attention::mha_bf16(ctx, &query, &key, &value, hidden.shape().dims()[0])?
+                };
+                let attended =
+                    attended.reshape(vec![hidden.shape().dims()[0], self.config.action_width()])?;
+                let projected = linear_bias(ctx, &attended, &block.attention.output)?;
+                hidden = backend.add(&hidden, &projected)?;
+                let normalized = norm::layer_bf16(
+                    ctx,
+                    &hidden,
+                    &self.unit_norm.weight,
+                    &self.unit_norm.bias,
+                    1e-5,
+                )?;
+                let ff = linear(ctx, &normalized, &block.feed_forward.input)?;
+                let ff =
+                    activation::bias_gelu_bf16(ctx, &ff, block.feed_forward.input.bias.as_ref())?;
+                let ff = linear_bias(ctx, &ff, &block.feed_forward.output)?;
+                hidden = backend.add(&hidden, &ff)?;
+            }
+
+            hidden = norm::adaptive_layer_bf16(ctx, &hidden, &condition.final_style, 1e-6, true)?;
+            let decoded_input = linear_bias(ctx, &hidden, &self.weights.final_projection)?;
+            let decoded_input =
+                elementwise::gather_rows_bf16(ctx, &decoded_input, &self.action_rows)?;
+            let velocity = category_mlp(ctx, &decoded_input, &self.weights.action_decoder)?;
+            actions = elementwise::euler_update_bf16(
+                ctx,
+                &actions,
+                &velocity,
+                1.0 / self.config.num_inference_timesteps as f32,
+            )?;
+        }
+        Ok(actions)
+    }
+
+    fn vl_block(
+        &self,
+        ctx: &CudaContext,
+        hidden: &Tensor,
+        block: &super::VlBlockWeights,
+    ) -> Result<Tensor> {
+        let normalized =
+            norm::layer_bf16(ctx, hidden, &block.norm1.weight, &block.norm1.bias, 1e-5)?;
+        let attended = self_attention(
+            ctx,
+            &normalized,
+            &block.attention,
+            self.config.vl_self_attention_cfg.num_attention_heads,
+            self.config.vl_self_attention_cfg.attention_head_dim,
+        )?;
+        let mut hidden = apxinf_cuda::kernels::elementwise::add(ctx, hidden, &attended)?;
+        let normalized =
+            norm::layer_bf16(ctx, &hidden, &block.norm3.weight, &block.norm3.bias, 1e-5)?;
+        let ff = feed_forward(ctx, &normalized, &block.feed_forward)?;
+        hidden = apxinf_cuda::kernels::elementwise::add(ctx, &hidden, &ff)?;
+        Ok(hidden)
+    }
+}
+
+fn linear(ctx: &CudaContext, input: &Tensor, weights: &LinearWeights) -> Result<Tensor> {
+    gemm::matmul(ctx, input, &weights.weight)
+}
+
+fn linear_bias(ctx: &CudaContext, input: &Tensor, weights: &LinearWeights) -> Result<Tensor> {
+    let output = linear(ctx, input, weights)?;
+    elementwise::bias_bf16(ctx, &output, weights.bias.as_ref())
+}
+
+fn category_mlp(ctx: &CudaContext, input: &Tensor, weights: &CategoryMlpWeights) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &weights.layer1)?;
+    let hidden = activation::bias_relu_bf16(ctx, &hidden, weights.layer1.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &weights.layer2)
+}
+
+fn feed_forward(ctx: &CudaContext, input: &Tensor, weights: &FeedForwardWeights) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &weights.input)?;
+    let hidden = activation::bias_gelu_bf16(ctx, &hidden, weights.input.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &weights.output)
+}
+
+fn self_attention(
+    ctx: &CudaContext,
+    input: &Tensor,
+    weights: &AttentionWeights,
+    heads: usize,
+    head_dim: usize,
+) -> Result<Tensor> {
+    let tokens = input.shape().dims()[0];
+    let q = linear_bias(ctx, input, &weights.q)?.reshape(vec![tokens, heads, head_dim])?;
+    let k = linear_bias(ctx, input, &weights.k)?.reshape(vec![tokens, heads, head_dim])?;
+    let v = linear_bias(ctx, input, &weights.v)?.reshape(vec![tokens, heads, head_dim])?;
+    let attended = attention::mha_bf16(ctx, &q, &k, &v, tokens)?;
+    let attended = attended.reshape(vec![tokens, heads * head_dim])?;
+    linear_bias(ctx, &attended, &weights.output)
+}
+
+fn action_time_embedding(timestep: u32, rows: usize, width: usize) -> Result<Tensor> {
+    let half = width / 2;
+    let mut row = Vec::with_capacity(width);
+    for index in 0..half {
+        let frequency = (-((index as f32) * 10000.0f32.ln() / half as f32)).exp();
+        row.push(bf16::from_f32((timestep as f32 * frequency).sin()));
+    }
+    for index in 0..half {
+        let frequency = (-((index as f32) * 10000.0f32.ln() / half as f32)).exp();
+        row.push(bf16::from_f32((timestep as f32 * frequency).cos()));
+    }
+    let values = row.repeat(rows);
+    Tensor::from_bf16(vec![rows, width], &values)
+}
+
+fn dit_time_embedding(timestep: u32, width: usize) -> Result<Tensor> {
+    if width % 2 != 0 || width < 4 {
+        return Err(Error::Other("invalid DiT timestep embedding width".into()));
+    }
+    let half = width / 2;
+    let denominator = (half - 1) as f32;
+    let mut cosine = Vec::with_capacity(half);
+    let mut sine = Vec::with_capacity(half);
+    for index in 0..half {
+        let frequency = (-(10000.0f32.ln()) * index as f32 / denominator).exp();
+        let phase = timestep as f32 * frequency;
+        cosine.push(bf16::from_f32(phase.cos()));
+        sine.push(bf16::from_f32(phase.sin()));
+    }
+    cosine.extend(sine);
+    Tensor::from_bf16(vec![1, width], &cosine)
+}

--- a/crates/apxinf-model/src/gr00t_n17/backbone_executor.rs
+++ b/crates/apxinf-model/src/gr00t_n17/backbone_executor.rs
@@ -1,0 +1,317 @@
+//! Fixed-shape, GPU-resident Cosmos/Qwen3-VL backbone for GR00T N1.7 LIBERO.
+
+use apxinf_core::{Error, Result, Tensor};
+use apxinf_cuda::buffer::CudaBuffer;
+use apxinf_cuda::kernels::{activation, attention, elementwise, embedding, gemm, norm, rope};
+use apxinf_cuda::CudaContext;
+use std::sync::Arc;
+
+use super::backbone_weights::{GrootLanguageLayer, GrootVisionMerger};
+use super::{GrootN17BackboneWeights, LayerNormWeights, LinearWeights};
+
+pub struct GrootN17BackboneExecutor {
+    weights: Arc<GrootN17BackboneWeights>,
+    token_count: usize,
+    view_count: usize,
+    patch_rows: usize,
+    token_ids: CudaBuffer,
+    language_positions: CudaBuffer,
+    vision_positions: CudaBuffer,
+    image_rows: elementwise::RowIndices,
+}
+
+impl GrootN17BackboneExecutor {
+    pub fn new(
+        weights: Arc<GrootN17BackboneWeights>,
+        token_ids: &[u32],
+        device: usize,
+    ) -> Result<Self> {
+        let view_count = match token_ids.len() {
+            76 => 1,
+            142 => 2,
+            count => {
+                return Err(Error::Other(format!(
+                    "GR00T profile requires 76 or 142 tokens, got {count}"
+                )))
+            }
+        };
+        let image_positions = token_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &token)| (token == 151655).then_some(i as u32))
+            .collect::<Vec<_>>();
+        if image_positions.len() != view_count * 64 {
+            return Err(Error::Other(format!(
+                "GR00T {view_count}-view profile requires {} image tokens, got {}",
+                view_count * 64,
+                image_positions.len()
+            )));
+        }
+        Ok(Self {
+            weights,
+            token_count: token_ids.len(),
+            view_count,
+            patch_rows: view_count * 256,
+            token_ids: upload_u32(device, token_ids)?,
+            language_positions: upload_u32(device, &mrope_positions(token_ids, view_count)?)?,
+            vision_positions: upload_u32(device, &vision_positions(view_count))?,
+            image_rows: elementwise::RowIndices::new(device, &image_positions)?,
+        })
+    }
+
+    pub fn forward(&self, ctx: &CudaContext, patches: &Tensor) -> Result<Tensor> {
+        if patches.shape().dims() != [self.patch_rows, 1536] {
+            return Err(Error::Other(format!(
+                "GR00T patches must be [{},1536], got {:?}",
+                self.patch_rows,
+                patches.shape().dims()
+            )));
+        }
+        let vision = self
+            .forward_vision(ctx, patches)
+            .map_err(|error| Error::Other(format!("GR00T vision tower: {error}")))?;
+        let mut hidden = embedding::lookup_unscaled_bf16(
+            ctx,
+            &self.weights.embedding,
+            &self.token_ids,
+            self.token_count,
+        )
+        .map_err(|error| Error::Other(format!("GR00T token embedding: {error}")))?;
+        hidden = elementwise::scatter_rows_bf16(ctx, &hidden, &vision.0, &self.image_rows, false)
+            .map_err(|error| {
+            Error::Other(format!("GR00T primary vision injection: {error}"))
+        })?;
+        for (index, layer) in self.weights.language_layers.iter().enumerate() {
+            hidden = language_layer(
+                ctx,
+                &hidden,
+                layer,
+                &self.language_positions,
+                self.token_count,
+            )
+            .map_err(|error| Error::Other(format!("GR00T language layer {index}: {error}")))?;
+            if index < vision.1.len() {
+                hidden = elementwise::scatter_rows_bf16(
+                    ctx,
+                    &hidden,
+                    &vision.1[index],
+                    &self.image_rows,
+                    true,
+                )
+                .map_err(|error| {
+                    Error::Other(format!("GR00T deepstack injection {index}: {error}"))
+                })?;
+            }
+        }
+        // GR00T selects `outputs.hidden_states[-1]` from the truncated Qwen
+        // backbone. Transformers records that boundary before the language
+        // model's final RMSNorm; the action head's own VLLN is the next norm.
+        Ok(hidden)
+    }
+
+    pub fn update_token_ids(&self, token_ids: &[u32]) -> Result<()> {
+        if token_ids.len() != self.token_count {
+            return Err(Error::Other(format!(
+                "GR00T prepared graph requires {} token IDs",
+                self.token_count
+            )));
+        }
+        let image_positions = token_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &token)| (token == 151655).then_some(i))
+            .collect::<Vec<_>>();
+        let expected = if self.view_count == 1 {
+            (4..68).collect::<Vec<_>>()
+        } else {
+            (4..68).chain(70..134).collect::<Vec<_>>()
+        };
+        if image_positions != expected {
+            return Err(Error::Other(
+                "GR00T token image spans do not match the prepared graph".into(),
+            ));
+        }
+        let bytes = token_ids
+            .iter()
+            .flat_map(|value| value.to_ne_bytes())
+            .collect::<Vec<_>>();
+        self.token_ids.copy_from_host(&bytes).map_err(Error::Cuda)
+    }
+
+    fn forward_vision(&self, ctx: &CudaContext, patches: &Tensor) -> Result<(Tensor, Vec<Tensor>)> {
+        let w = &self.weights.vision;
+        let mut hidden = linear_bias(ctx, patches, &w.patch)
+            .map_err(|error| Error::Other(format!("patch projection: {error}")))?;
+        let position = if self.view_count == 1 {
+            &w.position_one_view
+        } else {
+            &w.position_two_view
+        };
+        hidden = elementwise::add(ctx, &hidden, position)
+            .map_err(|error| Error::Other(format!("vision position add: {error}")))?;
+        let mut deep = Vec::with_capacity(3);
+        for (index, block) in w.blocks.iter().enumerate() {
+            hidden = (|| -> Result<Tensor> {
+                let normalized = layer_norm(ctx, &hidden, &block.norm1, 1e-6)?;
+                let q = linear_bias(ctx, &normalized, &block.q)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let k = linear_bias(ctx, &normalized, &block.k)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let v = linear_bias(ctx, &normalized, &block.v)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let q = rope::apply_vision_2d(ctx, &q, 16, 64, 10000.0, &self.vision_positions)?;
+                let k = rope::apply_vision_2d(ctx, &k, 16, 64, 10000.0, &self.vision_positions)?;
+                let attended = attention::mha_bf16(ctx, &q, &k, &v, 256)?
+                    .reshape(vec![self.patch_rows, 1024])?;
+                let output =
+                    elementwise::add(ctx, &hidden, &linear_bias(ctx, &attended, &block.output)?)?;
+                let normalized = layer_norm(ctx, &output, &block.norm2, 1e-6)?;
+                let ff = linear(ctx, &normalized, &block.fc1)?;
+                let ff = activation::bias_gelu_bf16(ctx, &ff, block.fc1.bias.as_ref())?;
+                elementwise::add(ctx, &output, &linear_bias(ctx, &ff, &block.fc2)?)
+            })()
+            .map_err(|error| Error::Other(format!("vision block {index}: {error}")))?;
+            if matches!(index, 5 | 11 | 17) {
+                deep.push(hidden.clone());
+            }
+        }
+        let merged_rows = self.view_count * 64;
+        let primary = merge_primary(ctx, &hidden, &w.primary_merger, merged_rows)
+            .map_err(|error| Error::Other(format!("primary merger: {error}")))?;
+        let deep = deep
+            .iter()
+            .zip(&w.deepstack_mergers)
+            .enumerate()
+            .map(|(index, (value, merger))| {
+                merge_deep(ctx, value, merger, merged_rows)
+                    .map_err(|error| Error::Other(format!("deepstack merger {index}: {error}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok((primary, deep))
+    }
+}
+
+fn language_layer(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootLanguageLayer,
+    positions: &CudaBuffer,
+    tokens: usize,
+) -> Result<Tensor> {
+    let normalized = norm::rms_bf16(ctx, input, &w.input_norm, 1e-6)?;
+    let q = linear(ctx, &normalized, &w.q)?.reshape(vec![tokens * 16, 128])?;
+    let k = linear(ctx, &normalized, &w.k)?.reshape(vec![tokens * 8, 128])?;
+    let q = norm::rms_bf16(ctx, &q, &w.q_norm, 1e-6)?.reshape(vec![tokens, 16, 128])?;
+    let k = norm::rms_bf16(ctx, &k, &w.k_norm, 1e-6)?.reshape(vec![tokens, 8, 128])?;
+    let v = linear(ctx, &normalized, &w.v)?.reshape(vec![tokens, 8, 128])?;
+    let q = rope::apply_mrope(ctx, &q, 16, 128, 5_000_000.0, [24, 20, 20], positions)?;
+    let k = rope::apply_mrope(ctx, &k, 8, 128, 5_000_000.0, [24, 20, 20], positions)?;
+    let attended = attention::causal_gqa_bf16(ctx, &q, &k, &v)?.reshape(vec![tokens, 2048])?;
+    let hidden = elementwise::add(ctx, input, &linear(ctx, &attended, &w.output)?)?;
+    let normalized = norm::rms_bf16(ctx, &hidden, &w.post_norm, 1e-6)?;
+    let gate = activation::silu(ctx, &linear(ctx, &normalized, &w.gate)?)?;
+    let up = linear(ctx, &normalized, &w.up)?;
+    let ff = elementwise::mul(ctx, &gate, &up)?;
+    elementwise::add(ctx, &hidden, &linear(ctx, &ff, &w.down)?)
+}
+
+fn merge_primary(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootVisionMerger,
+    rows: usize,
+) -> Result<Tensor> {
+    let normalized = layer_norm(ctx, input, &w.norm, 1e-6)?.reshape(vec![rows, 4096])?;
+    merger_mlp(ctx, &normalized, w)
+}
+
+fn merge_deep(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootVisionMerger,
+    rows: usize,
+) -> Result<Tensor> {
+    let merged = input.reshape(vec![rows, 4096])?;
+    let normalized = layer_norm(ctx, &merged, &w.norm, 1e-6)?;
+    merger_mlp(ctx, &normalized, w)
+}
+
+fn merger_mlp(ctx: &CudaContext, input: &Tensor, w: &GrootVisionMerger) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &w.fc1)?;
+    let hidden = activation::bias_gelu_bf16(ctx, &hidden, w.fc1.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &w.fc2)
+}
+
+fn linear(ctx: &CudaContext, input: &Tensor, w: &LinearWeights) -> Result<Tensor> {
+    gemm::matmul(ctx, input, &w.weight)
+}
+fn linear_bias(ctx: &CudaContext, input: &Tensor, w: &LinearWeights) -> Result<Tensor> {
+    elementwise::bias_bf16(ctx, &linear(ctx, input, w)?, w.bias.as_ref())
+}
+fn layer_norm(ctx: &CudaContext, input: &Tensor, w: &LayerNormWeights, eps: f32) -> Result<Tensor> {
+    norm::layer_bf16(ctx, input, &w.weight, &w.bias, eps)
+}
+
+fn upload_u32(device: usize, values: &[u32]) -> Result<CudaBuffer> {
+    let bytes = values
+        .iter()
+        .flat_map(|value| value.to_ne_bytes())
+        .collect::<Vec<_>>();
+    let output = CudaBuffer::alloc(bytes.len(), device).map_err(Error::Cuda)?;
+    output.copy_from_host(&bytes).map_err(Error::Cuda)?;
+    Ok(output)
+}
+
+fn vision_positions(views: usize) -> Vec<u32> {
+    let mut output = Vec::with_capacity(views * 512);
+    for _ in 0..views {
+        for mr in 0..8 {
+            for mc in 0..8 {
+                for ir in 0..2 {
+                    for ic in 0..2 {
+                        output.extend_from_slice(&[(mr * 2 + ir) as u32, (mc * 2 + ic) as u32]);
+                    }
+                }
+            }
+        }
+    }
+    output
+}
+
+fn mrope_positions(tokens: &[u32], expected_images: usize) -> Result<Vec<u32>> {
+    let mut output = Vec::with_capacity(tokens.len() * 3);
+    let mut cursor = 0usize;
+    let mut next = 0u32;
+    let mut images = 0;
+    while cursor < tokens.len() {
+        if tokens[cursor] != 151655 {
+            output.extend_from_slice(&[next, next, next]);
+            next += 1;
+            cursor += 1;
+            continue;
+        }
+        images += 1;
+        for row in 0..8 {
+            for col in 0..8 {
+                output.extend_from_slice(&[next, next + row, next + col]);
+            }
+        }
+        next += 8;
+        cursor += 64;
+    }
+    if images != expected_images {
+        return Err(Error::Other(format!(
+            "expected {expected_images} image spans, got {images}"
+        )));
+    }
+    Ok(output)
+}

--- a/crates/apxinf-model/src/gr00t_n17/backbone_weights.rs
+++ b/crates/apxinf-model/src/gr00t_n17/backbone_weights.rs
@@ -1,0 +1,309 @@
+//! GR00T-owned Cosmos/Qwen3-VL backbone weights.
+
+use super::weights::{take, transpose_2d, upload_linear};
+use super::{LayerNormWeights, LinearWeights};
+use apxinf_core::{Backend, DType, Error, Result, Tensor};
+use std::collections::HashMap;
+
+pub struct GrootLanguageLayer {
+    pub input_norm: Tensor,
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+    pub post_norm: Tensor,
+    pub gate: LinearWeights,
+    pub up: LinearWeights,
+    pub down: LinearWeights,
+}
+
+pub struct GrootVisionBlock {
+    pub norm1: LayerNormWeights,
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+    pub norm2: LayerNormWeights,
+    pub fc1: LinearWeights,
+    pub fc2: LinearWeights,
+}
+
+pub struct GrootVisionMerger {
+    pub norm: LayerNormWeights,
+    pub fc1: LinearWeights,
+    pub fc2: LinearWeights,
+}
+
+pub struct GrootVisionWeights {
+    pub patch: LinearWeights,
+    pub position_one_view: Tensor,
+    pub position_two_view: Tensor,
+    pub blocks: Vec<GrootVisionBlock>,
+    pub primary_merger: GrootVisionMerger,
+    pub deepstack_mergers: Vec<GrootVisionMerger>,
+}
+
+pub struct GrootN17BackboneWeights {
+    pub embedding: Tensor,
+    pub language_layers: Vec<GrootLanguageLayer>,
+    pub output_norm: Tensor,
+    pub vision: GrootVisionWeights,
+}
+
+impl GrootN17BackboneWeights {
+    pub fn from_map(tensors: &mut HashMap<String, Tensor>) -> Result<Self> {
+        const ROOT: &str = "backbone.model.model";
+        let mut language_layers = Vec::with_capacity(16);
+        for index in 0..16 {
+            let prefix = format!("{ROOT}.language_model.layers.{index}");
+            language_layers.push(GrootLanguageLayer {
+                input_norm: take(tensors, &format!("{prefix}.input_layernorm.weight"))?,
+                q: take_linear(tensors, &format!("{prefix}.self_attn.q_proj"), false)?,
+                k: take_linear(tensors, &format!("{prefix}.self_attn.k_proj"), false)?,
+                v: take_linear(tensors, &format!("{prefix}.self_attn.v_proj"), false)?,
+                output: take_linear(tensors, &format!("{prefix}.self_attn.o_proj"), false)?,
+                q_norm: take(tensors, &format!("{prefix}.self_attn.q_norm.weight"))?,
+                k_norm: take(tensors, &format!("{prefix}.self_attn.k_norm.weight"))?,
+                post_norm: take(
+                    tensors,
+                    &format!("{prefix}.post_attention_layernorm.weight"),
+                )?,
+                gate: take_linear(tensors, &format!("{prefix}.mlp.gate_proj"), false)?,
+                up: take_linear(tensors, &format!("{prefix}.mlp.up_proj"), false)?,
+                down: take_linear(tensors, &format!("{prefix}.mlp.down_proj"), false)?,
+            });
+        }
+        let mut blocks = Vec::with_capacity(24);
+        for index in 0..24 {
+            let prefix = format!("{ROOT}.visual.blocks.{index}");
+            let qkv_weight = take(tensors, &format!("{prefix}.attn.qkv.weight"))?;
+            let qkv_bias = take(tensors, &format!("{prefix}.attn.qkv.bias"))?;
+            blocks.push(GrootVisionBlock {
+                norm1: take_norm(tensors, &format!("{prefix}.norm1"))?,
+                q: split_linear(&qkv_weight, &qkv_bias, 0)?,
+                k: split_linear(&qkv_weight, &qkv_bias, 1)?,
+                v: split_linear(&qkv_weight, &qkv_bias, 2)?,
+                output: take_linear(tensors, &format!("{prefix}.attn.proj"), true)?,
+                norm2: take_norm(tensors, &format!("{prefix}.norm2"))?,
+                fc1: take_linear(tensors, &format!("{prefix}.mlp.linear_fc1"), true)?,
+                fc2: take_linear(tensors, &format!("{prefix}.mlp.linear_fc2"), true)?,
+            });
+        }
+        let patch_raw = take(tensors, &format!("{ROOT}.visual.patch_embed.proj.weight"))?;
+        let patch_weight = flatten_transpose(&patch_raw, 1024, 1536)?;
+        let patch_bias = take(tensors, &format!("{ROOT}.visual.patch_embed.proj.bias"))?;
+        Ok(Self {
+            embedding: take(
+                tensors,
+                &format!("{ROOT}.language_model.embed_tokens.weight"),
+            )?,
+            language_layers,
+            output_norm: take(tensors, &format!("{ROOT}.language_model.norm.weight"))?,
+            vision: GrootVisionWeights {
+                patch: LinearWeights {
+                    weight: patch_weight,
+                    bias: Some(patch_bias),
+                },
+                position_one_view: take(tensors, &format!("{ROOT}.visual.pos_embed.weight"))?,
+                position_two_view: Tensor::zeros(vec![1], DType::BF16),
+                blocks,
+                primary_merger: take_merger(tensors, &format!("{ROOT}.visual.merger"))?,
+                deepstack_mergers: (0..3)
+                    .map(|i| {
+                        take_merger(tensors, &format!("{ROOT}.visual.deepstack_merger_list.{i}"))
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            },
+        })
+    }
+
+    pub fn to_device(mut self, backend: &dyn Backend) -> Result<Self> {
+        self.embedding = backend.to_device(&self.embedding)?;
+        self.output_norm = backend.to_device(&self.output_norm)?;
+        for layer in &mut self.language_layers {
+            layer.input_norm = backend.to_device(&layer.input_norm)?;
+            layer.q_norm = backend.to_device(&layer.q_norm)?;
+            layer.k_norm = backend.to_device(&layer.k_norm)?;
+            layer.post_norm = backend.to_device(&layer.post_norm)?;
+            for linear in [
+                &mut layer.q,
+                &mut layer.k,
+                &mut layer.v,
+                &mut layer.output,
+                &mut layer.gate,
+                &mut layer.up,
+                &mut layer.down,
+            ] {
+                upload_linear(linear, backend)?;
+            }
+        }
+        upload_linear(&mut self.vision.patch, backend)?;
+        let (one_view, two_view) = fixed_vision_positions(&self.vision.position_one_view)?;
+        self.vision.position_one_view = backend.to_device(&one_view)?;
+        self.vision.position_two_view = backend.to_device(&two_view)?;
+        for block in &mut self.vision.blocks {
+            upload_norm(&mut block.norm1, backend)?;
+            upload_norm(&mut block.norm2, backend)?;
+            for linear in [
+                &mut block.q,
+                &mut block.k,
+                &mut block.v,
+                &mut block.output,
+                &mut block.fc1,
+                &mut block.fc2,
+            ] {
+                upload_linear(linear, backend)?;
+            }
+        }
+        upload_merger(&mut self.vision.primary_merger, backend)?;
+        for merger in &mut self.vision.deepstack_mergers {
+            upload_merger(merger, backend)?;
+        }
+        Ok(self)
+    }
+}
+
+fn take_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    bias: bool,
+) -> Result<LinearWeights> {
+    Ok(LinearWeights {
+        weight: transpose_2d(&take(tensors, &format!("{prefix}.weight"))?)?,
+        bias: bias
+            .then(|| take(tensors, &format!("{prefix}.bias")))
+            .transpose()?,
+    })
+}
+
+fn take_norm(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<LayerNormWeights> {
+    Ok(LayerNormWeights {
+        weight: take(tensors, &format!("{prefix}.weight"))?,
+        bias: take(tensors, &format!("{prefix}.bias"))?,
+    })
+}
+
+fn take_merger(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<GrootVisionMerger> {
+    Ok(GrootVisionMerger {
+        norm: take_norm(tensors, &format!("{prefix}.norm"))?,
+        fc1: take_linear(tensors, &format!("{prefix}.linear_fc1"), true)?,
+        fc2: take_linear(tensors, &format!("{prefix}.linear_fc2"), true)?,
+    })
+}
+
+fn upload_norm(value: &mut LayerNormWeights, backend: &dyn Backend) -> Result<()> {
+    value.weight = backend.to_device(&value.weight)?;
+    value.bias = backend.to_device(&value.bias)?;
+    Ok(())
+}
+
+fn upload_merger(value: &mut GrootVisionMerger, backend: &dyn Backend) -> Result<()> {
+    upload_norm(&mut value.norm, backend)?;
+    upload_linear(&mut value.fc1, backend)?;
+    upload_linear(&mut value.fc2, backend)
+}
+
+fn split_linear(weight: &Tensor, bias: &Tensor, part: usize) -> Result<LinearWeights> {
+    let width = weight.shape().dims()[0] / 3;
+    Ok(LinearWeights {
+        weight: transpose_2d(&slice_rows(weight, part * width, width)?)?,
+        bias: Some(slice_rows(bias, part * width, width)?),
+    })
+}
+
+fn slice_rows(tensor: &Tensor, start: usize, rows: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    let stride: usize = dims.get(1..).unwrap_or(&[]).iter().product();
+    let mut shape = dims.to_vec();
+    shape[0] = rows;
+    match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(
+            shape,
+            &tensor.as_bf16()?[start * stride..(start + rows) * stride],
+        ),
+        DType::F32 => Tensor::from_f32(
+            shape,
+            &tensor.as_f32()?[start * stride..(start + rows) * stride],
+        ),
+        dtype => Err(Error::Other(format!("unsupported backbone dtype {dtype}"))),
+    }
+}
+
+fn flatten_transpose(tensor: &Tensor, rows: usize, cols: usize) -> Result<Tensor> {
+    let reshaped = match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(vec![rows, cols], tensor.as_bf16()?)?,
+        DType::F32 => Tensor::from_f32(vec![rows, cols], tensor.as_f32()?)?,
+        dtype => return Err(Error::Other(format!("unsupported patch dtype {dtype}"))),
+    };
+    transpose_2d(&reshaped)
+}
+
+fn fixed_vision_positions(table: &Tensor) -> Result<(Tensor, Tensor)> {
+    const SOURCE: usize = 48;
+    const TARGET: usize = 16;
+    const WIDTH: usize = 1024;
+    let values = table.to_f32_vec()?;
+    let mut one_view = vec![0.0f32; TARGET * TARGET * WIDTH];
+    for row in 0..TARGET {
+        let yf = row as f32 * (SOURCE - 1) as f32 / (TARGET - 1) as f32;
+        let y0 = yf.floor() as usize;
+        let y1 = (y0 + 1).min(SOURCE - 1);
+        let dy = yf - y0 as f32;
+        for col in 0..TARGET {
+            let xf = col as f32 * (SOURCE - 1) as f32 / (TARGET - 1) as f32;
+            let x0 = xf.floor() as usize;
+            let x1 = (x0 + 1).min(SOURCE - 1);
+            let dx = xf - x0 as f32;
+            // Transformers casts the interpolation weights to the embedding
+            // table's BF16 dtype before multiplying, then performs the four
+            // additions in BF16. Preserve those rounding boundaries: doing
+            // the complete bilinear expression in f32 measurably changes the
+            // frozen vision prefix after 24 residual blocks.
+            let round = |value: f32| half::bf16::from_f32(value).to_f32();
+            let weights = [
+                round((1.0 - dy) * (1.0 - dx)),
+                round((1.0 - dy) * dx),
+                round(dy * (1.0 - dx)),
+                round(dy * dx),
+            ];
+            for channel in 0..WIDTH {
+                let at = |y, x| values[(y * SOURCE + x) * WIDTH + channel];
+                let products = [
+                    round(at(y0, x0) * weights[0]),
+                    round(at(y0, x1) * weights[1]),
+                    round(at(y1, x0) * weights[2]),
+                    round(at(y1, x1) * weights[3]),
+                ];
+                let sum =
+                    round(round(round(products[0] + products[1]) + products[2]) + products[3]);
+                one_view[(row * TARGET + col) * WIDTH + channel] = sum;
+            }
+        }
+    }
+    // Processor patch order already groups each 2x2 merge tile contiguously.
+    let mut permuted = Vec::with_capacity(one_view.len());
+    for macro_row in 0..TARGET / 2 {
+        for macro_col in 0..TARGET / 2 {
+            for inner_row in 0..2 {
+                for inner_col in 0..2 {
+                    let offset =
+                        ((macro_row * 2 + inner_row) * TARGET + macro_col * 2 + inner_col) * WIDTH;
+                    permuted.extend_from_slice(&one_view[offset..offset + WIDTH]);
+                }
+            }
+        }
+    }
+    let one_values = permuted
+        .into_iter()
+        .map(half::bf16::from_f32)
+        .collect::<Vec<_>>();
+    let mut two_values = Vec::with_capacity(one_values.len() * 2);
+    two_values.extend_from_slice(&one_values);
+    two_values.extend_from_slice(&one_values);
+    Ok((
+        Tensor::from_bf16(vec![256, WIDTH], &one_values)?,
+        Tensor::from_bf16(vec![512, WIDTH], &two_values)?,
+    ))
+}

--- a/crates/apxinf-model/src/gr00t_n17/config.rs
+++ b/crates/apxinf-model/src/gr00t_n17/config.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use apxinf_core::{Error, Result};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17DiffusionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+    pub output_dim: usize,
+    pub interleave_self_attention: bool,
+    pub norm_type: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17VlSelfAttentionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+}
+
+/// Frozen architecture fields used by the native GR00T N1.7 executor.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17Config {
+    pub model_type: String,
+    pub model_name: String,
+    pub dtype: String,
+    pub action_horizon: usize,
+    pub max_action_dim: usize,
+    pub max_state_dim: usize,
+    pub max_num_embodiments: usize,
+    pub max_seq_len: usize,
+    pub hidden_size: usize,
+    pub backbone_embedding_dim: usize,
+    pub select_layer: usize,
+    pub num_inference_timesteps: usize,
+    pub num_timestep_buckets: usize,
+    pub add_pos_embed: bool,
+    pub use_alternate_vl_dit: bool,
+    pub use_vlln: bool,
+    pub diffusion_model_cfg: GrootN17DiffusionConfig,
+    pub vl_self_attention_cfg: GrootN17VlSelfAttentionConfig,
+}
+
+impl GrootN17Config {
+    pub const LIBERO_EMBODIMENT_ID: usize = 2;
+    pub const LIBERO_ACTION_HORIZON: usize = 16;
+    pub const LIBERO_ACTION_DIM: usize = 7;
+
+    pub fn from_json_file(path: &Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|error| Error::Other(format!("read {}: {error}", path.display())))?;
+        let config: Self = serde_json::from_str(&raw)
+            .map_err(|error| Error::Other(format!("parse {}: {error}", path.display())))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn action_width(&self) -> usize {
+        self.diffusion_model_cfg.num_attention_heads
+            * self.diffusion_model_cfg.attention_head_dim
+    }
+
+    pub fn vl_attention_width(&self) -> usize {
+        self.vl_self_attention_cfg.num_attention_heads
+            * self.vl_self_attention_cfg.attention_head_dim
+    }
+
+    pub fn timestep_values(&self) -> Vec<u32> {
+        (0..self.num_inference_timesteps)
+            .map(|step| step * self.num_timestep_buckets / self.num_inference_timesteps)
+            .map(|value| value as u32)
+            .collect()
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let expected = [
+            (self.model_type == "Gr00tN1d7", "model_type must be Gr00tN1d7"),
+            (self.dtype == "bfloat16", "only the BF16 checkpoint is supported"),
+            (self.action_horizon == 40, "action_horizon must be 40"),
+            (self.max_action_dim == 132, "max_action_dim must be 132"),
+            (self.max_state_dim == 132, "max_state_dim must be 132"),
+            (self.select_layer == 16, "select_layer must be 16"),
+            (self.num_inference_timesteps == 4, "denoising steps must be 4"),
+            (self.num_timestep_buckets == 1000, "timestep buckets must be 1000"),
+            (self.add_pos_embed, "action position embedding is required"),
+            (self.use_alternate_vl_dit, "alternate VL DiT is required"),
+            (self.use_vlln, "VL LayerNorm is required"),
+            (self.action_width() == 1536, "DiT width must be 1536"),
+            (self.diffusion_model_cfg.num_layers == 32, "DiT depth must be 32"),
+            (self.diffusion_model_cfg.output_dim == 1024, "DiT output must be 1024"),
+            (self.diffusion_model_cfg.interleave_self_attention, "DiT must interleave self attention"),
+            (self.diffusion_model_cfg.norm_type == "ada_norm", "DiT must use ada_norm"),
+            (self.vl_attention_width() == 2048, "VL attention width must be 2048"),
+            (self.vl_self_attention_cfg.num_layers == 4, "VL attention depth must be 4"),
+        ];
+        if let Some((_, message)) = expected.into_iter().find(|(ok, _)| !ok) {
+            return Err(Error::Other(format!("unsupported GR00T N1.7 config: {message}")));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GrootN17Config;
+
+    #[test]
+    fn parses_frozen_libero_checkpoint() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../experiment/gr00t-n1d7-workflow-validation/checkpoint_metadata/config.json");
+        if !path.is_file() {
+            return;
+        }
+        let config = GrootN17Config::from_json_file(&path).unwrap();
+        assert_eq!(config.action_width(), 1536);
+        assert_eq!(config.vl_attention_width(), 2048);
+        assert_eq!(config.timestep_values(), [0, 250, 500, 750]);
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/mod.rs
+++ b/crates/apxinf-model/src/gr00t_n17/mod.rs
@@ -1,0 +1,34 @@
+//! NVIDIA GR00T N1.7 vision-language-action model.
+//!
+//! The family owns its model orchestration, weight names, fixed LIBERO profile,
+//! and CUDA Graph boundary. It shares only model-neutral ApxInf backend and
+//! kernel interfaces with other families.
+
+mod config;
+#[cfg(feature = "cuda")]
+mod action_executor;
+#[cfg(feature = "cuda")]
+mod backbone_executor;
+#[cfg(feature = "cuda")]
+mod vla_runtime;
+mod backbone_weights;
+mod weights;
+
+#[cfg(feature = "cuda")]
+pub use action_executor::GrootN17ActionExecutor;
+#[cfg(feature = "cuda")]
+pub use backbone_executor::GrootN17BackboneExecutor;
+#[cfg(feature = "cuda")]
+pub use vla_runtime::GrootN17VlaRuntime;
+pub use backbone_weights::GrootN17BackboneWeights;
+
+pub use config::{GrootN17Config, GrootN17DiffusionConfig, GrootN17VlSelfAttentionConfig};
+pub use weights::{
+    ActionEncoderWeights, AttentionWeights, CategoryMlpWeights, DitBlockWeights,
+    FeedForwardWeights, GrootN17ActionWeights, LayerNormWeights, LinearWeights, VlBlockWeights,
+};
+
+#[cfg(feature = "cuda")]
+pub(crate) fn register_builtin() {
+    crate::registry::register("Gr00tN1d7-cuda", vla_runtime::load_registered);
+}

--- a/crates/apxinf-model/src/gr00t_n17/vla_runtime.rs
+++ b/crates/apxinf-model/src/gr00t_n17/vla_runtime.rs
@@ -1,0 +1,348 @@
+//! Owning CUDA runtime and whole-model CUDA Graph for GR00T N1.7 LIBERO.
+
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use apxinf_core::{
+    Backend, DType, Device, Error, Graph, NormalGenerator, Result, SamplingBackend, Tensor,
+};
+use apxinf_cuda::buffer::CudaBuffer;
+use apxinf_cuda::kernels::preprocess::{self, ImageLayout as KernelImageLayout};
+use apxinf_cuda::kernels::{self, GraphWorkspace};
+use apxinf_cuda::transfers;
+use apxinf_cuda::CudaBackend;
+
+use crate::accelerator::cuda::downcast_arc;
+use crate::auto::{LoadOptions, LoadedModel, ModelPrecision};
+use crate::vla::{
+    Action, InferenceSpec, InitialLatent, PreparedInference, VisionObservation, VlaRequest,
+    VlaRuntime,
+};
+
+use super::{
+    GrootN17ActionExecutor, GrootN17ActionWeights, GrootN17BackboneExecutor,
+    GrootN17BackboneWeights, GrootN17Config,
+};
+
+const GRAPH_WORKSPACE_BYTES: usize = 3 * 1024 * 1024 * 1024;
+
+pub struct GrootN17VlaRuntime {
+    backend: Arc<CudaBackend>,
+    backbone_weights: Arc<GrootN17BackboneWeights>,
+    action: Arc<GrootN17ActionExecutor>,
+    prepared: RefCell<Option<Rc<GrootPrepared>>>,
+}
+
+struct GrootPrepared {
+    spec: InferenceSpec,
+    backbone: GrootN17BackboneExecutor,
+    graph: Box<dyn Graph>,
+    output: Tensor,
+    patches: Tensor,
+    state: Tensor,
+    noise: Tensor,
+    normal: RefCell<Box<dyn NormalGenerator>>,
+    _raw_images: Option<CudaBuffer>,
+    _text_rows: apxinf_cuda::kernels::elementwise::RowIndices,
+    _image_rows: apxinf_cuda::kernels::elementwise::RowIndices,
+    _workspace: GraphWorkspace,
+    _action: Arc<GrootN17ActionExecutor>,
+}
+
+impl GrootN17VlaRuntime {
+    fn build_prepared(&self, spec: &InferenceSpec) -> Result<GrootPrepared> {
+        let view_count = match spec.token_count {
+            76 => 1,
+            142 => 2,
+            _ => return Err(Error::Other(format!(
+                "GR00T N1.7 requires the 76-token one-view or 142-token two-view patch profile, got {spec:?}"))),
+        };
+        let mut template = vec![0u32; spec.token_count];
+        for row in 4..68 {
+            template[row] = 151655;
+        }
+        if view_count == 2 {
+            for row in 70..134 {
+                template[row] = 151655;
+            }
+        }
+        let backbone = GrootN17BackboneExecutor::new(
+            Arc::clone(&self.backbone_weights),
+            &template,
+            self.backend.device_id(),
+        )?;
+        let patches = self
+            .backend
+            .to_device(&Tensor::zeros((view_count * 256, 1536), DType::BF16))?;
+        let raw_images = spec
+            .image_layout
+            .map(|_| CudaBuffer::alloc(view_count * 256 * 256 * 3, self.backend.device_id()))
+            .transpose()
+            .map_err(Error::Cuda)?;
+        let state = self
+            .backend
+            .to_device(&Tensor::zeros((1, 132), DType::BF16))?;
+        let noise = self
+            .backend
+            .to_device(&Tensor::zeros((40, 132), DType::BF16))?;
+        let normal = self.backend.create_normal_generator(noise.clone())?;
+        let workspace = GraphWorkspace::new(GRAPH_WORKSPACE_BYTES, self.backend.device_id())?;
+        let image_rows = image_rows(self.backend.device_id(), &template)?;
+        let text_rows = text_rows(self.backend.device_id(), &template)?;
+        let execute = || -> Result<Tensor> {
+            if let (Some(images), Some(layout)) = (&raw_images, spec.image_layout) {
+                preprocess::groot_rgb_u8_to_patches_bf16(
+                    self.backend.context(),
+                    images,
+                    &patches,
+                    view_count,
+                    kernel_image_layout(layout),
+                )?;
+            }
+            let features = backbone
+                .forward(self.backend.context(), &patches)
+                .map_err(|error| Error::Other(format!("GR00T backbone execution: {error}")))?;
+            let refined = self
+                .action
+                .refine_backbone(self.backend.context(), &features)
+                .map_err(|error| Error::Other(format!("GR00T VL refinement: {error}")))?;
+            let output = self
+                .action
+                .infer(
+                    self.backend.context(),
+                    &refined,
+                    &state,
+                    &noise,
+                    &text_rows,
+                    &image_rows,
+                    &*self.backend,
+                )
+                .map_err(|error| Error::Other(format!("GR00T action execution: {error}")))?;
+            Ok(output)
+        };
+        let eager = kernels::prepare_with_workspace(&workspace, || execute())?;
+        self.backend.synchronize()?;
+        drop(eager);
+        self.backend.begin_capture()?;
+        let output = match kernels::with_workspace(&workspace, || execute()) {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = self.backend.end_capture();
+                return Err(error);
+            }
+        };
+        let graph = self.backend.end_capture()?;
+        Ok(GrootPrepared {
+            spec: *spec,
+            backbone,
+            graph,
+            output,
+            patches,
+            state,
+            noise,
+            normal: RefCell::new(normal),
+            _raw_images: raw_images,
+            _workspace: workspace,
+            _text_rows: text_rows,
+            _image_rows: image_rows,
+            _action: Arc::clone(&self.action),
+        })
+    }
+}
+
+impl PreparedInference for GrootPrepared {
+    fn spec(&self) -> &InferenceSpec {
+        &self.spec
+    }
+
+    fn run(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        if !self.spec.matches(request.observation) {
+            return Err(Error::Other(
+                "GR00T prepared shape does not match request".into(),
+            ));
+        }
+        match &request.observation.vision {
+            VisionObservation::Patches(value) => {
+                if self._raw_images.is_some() {
+                    return Err(Error::Other(
+                        "GR00T prepared RGB graph received patches".into(),
+                    ));
+                }
+                let patch_rows = if self.spec.token_count == 76 {
+                    256
+                } else {
+                    512
+                };
+                let patches = normalize_cpu(value, [patch_rows, 1536], "patches")?;
+                transfers::copy_cpu_to_cuda(&patches, &self.patches)?;
+            }
+            VisionObservation::RgbU8 { bytes, .. } => {
+                let images = self._raw_images.as_ref().ok_or_else(|| {
+                    Error::Other("GR00T prepared patch graph received RGB".into())
+                })?;
+                if bytes.len() != images.len() {
+                    return Err(Error::Other(format!(
+                        "GR00T RGB input expected {} bytes, got {}",
+                        images.len(),
+                        bytes.len()
+                    )));
+                }
+                images.copy_from_host(bytes).map_err(Error::Cuda)?;
+            }
+        }
+        let state = normalize_cpu(
+            request
+                .state
+                .ok_or_else(|| Error::Other("GR00T inference requires normalized state".into()))?,
+            [1, 132],
+            "state",
+        )?;
+        transfers::copy_cpu_to_cuda(&state, &self.state)?;
+        self.backbone
+            .update_token_ids(&request.observation.token_ids)?;
+        match request.initial_latent {
+            InitialLatent::Provided(value) => {
+                let noise = normalize_cpu(value, [40, 132], "initial latent")?;
+                transfers::copy_cpu_to_cuda(&noise, &self.noise)?;
+            }
+            InitialLatent::Generate { rng } => {
+                self.normal.borrow_mut().generate(rng)?;
+            }
+        }
+        self.graph.replay()?;
+        Ok(Action::new(self.output.clone()))
+    }
+}
+
+impl VlaRuntime for GrootN17VlaRuntime {
+    fn infer(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        let spec = request.observation.inference_spec();
+        let prepared = self
+            .prepared
+            .borrow()
+            .as_ref()
+            .filter(|value| value.spec == spec)
+            .map(Rc::clone);
+        let prepared = if let Some(value) = prepared {
+            value
+        } else {
+            self.prepared.borrow_mut().take();
+            let value = Rc::new(self.build_prepared(&spec)?);
+            *self.prepared.borrow_mut() = Some(Rc::clone(&value));
+            value
+        };
+        prepared.run(request)
+    }
+
+    fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference>> {
+        Ok(Box::new(self.build_prepared(spec)?))
+    }
+
+    fn infer_host_f32(&self, request: &VlaRequest<'_>) -> Result<Vec<f32>> {
+        let action = self.infer(request)?;
+        self.backend.to_cpu(action.tensor())?.to_f32_vec()
+    }
+}
+
+pub(crate) fn load_registered(
+    path: &Path,
+    device: Device,
+    backend: Arc<dyn Backend>,
+    options: &LoadOptions,
+) -> Result<LoadedModel> {
+    if !matches!(device, Device::Cuda(_)) {
+        return Err(Error::Other("GR00T requires CUDA".into()));
+    }
+    if !matches!(
+        options.precision,
+        ModelPrecision::Auto | ModelPrecision::Bf16
+    ) {
+        return Err(Error::Other(
+            "GR00T N1.7 currently requires BF16 precision".into(),
+        ));
+    }
+    let backend =
+        downcast_arc(backend).ok_or_else(|| Error::Other("GR00T requires CudaBackend".into()))?;
+    let root = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(Path::new("."))
+    };
+    let config = Arc::new(GrootN17Config::from_json_file(&root.join("config.json"))?);
+    let (mut tensors, _) = apxinf_loader::safetensors::load_native_path(path)
+        .map_err(|error| Error::Other(format!("load GR00T checkpoint: {error}")))?;
+    let backbone_weights =
+        Arc::new(GrootN17BackboneWeights::from_map(&mut tensors)?.to_device(&*backend)?);
+    let action_weights =
+        Arc::new(GrootN17ActionWeights::from_map(&config, &mut tensors)?.to_device(&*backend)?);
+    let action = Arc::new(GrootN17ActionExecutor::new(
+        Arc::clone(&config),
+        action_weights,
+        &*backend,
+        &backend,
+    )?);
+    Ok(LoadedModel::Vla(Box::new(GrootN17VlaRuntime {
+        backend,
+        backbone_weights,
+        action,
+        prepared: RefCell::new(None),
+    })))
+}
+
+fn normalize_cpu<const N: usize>(
+    tensor: &Tensor,
+    shape: [usize; N],
+    label: &str,
+) -> Result<Tensor> {
+    if tensor.device() != Device::Cpu || tensor.shape().dims() != shape {
+        return Err(Error::Other(format!(
+            "GR00T {label} must be CPU {:?}, got {:?} on {}",
+            shape,
+            tensor.shape().dims(),
+            tensor.device()
+        )));
+    }
+    if tensor.dtype() == DType::BF16 {
+        return Ok(tensor.clone());
+    }
+    Tensor::from_bf16(
+        shape.to_vec(),
+        &tensor
+            .to_f32_vec()?
+            .into_iter()
+            .map(half::bf16::from_f32)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn image_rows(
+    device: usize,
+    tokens: &[u32],
+) -> Result<apxinf_cuda::kernels::elementwise::RowIndices> {
+    let rows = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &token)| (token == 151655).then_some(index as u32))
+        .collect::<Vec<_>>();
+    apxinf_cuda::kernels::elementwise::RowIndices::new(device, &rows)
+}
+fn text_rows(
+    device: usize,
+    tokens: &[u32],
+) -> Result<apxinf_cuda::kernels::elementwise::RowIndices> {
+    let rows = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &token)| (token != 151655).then_some(index as u32))
+        .collect::<Vec<_>>();
+    apxinf_cuda::kernels::elementwise::RowIndices::new(device, &rows)
+}
+
+fn kernel_image_layout(layout: crate::vla::ImageLayout) -> KernelImageLayout {
+    match layout {
+        crate::vla::ImageLayout::Nhwc => KernelImageLayout::Nhwc,
+        crate::vla::ImageLayout::Nchw => KernelImageLayout::Nchw,
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/weights.rs
+++ b/crates/apxinf-model/src/gr00t_n17/weights.rs
@@ -1,0 +1,398 @@
+//! Typed GR00T action-head weights.
+//!
+//! Hugging Face `nn.Linear` tensors are `[out, in]`; native GEMMs consume
+//! `[in, out]`. Category-specific tensors are already `[category, in, out]`,
+//! so the fixed LIBERO category is sliced without transposition.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use apxinf_core::{Backend, DType, Error, Result, Tensor};
+
+use super::GrootN17Config;
+
+#[derive(Debug)]
+pub struct LinearWeights {
+    pub weight: Tensor,
+    pub bias: Option<Tensor>,
+}
+
+#[derive(Debug)]
+pub struct LayerNormWeights {
+    pub weight: Tensor,
+    pub bias: Tensor,
+}
+
+#[derive(Debug)]
+pub struct AttentionWeights {
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct FeedForwardWeights {
+    pub input: LinearWeights,
+    pub output: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct VlBlockWeights {
+    pub norm1: LayerNormWeights,
+    pub attention: AttentionWeights,
+    pub norm3: LayerNormWeights,
+    pub feed_forward: FeedForwardWeights,
+}
+
+#[derive(Debug)]
+pub struct DitBlockWeights {
+    /// Timestep conditioning projection `[1536, 3072]`.
+    pub ada_norm: LinearWeights,
+    pub attention: AttentionWeights,
+    pub feed_forward: FeedForwardWeights,
+}
+
+#[derive(Debug)]
+pub struct CategoryMlpWeights {
+    pub layer1: LinearWeights,
+    pub layer2: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct ActionEncoderWeights {
+    pub w1: LinearWeights,
+    pub w2: LinearWeights,
+    pub w3: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct GrootN17ActionWeights {
+    pub vlln: LayerNormWeights,
+    pub vl_blocks: Vec<VlBlockWeights>,
+    pub state_encoder: CategoryMlpWeights,
+    pub action_encoder: ActionEncoderWeights,
+    pub position_embedding: Tensor,
+    pub timestep_in: LinearWeights,
+    pub timestep_out: LinearWeights,
+    pub dit_blocks: Vec<DitBlockWeights>,
+    pub final_condition: LinearWeights,
+    pub final_projection: LinearWeights,
+    pub action_decoder: CategoryMlpWeights,
+}
+
+impl GrootN17ActionWeights {
+    pub fn from_safetensors(config: &GrootN17Config, path: &Path) -> Result<Self> {
+        let (mut tensors, _) = apxinf_loader::safetensors::load_native_path(path)
+            .map_err(|error| Error::Other(format!("load GR00T SafeTensors: {error}")))?;
+        Self::from_map(config, &mut tensors)
+    }
+
+    pub fn from_map(
+        config: &GrootN17Config,
+        tensors: &mut HashMap<String, Tensor>,
+    ) -> Result<Self> {
+        config.validate()?;
+        let root = "action_head";
+        let mut vl_blocks = Vec::with_capacity(config.vl_self_attention_cfg.num_layers);
+        for index in 0..config.vl_self_attention_cfg.num_layers {
+            let prefix = format!("{root}.vl_self_attention.transformer_blocks.{index}");
+            vl_blocks.push(VlBlockWeights {
+                norm1: take_layer_norm(tensors, &format!("{prefix}.norm1"))?,
+                attention: take_attention(tensors, &prefix)?,
+                norm3: take_layer_norm(tensors, &format!("{prefix}.norm3"))?,
+                feed_forward: take_feed_forward(tensors, &prefix)?,
+            });
+        }
+
+        let mut dit_blocks = Vec::with_capacity(config.diffusion_model_cfg.num_layers);
+        for index in 0..config.diffusion_model_cfg.num_layers {
+            let prefix = format!("{root}.model.transformer_blocks.{index}");
+            dit_blocks.push(DitBlockWeights {
+                ada_norm: take_linear(tensors, &format!("{prefix}.norm1.linear"), true)?,
+                attention: take_attention(tensors, &prefix)?,
+                feed_forward: take_feed_forward(tensors, &prefix)?,
+            });
+        }
+
+        Ok(Self {
+            vlln: take_layer_norm(tensors, &format!("{root}.vlln"))?,
+            vl_blocks,
+            state_encoder: take_category_mlp(
+                tensors,
+                &format!("{root}.state_encoder"),
+                GrootN17Config::LIBERO_EMBODIMENT_ID,
+            )?,
+            action_encoder: ActionEncoderWeights {
+                w1: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W1"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+                w2: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W2"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+                w3: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W3"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+            },
+            position_embedding: take_leading_rows(
+                &take(tensors, &format!("{root}.position_embedding.weight"))?,
+                config.action_horizon,
+            )?,
+            timestep_in: take_linear(
+                tensors,
+                &format!("{root}.model.timestep_encoder.timestep_embedder.linear_1"),
+                true,
+            )?,
+            timestep_out: take_linear(
+                tensors,
+                &format!("{root}.model.timestep_encoder.timestep_embedder.linear_2"),
+                true,
+            )?,
+            dit_blocks,
+            final_condition: take_linear(tensors, &format!("{root}.model.proj_out_1"), true)?,
+            final_projection: take_linear(tensors, &format!("{root}.model.proj_out_2"), true)?,
+            action_decoder: take_category_mlp(
+                tensors,
+                &format!("{root}.action_decoder"),
+                GrootN17Config::LIBERO_EMBODIMENT_ID,
+            )?,
+        })
+    }
+
+    pub fn to_device(mut self, backend: &dyn Backend) -> Result<Self> {
+        upload_norm(&mut self.vlln, backend)?;
+        for block in &mut self.vl_blocks {
+            upload_norm(&mut block.norm1, backend)?;
+            upload_attention(&mut block.attention, backend)?;
+            upload_norm(&mut block.norm3, backend)?;
+            upload_feed_forward(&mut block.feed_forward, backend)?;
+        }
+        upload_category_mlp(&mut self.state_encoder, backend)?;
+        upload_linear(&mut self.action_encoder.w1, backend)?;
+        upload_linear(&mut self.action_encoder.w2, backend)?;
+        upload_linear(&mut self.action_encoder.w3, backend)?;
+        self.position_embedding = backend.to_device(&self.position_embedding)?;
+        upload_linear(&mut self.timestep_in, backend)?;
+        upload_linear(&mut self.timestep_out, backend)?;
+        for block in &mut self.dit_blocks {
+            upload_linear(&mut block.ada_norm, backend)?;
+            upload_attention(&mut block.attention, backend)?;
+            upload_feed_forward(&mut block.feed_forward, backend)?;
+        }
+        upload_linear(&mut self.final_condition, backend)?;
+        upload_linear(&mut self.final_projection, backend)?;
+        upload_category_mlp(&mut self.action_decoder, backend)?;
+        Ok(self)
+    }
+}
+
+pub(super) fn upload_linear(linear: &mut LinearWeights, backend: &dyn Backend) -> Result<()> {
+    linear.weight = backend.to_device(&linear.weight)?;
+    if let Some(bias) = &linear.bias {
+        linear.bias = Some(backend.to_device(bias)?);
+    }
+    Ok(())
+}
+
+fn upload_norm(norm: &mut LayerNormWeights, backend: &dyn Backend) -> Result<()> {
+    norm.weight = backend.to_device(&norm.weight)?;
+    norm.bias = backend.to_device(&norm.bias)?;
+    Ok(())
+}
+
+fn upload_attention(attention: &mut AttentionWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut attention.q, backend)?;
+    upload_linear(&mut attention.k, backend)?;
+    upload_linear(&mut attention.v, backend)?;
+    upload_linear(&mut attention.output, backend)
+}
+
+fn upload_feed_forward(feed_forward: &mut FeedForwardWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut feed_forward.input, backend)?;
+    upload_linear(&mut feed_forward.output, backend)
+}
+
+fn upload_category_mlp(mlp: &mut CategoryMlpWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut mlp.layer1, backend)?;
+    upload_linear(&mut mlp.layer2, backend)
+}
+
+fn take_attention(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<AttentionWeights> {
+    Ok(AttentionWeights {
+        q: take_linear(tensors, &format!("{prefix}.attn1.to_q"), true)?,
+        k: take_linear(tensors, &format!("{prefix}.attn1.to_k"), true)?,
+        v: take_linear(tensors, &format!("{prefix}.attn1.to_v"), true)?,
+        output: take_linear(tensors, &format!("{prefix}.attn1.to_out.0"), true)?,
+    })
+}
+
+fn take_feed_forward(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+) -> Result<FeedForwardWeights> {
+    Ok(FeedForwardWeights {
+        input: take_linear(tensors, &format!("{prefix}.ff.net.0.proj"), true)?,
+        output: take_linear(tensors, &format!("{prefix}.ff.net.2"), true)?,
+    })
+}
+
+fn take_category_mlp(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    category: usize,
+) -> Result<CategoryMlpWeights> {
+    Ok(CategoryMlpWeights {
+        layer1: take_category_linear(tensors, &format!("{prefix}.layer1"), category)?,
+        layer2: take_category_linear(tensors, &format!("{prefix}.layer2"), category)?,
+    })
+}
+
+fn take_layer_norm(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+) -> Result<LayerNormWeights> {
+    Ok(LayerNormWeights {
+        weight: take(tensors, &format!("{prefix}.weight"))?,
+        bias: take(tensors, &format!("{prefix}.bias"))?,
+    })
+}
+
+fn take_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    bias: bool,
+) -> Result<LinearWeights> {
+    let weight = transpose_2d(&take(tensors, &format!("{prefix}.weight"))?)?;
+    let bias = bias
+        .then(|| take(tensors, &format!("{prefix}.bias")))
+        .transpose()?;
+    Ok(LinearWeights { weight, bias })
+}
+
+fn take_category_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    category: usize,
+) -> Result<LinearWeights> {
+    let weight = select_category(&take(tensors, &format!("{prefix}.W"))?, category)?;
+    let bias = select_category(&take(tensors, &format!("{prefix}.b"))?, category)?;
+    Ok(LinearWeights {
+        weight,
+        bias: Some(bias),
+    })
+}
+
+pub(super) fn take(tensors: &mut HashMap<String, Tensor>, name: &str) -> Result<Tensor> {
+    tensors
+        .remove(name)
+        .ok_or_else(|| Error::Other(format!("missing GR00T tensor `{name}`")))
+}
+
+fn select_category(tensor: &Tensor, category: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() < 2 || category >= dims[0] {
+        return Err(Error::Other(format!(
+            "category {category} is invalid for shape {dims:?}"
+        )));
+    }
+    let category_elements: usize = dims[1..].iter().product();
+    let output_shape = dims[1..].to_vec();
+    match tensor.dtype() {
+        DType::BF16 => {
+            let values = tensor.as_bf16()?;
+            let start = category * category_elements;
+            Tensor::from_bf16(output_shape, &values[start..start + category_elements])
+        }
+        DType::F32 => {
+            let values = tensor.as_f32()?;
+            let start = category * category_elements;
+            Tensor::from_f32(output_shape, &values[start..start + category_elements])
+        }
+        dtype => Err(Error::Other(format!(
+            "GR00T category weights require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+fn take_leading_rows(tensor: &Tensor, rows: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() != 2 || rows > dims[0] {
+        return Err(Error::Other(format!(
+            "cannot take {rows} leading rows from shape {dims:?}"
+        )));
+    }
+    let cols = dims[1];
+    match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(vec![rows, cols], &tensor.as_bf16()?[..rows * cols]),
+        DType::F32 => Tensor::from_f32(vec![rows, cols], &tensor.as_f32()?[..rows * cols]),
+        dtype => Err(Error::Other(format!(
+            "GR00T leading rows require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+pub(super) fn transpose_2d(tensor: &Tensor) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() != 2 {
+        return Err(Error::Other(format!(
+            "GR00T linear weight must be 2D, got {dims:?}"
+        )));
+    }
+    let (rows, cols) = (dims[0], dims[1]);
+    match tensor.dtype() {
+        DType::BF16 => {
+            let input = tensor.as_bf16()?;
+            let mut output = vec![half::bf16::from_f32(0.0); input.len()];
+            for row in 0..rows {
+                for col in 0..cols {
+                    output[col * rows + row] = input[row * cols + col];
+                }
+            }
+            Tensor::from_bf16(vec![cols, rows], &output)
+        }
+        DType::F32 => {
+            let input = tensor.as_f32()?;
+            let mut output = vec![0.0; input.len()];
+            for row in 0..rows {
+                for col in 0..cols {
+                    output[col * rows + row] = input[row * cols + col];
+                }
+            }
+            Tensor::from_f32(vec![cols, rows], &output)
+        }
+        dtype => Err(Error::Other(format!(
+            "GR00T linear weights require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use apxinf_core::Tensor;
+    use half::bf16;
+
+    use super::{select_category, transpose_2d};
+
+    #[test]
+    fn category_slice_preserves_in_out_layout() {
+        let values = (0..24).map(|value| bf16::from_f32(value as f32)).collect::<Vec<_>>();
+        let tensor = Tensor::from_bf16(vec![2, 3, 4], &values).unwrap();
+        let selected = select_category(&tensor, 1).unwrap();
+        assert_eq!(selected.shape().dims(), [3, 4]);
+        assert_eq!(selected.to_f32_vec().unwrap(), (12..24).map(|v| v as f32).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn transposes_hugging_face_linear_weight() {
+        let tensor = Tensor::from_f32(vec![2, 3], &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        let transposed = transpose_2d(&tensor).unwrap();
+        assert_eq!(transposed.shape().dims(), [3, 2]);
+        assert_eq!(transposed.as_f32().unwrap(), &[0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+    }
+}

--- a/crates/apxinf-model/src/lib.rs
+++ b/crates/apxinf-model/src/lib.rs
@@ -4,6 +4,7 @@ mod accelerator;
 pub mod builtin;
 pub mod debug;
 mod generation_config;
+pub mod gr00t_n17;
 pub mod llama;
 pub mod llm_trait;
 pub mod registry;
@@ -16,6 +17,7 @@ pub mod vla;
 pub use builtin::register_builtin_models;
 pub use debug::{DebugCapture, DebugConfig};
 pub use generation_config::{GenerationConfigSource, GenerationOptions, SamplingMode};
+pub use gr00t_n17::GrootN17Config;
 pub use llama::{GeneralLlama, LlamaModel, LlamaWeights, TransformerLayer, KVCache};
 pub use llm_trait::{
     generate_streaming, generate_streaming_with_options, GeneratedToken, GenerationOutput,

--- a/crates/apxinf-model/src/pi05/config.rs
+++ b/crates/apxinf-model/src/pi05/config.rs
@@ -576,6 +576,27 @@ mod tests {
     }
 
     #[test]
+    fn parses_the_config_json_synthesised_from_an_openpi_metadata_pt() {
+        // An openpi PyTorch export ships no config.json at all, so the Python
+        // side reads metadata.pt and hands the loader this string through
+        // `Model.load(config_json=...)`. Without it the loader fell back to
+        // `Pi05Config::default()` in silence, serving a 3-view/50-step default
+        // whatever the checkpoint actually was. This is the exact spelling
+        // `apxinf.checkpoints.train_config_facts` emits, so a change on either
+        // side that breaks the handshake fails here rather than on a robot.
+        let cfg = Pi05Config::from_json_str(
+            r#"{"action_dim": 32, "action_horizon": 50, "discrete_state_input": true,
+                "max_token_len": 200, "num_views": 3}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.action_dim, 32);
+        assert_eq!(cfg.action_horizon, 50);
+        assert_eq!(cfg.max_token_len, 200);
+        assert_eq!(cfg.num_views, 3);
+        assert!(cfg.discrete_state_input);
+    }
+
+    #[test]
     fn language_dual_geglu_shapes_are_reachable_only_for_two_view_profile() {
         assert!(Pi05Config::thor_two_view().language_dual_geglu_shape_possible());
         assert!(!Pi05Config::default().language_dual_geglu_shape_possible());

--- a/crates/apxinf-model/src/pi05/math.rs
+++ b/crates/apxinf-model/src/pi05/math.rs
@@ -26,12 +26,41 @@ pub fn sinusoidal_time_embedding(
     sin
 }
 
-/// Match NumPy `digitize(state, linspace(-1, 1, 257)[:-1]) - 1`, with
-/// saturation for out-of-range sensor values.
-pub fn discretize_state(state: &[f32]) -> Vec<u8> {
+/// Match NumPy `digitize(state, linspace(-1, 1, 257)[:-1]) - 1`.
+///
+/// `digitize` returns `0` for `v < -1`, so the bin is `-1`, and openpi writes
+/// that straight into the prompt (`models/tokenizer.py`) — it is a value the
+/// model saw during training, so it must not be clamped to `0`. The return type
+/// is therefore signed. Values `>= 1` do saturate, to `255`.
+///
+/// Implemented as a search over the edges, which is what `digitize` does, rather
+/// than the arithmetic `floor((v + 1.0) * 128.0)`. The two are not equal: adding
+/// `1.0` to a value just below an edge in `[-0.5, -0.25)` moves it into a binade
+/// with twice the ulp, the sum rounds *up* onto the edge, and the floor lands one
+/// bin high. `-0.4921875` (edge 65) is the one f32 value where this happens, and
+/// one bin is a different prompt string, different token ids, different rollout.
+///
+/// Every edge is `-1 + i/128` with `i <= 255`, i.e. `(i - 128)/128` — at most
+/// eight significant bits — so it is exact in f32 and each comparison below is
+/// exact. NaN falls out as `-1` here (all comparisons false); NaN state is
+/// rejected upstream and is not a supported input on either side.
+pub fn discretize_state(state: &[f32]) -> Vec<i16> {
     state
         .iter()
-        .map(|&value| (((value + 1.0) * 128.0).floor() as i32).clamp(0, 255) as u8)
+        .map(|&value| {
+            // Binary search for the number of edges <= value, i.e.
+            // `searchsorted(edges, value, side="right")`; the bin is that minus one.
+            let (mut lo, mut hi) = (0i32, 256i32);
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2;
+                if -1.0 + mid as f32 / 128.0 <= value {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            (lo - 1) as i16
+        })
         .collect()
 }
 
@@ -42,7 +71,7 @@ pub fn pi05_prompt(task: &str, normalized_state: &[f32], discrete_state_input: b
     }
     let state = discretize_state(normalized_state)
         .iter()
-        .map(u8::to_string)
+        .map(i16::to_string)
         .collect::<Vec<_>>()
         .join(" ");
     format!("Task: {task}, State: {state};\nAction: ")
@@ -73,14 +102,63 @@ mod tests {
     #[test]
     fn state_discretization_and_prompt_match_pi05() {
         assert_eq!(
-            discretize_state(&[-2.0, -1.0, 0.0, 0.999, 1.0, 2.0]),
-            vec![0, 0, 128, 255, 255, 255]
+            discretize_state(&[-2.0, -1.000_001, -1.0, 0.0, 0.999, 1.0, 2.0]),
+            vec![-1, -1, 0, 128, 255, 255, 255]
         );
         assert_eq!(
-            pi05_prompt(" pick_up\ncup ", &[-1.0, 0.0, 1.0], true),
-            "Task: pick up cup, State: 0 128 255;\nAction: "
+            pi05_prompt(" pick_up\ncup ", &[-2.0, -1.0, 0.0, 1.0], true),
+            "Task: pick up cup, State: -1 0 128 255;\nAction: "
         );
         assert_eq!(pi05_prompt("pick_up", &[], false), "pick up\n");
+    }
+
+    /// The next representable f32 below `x`. `0.0` steps to the smallest
+    /// negative subnormal, which is what makes edge 128 (exactly `0.0`) testable.
+    fn next_below(x: f32) -> f32 {
+        if x > 0.0 {
+            f32::from_bits(x.to_bits() - 1)
+        } else if x < 0.0 {
+            f32::from_bits(x.to_bits() + 1)
+        } else {
+            -f32::from_bits(1)
+        }
+    }
+
+    fn next_above(x: f32) -> f32 {
+        -next_below(-x)
+    }
+
+    #[test]
+    fn discretization_matches_digitize_at_every_bin_edge() {
+        // Each edge and both of its f32 neighbours: the edge itself opens its own
+        // bin, one ulp below stays in the previous one. The arithmetic form
+        // `floor((v + 1.0) * 128.0)` gets exactly one of these 768 cases wrong.
+        for i in 0..256i32 {
+            let edge = -1.0 + i as f32 / 128.0;
+            assert_eq!(discretize_state(&[edge]), vec![i as i16], "edge {i}");
+            assert_eq!(
+                discretize_state(&[next_below(edge)]),
+                vec![(i - 1) as i16],
+                "one ulp below edge {i}"
+            );
+            assert_eq!(
+                discretize_state(&[next_above(edge)]),
+                vec![i as i16],
+                "one ulp above edge {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn discretization_does_not_round_up_onto_an_edge() {
+        // One ulp below edge 65 (-0.4921875). Adding 1.0 lands the value in a
+        // binade with twice the ulp, so the sum rounds up to exactly 0.5078125
+        // and a floor-based index returns 65 instead of 64 -- a different prompt
+        // string for a state that is, by NumPy's reckoning, in bin 64.
+        let v = f32::from_bits((-0.4921875f32).to_bits() + 1);
+        assert!(v < -0.4921875, "one ulp below the edge");
+        assert_eq!(((v + 1.0) * 128.0).floor() as i32, 65, "the trap this guards");
+        assert_eq!(discretize_state(&[v]), vec![64]);
     }
 
     #[test]

--- a/crates/apxinf-model/src/pi05/vla_runtime.rs
+++ b/crates/apxinf-model/src/pi05/vla_runtime.rs
@@ -616,14 +616,15 @@ pub(super) fn load_registered(
                     &calibration,
                 )?)
             };
-            // A checkpoint-free synthetic load relies on the kernel's tactic
-            // fallback, so a tuning database is only required for real FP8 runs.
-            if synthetic.is_none() {
-                tuning_database.as_ref().ok_or_else(|| {
-                    Error::Other(
-                        "FP8 PI0.5 requires LoadOptions.tuning_path or tactics.json".into(),
-                    )
-                })?;
+            // No tuning database is fatal: the FP8 GEMM falls back to a
+            // shape-heuristic tactic. Warn on real weights, where an untuned
+            // tactic is a silent latency regression rather than a wrong answer.
+            if synthetic.is_none() && tuning_database.is_none() {
+                eprintln!(
+                    "[apxinf] FP8 PI0.5 running without a GEMM tactic database \
+                     (no LoadOptions.tuning_path, no tactics.json in the checkpoint); \
+                     using heuristic tactics, expect lower throughput"
+                );
             }
             let weights = Arc::new(StaticFp8Pi05Weights::from_host(
                 &host_weights,

--- a/crates/apxinf-model/src/vla/mod.rs
+++ b/crates/apxinf-model/src/vla/mod.rs
@@ -61,6 +61,8 @@ pub enum InitialLatent<'a> {
 pub struct VlaRequest<'a> {
     pub observation: &'a Observation,
     pub initial_latent: InitialLatent<'a>,
+    /// Optional normalized proprioceptive state for state-conditioned VLAs.
+    pub state: Option<&'a Tensor>,
 }
 
 impl<'a> VlaRequest<'a> {
@@ -68,6 +70,7 @@ impl<'a> VlaRequest<'a> {
         Self {
             observation,
             initial_latent: InitialLatent::Generate { rng },
+            state: None,
         }
     }
 
@@ -75,7 +78,13 @@ impl<'a> VlaRequest<'a> {
         Self {
             observation,
             initial_latent: InitialLatent::Provided(latent),
+            state: None,
         }
+    }
+
+    pub const fn with_state(mut self, state: &'a Tensor) -> Self {
+        self.state = Some(state);
+        self
     }
 }
 

--- a/crates/apxinf-py/apxinf_py.pyi
+++ b/crates/apxinf-py/apxinf_py.pyi
@@ -18,6 +18,7 @@ class Model:
         precision: str = ...,
         calibration: str | None = ...,
         tactics: str | None = ...,
+        config_json: str | None = ...,
         action_horizon: int | None = ...,
         num_views: int | None = ...,
         sampling_seed: int = ...,
@@ -26,6 +27,10 @@ class Model:
 
         ``device`` is ``cuda:N`` (default) or ``cpu``.
         ``precision`` is ``auto`` (default), ``fp8``, ``bf16``, or ``int8``.
+        ``config_json`` supplies the architecture for a checkpoint that has no
+        ``config.json`` — an openpi PyTorch export keeps its constants in
+        ``metadata.pt``, which :mod:`apxinf.checkpoints` reads and passes here.
+        ``None`` reads ``config.json`` from the checkpoint directory as before.
         ``action_horizon`` overrides the checkpoint's chunk length (a sequence
         length, not a weight dimension).
         ``num_views`` serves fewer cameras than the checkpoint declares (1..=its

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -241,6 +241,15 @@ impl Model {
     /// * `calibration` / `tactics` — optional FP8 calibration / tactics json.
     /// * `sampling_seed` — seed for the implicit device-side noise stream used
     ///   when inference is called without `noise`.
+    /// * `config_json` — the architecture, as a `config.json`-shaped string,
+    ///   for a checkpoint that has no `config.json`. An openpi PyTorch export
+    ///   never carries one: its constants live in `metadata.pt`, which the
+    ///   Python side reads (`apxinf.checkpoints`) and passes through here.
+    ///   Without it such a checkpoint silently loaded at `Pi05Config::default()`,
+    ///   so a chunk length or view count that differed from the default was
+    ///   wrong with no error anywhere. `None` keeps the old behaviour: read
+    ///   `config.json` from the checkpoint directory, else fall back to the
+    ///   default.
     /// * `action_horizon` — override the checkpoint's chunk length. `None`
     ///   (default) runs the native `config.json` value; an explicit value wins
     ///   over it. The horizon is a sequence length, not a weight dimension, so
@@ -255,7 +264,7 @@ impl Model {
     /// tokens per step. Nothing weight-shaped depends on the count; it only sizes
     /// the prefix, so this is a load-time constant, not a per-request one.
     #[staticmethod]
-    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, action_horizon=None, num_views=None, sampling_seed=0))]
+    #[pyo3(signature = (model, path, device="cuda:0", precision="auto", calibration=None, tactics=None, config_json=None, action_horizon=None, num_views=None, sampling_seed=0))]
     fn load(
         model: &str,
         path: PathBuf,
@@ -263,16 +272,19 @@ impl Model {
         precision: &str,
         calibration: Option<PathBuf>,
         tactics: Option<PathBuf>,
+        config_json: Option<&str>,
         action_horizon: Option<usize>,
         num_views: Option<usize>,
         sampling_seed: u64,
     ) -> PyResult<Self> {
         let device = parse_device(device)?;
-        let mut config = load_config(&path)?;
         // Only hand the loader an explicit config when the caller actually
-        // overrode something; otherwise it reads `config.json` itself, exactly
-        // as before.
-        let mut overridden = false;
+        // supplied or overrode one; otherwise it reads `config.json` itself,
+        // exactly as before.
+        let (mut config, mut overridden) = match config_json {
+            Some(raw) => (Pi05Config::from_json_str(raw).map_err(runtime_err)?, true),
+            None => (load_config(&path)?, false),
+        };
         if let Some(horizon) = action_horizon {
             config.action_horizon = horizon;
             overridden = true;

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -43,6 +43,46 @@ use apxinf_model::{
     SyntheticWeights, VisionObservation, VlaRequest,
 };
 
+#[derive(Clone)]
+struct RuntimeShape {
+    num_views: usize,
+    image_size: usize,
+    patch_size: usize,
+    action_horizon: usize,
+    action_dim: usize,
+    max_token_len: usize,
+    groot: bool,
+}
+
+impl RuntimeShape {
+    fn from_pi(config: &Pi05Config) -> Self {
+        Self {
+            num_views: config.num_views,
+            image_size: config.image_size,
+            patch_size: config.patch_size,
+            action_horizon: config.action_horizon,
+            action_dim: config.action_dim,
+            max_token_len: config.max_token_len,
+            groot: false,
+        }
+    }
+    fn groot(num_views: usize) -> Self {
+        Self {
+            num_views,
+            image_size: 256,
+            patch_size: 16,
+            action_horizon: 40,
+            action_dim: 132,
+            max_token_len: 142,
+            groot: true,
+        }
+    }
+    fn patches_per_view(&self) -> usize {
+        let side = self.image_size / self.patch_size;
+        side * side
+    }
+}
+
 /// Map any Rust error into a Python `RuntimeError`.
 fn runtime_err<E: std::fmt::Display>(error: E) -> PyErr {
     PyRuntimeError::new_err(error.to_string())
@@ -117,7 +157,7 @@ fn load_config(checkpoint: &Path) -> PyResult<Pi05Config> {
 #[pyclass(unsendable)]
 pub struct Model {
     model: LoadedModel,
-    config: Pi05Config,
+    config: RuntimeShape,
     device: Device,
     sampling_seed: Cell<u64>,
     sampling_draw: Cell<u64>,
@@ -129,7 +169,8 @@ impl Model {
     }
 
     fn patch_width(&self) -> usize {
-        3 * self.config.patch_size * self.config.patch_size
+        let temporal_patch = if self.config.groot { 2 } else { 1 };
+        temporal_patch * 3 * self.config.patch_size * self.config.patch_size
     }
 
     fn validate_tokens(&self, token_ids: &[u32]) -> PyResult<()> {
@@ -162,11 +203,7 @@ impl Model {
         let data = noise.as_slice().map_err(|_| {
             PyValueError::new_err("apxinf_py.infer: noise must be C-contiguous float32")
         })?;
-        Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            data,
-        )
-        .map_err(runtime_err)
+        Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), data).map_err(runtime_err)
     }
 
     fn action_array<'py>(
@@ -210,8 +247,12 @@ impl Model {
         py: Python<'py>,
         observation: Observation,
         latent: Tensor,
+        state: Option<Tensor>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
-        let request = VlaRequest::provided(&observation, &latent);
+        let mut request = VlaRequest::provided(&observation, &latent);
+        if let Some(value) = state.as_ref() {
+            request = request.with_state(value);
+        }
         let flat = self.model.infer_host_f32(&request).map_err(runtime_err)?;
         self.action_array(py, flat)
     }
@@ -223,8 +264,12 @@ impl Model {
         py: Python<'py>,
         observation: Observation,
         rng: RngKey,
+        state: Option<Tensor>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
-        let request = VlaRequest::generated(&observation, rng);
+        let mut request = VlaRequest::generated(&observation, rng);
+        if let Some(value) = state.as_ref() {
+            request = request.with_state(value);
+        }
         let flat = self.model.infer_host_f32(&request).map_err(runtime_err)?;
         self.action_array(py, flat)
     }
@@ -278,46 +323,63 @@ impl Model {
         sampling_seed: u64,
     ) -> PyResult<Self> {
         let device = parse_device(device)?;
+        let is_groot = model.eq_ignore_ascii_case("Gr00tN1d7");
+        if is_groot && (config_json.is_some() || action_horizon.is_some()) {
+            return Err(PyValueError::new_err(
+                "apxinf_py.load: GR00T N1.7 architecture overrides are unsupported",
+            ));
+        }
+        let groot_views = num_views.unwrap_or(2);
+        if is_groot && !matches!(groot_views, 1 | 2) {
+            return Err(PyValueError::new_err(
+                "apxinf_py.load: GR00T N1.7 num_views must be 1 or 2",
+            ));
+        }
         // Only hand the loader an explicit config when the caller actually
         // supplied or overrode one; otherwise it reads `config.json` itself,
         // exactly as before.
-        let (mut config, mut overridden) = match config_json {
+        let (mut pi_config, mut overridden) = match config_json {
             Some(raw) => (Pi05Config::from_json_str(raw).map_err(runtime_err)?, true),
+            None if is_groot => (Pi05Config::default(), false),
             None => (load_config(&path)?, false),
         };
         if let Some(horizon) = action_horizon {
-            config.action_horizon = horizon;
+            pi_config.action_horizon = horizon;
             overridden = true;
         }
         if let Some(views) = num_views {
-            if views == 0 || views > config.num_views {
+            if views == 0 || views > pi_config.num_views {
                 return Err(PyValueError::new_err(format!(
                     "apxinf_py.load: num_views={views} must be in 1..={} (the \
                      checkpoint's view count); a checkpoint cannot serve more \
                      cameras than it was trained on",
-                    config.num_views
+                    pi_config.num_views
                 )));
             }
-            config.num_views = views;
+            pi_config.num_views = views;
             overridden = true;
         }
         // Validate once, after every override, so a combination that is
         // individually valid but jointly is not still fails here.
         if overridden {
-            config.validate().map_err(runtime_err)?;
+            pi_config.validate().map_err(runtime_err)?;
         }
         let options = LoadOptions {
             model_name: Some(model.to_owned()),
             precision: parse_precision(precision)?,
             calibration_path: calibration,
             tuning_path: tactics,
-            config: overridden.then(|| config.clone()),
+            config: (!is_groot && overridden).then(|| pi_config.clone()),
             ..LoadOptions::default()
         };
         let loaded = AutoModel::load_model(device, &path, &options).map_err(runtime_err)?;
         Ok(Self {
             model: loaded,
-            config,
+            config: if is_groot {
+                RuntimeShape::groot(groot_views)
+            } else {
+                RuntimeShape::from_pi(&pi_config)
+            },
             device,
             sampling_seed: Cell::new(sampling_seed),
             sampling_draw: Cell::new(0),
@@ -408,11 +470,10 @@ impl Model {
             uniform_fp8_scale,
             ..LoadOptions::default()
         };
-        let loaded = AutoModel::load_model(device, Path::new(""), &options)
-            .map_err(runtime_err)?;
+        let loaded = AutoModel::load_model(device, Path::new(""), &options).map_err(runtime_err)?;
         Ok(Self {
             model: loaded,
-            config,
+            config: RuntimeShape::from_pi(&config),
             device,
             sampling_seed: Cell::new(sampling_seed),
             sampling_draw: Cell::new(0),
@@ -429,13 +490,14 @@ impl Model {
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
-    #[pyo3(name = "_infer_patches", signature = (patches, token_ids, noise=None))]
+    #[pyo3(name = "_infer_patches", signature = (patches, token_ids, noise=None, state=None))]
     fn infer_patches<'py>(
         &self,
         py: Python<'py>,
         patches: PyReadonlyArray2<'py, f32>,
         token_ids: PyReadonlyArray1<'py, u32>,
         noise: Option<PyReadonlyArray2<'py, f32>>,
+        state: Option<PyReadonlyArray2<'py, f32>>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
         let expected = [self.patch_rows(), self.patch_width()];
         let shape = patches.shape();
@@ -451,27 +513,52 @@ impl Model {
         let tokens = token_ids
             .as_slice()
             .map_err(|_| {
-                PyValueError::new_err("apxinf_py._infer_patches: token_ids must be C-contiguous uint32")
+                PyValueError::new_err(
+                    "apxinf_py._infer_patches: token_ids must be C-contiguous uint32",
+                )
             })?
             .to_vec();
         self.validate_tokens(&tokens)?;
 
-        let patch_tensor = Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            patch_data,
-        )
-        .map_err(runtime_err)?;
+        let patch_tensor = Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), patch_data)
+            .map_err(runtime_err)?;
 
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
         };
+        let state = match state {
+            Some(value) => {
+                if value.shape() != [1, 132] {
+                    return Err(PyValueError::new_err(
+                        "apxinf_py._infer_patches: GR00T state must have shape [1,132]",
+                    ));
+                }
+                Some(
+                    Tensor::from_f32(
+                        (1, 132),
+                        value.as_slice().map_err(|_| {
+                            PyValueError::new_err(
+                                "apxinf_py._infer_patches: state must be contiguous float32",
+                            )
+                        })?,
+                    )
+                    .map_err(runtime_err)?,
+                )
+            }
+            None => None,
+        };
+        if self.config.groot && state.is_none() {
+            return Err(PyValueError::new_err(
+                "apxinf_py._infer_patches: GR00T requires state",
+            ));
+        }
         match noise {
             Some(noise) => {
                 let noise_tensor = self.noise_tensor(noise)?;
-                self.run_provided(py, observation, noise_tensor)
+                self.run_provided(py, observation, noise_tensor, state)
             }
-            None => self.run_generated(py, observation, self.next_sampling_rng()?),
+            None => self.run_generated(py, observation, self.next_sampling_rng()?, state),
         }
     }
 
@@ -509,16 +596,13 @@ impl Model {
             })?
             .to_vec();
         self.validate_tokens(&tokens)?;
-        let patch_tensor = Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            patch_data,
-        )
-        .map_err(runtime_err)?;
+        let patch_tensor = Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), patch_data)
+            .map_err(runtime_err)?;
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
         };
-        self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
+        self.run_generated(py, observation, RngKey::new(seed, sequence, draw), None)
     }
 
     /// **L1** — infer from resized RGB `uint8` images; vision→patches runs in the
@@ -532,7 +616,7 @@ impl Model {
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
-    #[pyo3(signature = (rgb_u8, layout, token_ids, noise=None))]
+    #[pyo3(signature = (rgb_u8, layout, token_ids, noise=None, state=None))]
     fn infer_rgb<'py>(
         &self,
         py: Python<'py>,
@@ -540,6 +624,7 @@ impl Model {
         layout: &str,
         token_ids: PyReadonlyArray1<'py, u32>,
         noise: Option<PyReadonlyArray2<'py, f32>>,
+        state: Option<PyReadonlyArray2<'py, f32>>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
         let layout = parse_layout(layout)?;
         let expected_bytes =
@@ -571,12 +656,38 @@ impl Model {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
         };
+        let state = match state {
+            Some(value) => {
+                if value.shape() != [1, 132] {
+                    return Err(PyValueError::new_err(
+                        "apxinf_py.infer_rgb: GR00T state must have shape [1,132]",
+                    ));
+                }
+                Some(
+                    Tensor::from_f32(
+                        (1, 132),
+                        value.as_slice().map_err(|_| {
+                            PyValueError::new_err(
+                                "apxinf_py.infer_rgb: state must be contiguous float32",
+                            )
+                        })?,
+                    )
+                    .map_err(runtime_err)?,
+                )
+            }
+            None => None,
+        };
+        if self.config.groot && state.is_none() {
+            return Err(PyValueError::new_err(
+                "apxinf_py.infer_rgb: GR00T requires state",
+            ));
+        }
         match noise {
             Some(noise) => {
                 let noise_tensor = self.noise_tensor(noise)?;
-                self.run_provided(py, observation, noise_tensor)
+                self.run_provided(py, observation, noise_tensor, state)
             }
-            None => self.run_generated(py, observation, self.next_sampling_rng()?),
+            None => self.run_generated(py, observation, self.next_sampling_rng()?, state),
         }
     }
 
@@ -627,7 +738,7 @@ impl Model {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
         };
-        self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
+        self.run_generated(py, observation, RngKey::new(seed, sequence, draw), None)
     }
 
     /// Reset the implicit device-side sampling stream used when `noise=None`.

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -17,13 +17,16 @@ arrives as `observation/image` or as `obs["images"]["cam_high"]`, whether the
 state vector is discretized into the prompt or dropped, or whether the 32-wide
 model output should be truncated to 7 or to 16.
 
-Before presets, `Pi05Policy`'s LIBERO defaults applied to *every* checkpoint. A
-G1 checkpoint served with no extra arguments ran LIBERO's keys, dropped state,
-and skipped the G1 delta→absolute and 32→16 steps. Nothing failed. Nothing
-logged. It looked exactly like a "model accuracy problem."
+Before presets, `Pi05Policy` defaulted `image_keys` to LIBERO's two, so that
+contract applied to *every* checkpoint. A G1 checkpoint served with no extra
+arguments ran LIBERO's keys, dropped state, and skipped the G1 delta→absolute and
+32→16 steps. Nothing failed. Nothing logged. It looked exactly like a "model
+accuracy problem."
 
-So the embodiment is a named, explicit launch flag on both sides — the same shape
-OpenPI uses, so the two line up one-to-one:
+The model layer now names no wire keys at all — construct a policy without them
+and it falls back to its own view slots, which no client sends, so a mismatch is
+a `KeyError` naming both sides. The embodiment is a named, explicit launch flag
+on both sides — the same shape OpenPI uses, so the two line up one-to-one:
 
 ```
 openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
@@ -37,7 +40,7 @@ things and they never need to be equal.
 
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
-| **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `robots/presets.py` | never — the *order* is baked into the weights |
+| **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
 | **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `slots` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
@@ -46,6 +49,13 @@ order-significant: entry *i* is stacked into model view slot *i*. A tuple writte
 in the wrong order still stacks, still has the right shape, and silently feeds
 the wrong camera to each slot — pairing every key with its slot makes that
 reviewable instead of positional.
+
+The slot names live in `policies/base.py`, not in the preset table: they are
+*model* vocabulary, so the robot layer reads them rather than restating them. The
+policy layer holds **no** wire keys at all. Construct a policy without naming
+cameras and it names them after its own view slots — a client sending
+`observation/image` then gets a `KeyError` naming both sides, instead of the old
+behaviour where LIBERO's two keys were the built-in default for every checkpoint.
 
 ## Launching a server for an existing embodiment
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -77,7 +77,7 @@ connect-time metadata. Read one of them **before** concluding anything about
 accuracy:
 
 ```
-INFO serving robot=unitree_g1 H=50 x D=32
+INFO serving robot=unitree_g1 robot_steps=True H=50 x D=32
      image_keys=['images/cam_high', 'images/cam_left_wrist', 'images/cam_right_wrist']
      state=state discrete_state=False
 ```
@@ -89,14 +89,17 @@ from openpi_client import websocket_client_policy as wcp
 c = wcp.WebsocketClientPolicy(host="127.0.0.1", port=8000)
 meta = c.get_server_metadata()
 assert meta["robot"] == "unitree_g1"
+assert meta["robot_steps"] is True      # this robot's arithmetic is actually wired
 assert meta["image_keys"] == [...]      # the keys you are actually sending
 assert meta["discrete_state"] is True   # a joint-space robot needs this on
 ```
 
-Published keys: `robot`, `robot_slots`, `model_type`, `image_keys`, `state_key`,
-`prompt_key`, `discrete_state`, `state_normalized`, `action_horizon`,
-`action_dim`, `model_action_dim`, `num_views`, `image_size`, `input_pipeline`,
-`output_pipeline`. A key mismatch is invisible on the wire but obvious here.
+Published keys: `robot`, `robot_steps`, `robot_slots`, `model_type`,
+`image_keys`, `state_key`, `prompt_key`, `discrete_state`, `state_normalized`,
+`action_horizon`, `action_dim`, `model_action_dim`, `num_views`, `image_size`,
+`input_pipeline`, `output_pipeline`. A key mismatch is invisible on the wire but
+obvious here. `robot_steps` is `False` on a server that serves a preset's keys
+without running its builder — see `--random-weights` below.
 
 ### Per-field overrides
 
@@ -275,7 +278,7 @@ suffix — `unitree_g1`.
 
 ### Step 5 — tests
 
-Add to `tests/test_robot_presets.py`. Four things are worth asserting, and they
+Add to `tests/test_robot_presets.py`. Five things are worth asserting, and they
 run on CPU with a mock model — no GPU, no checkpoint:
 
 1. **the preset matches the openpi transform it mirrors** — keys, order, widths,
@@ -286,7 +289,11 @@ run on CPU with a mock model — no GPU, no checkpoint:
 3. **the wrong dialect fails loudly** — a LIBERO-shaped observation against your
    server must raise, naming the served `image_keys`;
 4. **slot order is load-bearing** — reordering `image_keys` reorders the stacked
-   views (`ImageSlotOrderTest` asserts this against the tensor, not the metadata).
+   views (`ImageSlotOrderTest` asserts this against the tensor, not the metadata);
+5. **the contract you publish is the one you serve** — `BuildRobotPolicyTest`
+   asserts the resolved keys and `robot_steps` reach the builder and the metadata,
+   and `SyntheticContractTest` asserts a checkpoint-free server names what it
+   cannot honour instead of passing for the real embodiment.
 
 ```bash
 python3 tests/test_robot_presets.py          # no GPU needed
@@ -318,9 +325,13 @@ constant. A hard-coded expected shape tests your memory of the checkpoint rather
 than the server.
 
 For a transport-only check with no weights on disk, `--random-weights --robot
-<preset>` serves the preset's key layout on synthetic weights. Its actions are
-numerically meaningless, and it cannot honour `discrete_state=True` (the
-synthetic tokenizer never reads state) — it warns at startup when you ask it to.
+<preset>` serves the preset's key layout and view count on synthetic weights.
+That is all it serves: the actions are numerically meaningless, and the preset's
+`builder` never runs, so none of its robot pre/post steps is wired. It publishes
+`robot_steps=false` and warns once at startup naming every gap — `discrete_state`
+(the synthetic tokenizer never reads state) and, for a robot-step preset, the
+skipped factory and the action width that came out of the model instead of out of
+the encode step.
 
 ## Gotchas we hit
 
@@ -342,10 +353,12 @@ synthetic tokenizer never reads state) — it warns at startup when you ask it t
 6. **A preset's `num_views` must equal the checkpoint's**, unless you pass
    `--num-views` to load fewer. `Pi05Policy.default_pipelines` rejects a mismatch
    and names the fix in the message.
-7. **`--random-weights` cannot preview a `discrete_state=True` contract.** Its
-   synthetic tokenizer ignores state, so the published metadata says
-   `discrete_state=False` — truthful about that server, misleading as a preview.
-   It warns; use a checkpoint for a real contract check.
+7. **`--random-weights` previews the wire layer only.** Its synthetic tokenizer
+   ignores state, so the published metadata says `discrete_state=False`, and it
+   never runs `preset.builder`, so no robot pre/post step is wired and the action
+   width is the model's rather than the encode step's. Truthful about that server,
+   misleading as a preview — hence `robot_steps=false` in the metadata and a
+   startup warning per gap. Use a checkpoint for a real contract check.
 8. **Metadata is the contract; assert it from the client.** Every silent failure
    in this area is visible in the connect-time metadata one line before it
    becomes an "accuracy problem."

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -41,7 +41,7 @@ things and they never need to be equal.
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
 | **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
-| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `slots` | yes — this is what the client sends |
+| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `Convention` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
 A preset pairs each view slot with the wire key that fills it. `image_keys` is
@@ -268,28 +268,55 @@ width instead of advertising one nothing emits.
 One entry in `python/apxinf/apxinf/robots/presets.py`. This is the whole
 registration step — OpenPI's `training/config.py` equivalent.
 
+A preset is two halves, because the arm and the key convention vary
+independently. An `Embodiment` is the **body**: camera count, deployable action
+width, which pre/post steps its actions need. It survives a change of dataset. A
+`Convention` is a **dataset's recording dialect**: the wire keys and the state
+routing that follows from how the data was recorded. It survives a change of
+robot.
+
 ```python
+MY_ARM = Embodiment(
+    name="myarm",
+    num_cameras=2,
+    action_dim=7,               # None keeps full width when an encode step truncates
+    builder=build_my_robot_policy,   # omit for the stock policy
+    builder_kwargs={},          # constants the builder always receives
+)
+
+MY_DATASET_KEYS = Convention(
+    name="mydataset",
+    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
+    state_key="observation/state",
+    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
+)
+
 MY_ROBOT = RobotPreset(
     name="myarm_mydataset",
-    slots=(
-        ("base_0_rgb", "observation/image"),
-        ("left_wrist_0_rgb", "observation/wrist_image"),
-    ),
-    state_key="observation/state",
-    action_dim=7,               # None keeps full width when an encode step truncates
-    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
-    builder=build_my_robot_policy,   # omit for the stock policy
+    embodiment=MY_ARM,
+    convention=MY_DATASET_KEYS,
     summary="MyArm, MyDataset keys: 2 cameras, 7-dim action",
-    builder_kwargs={},          # constants the builder always receives
 )
 
 ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 ```
 
-`__post_init__` rejects a `slots` tuple that is not an in-order prefix of
-`VIEW_SLOTS`, and rejects duplicate wire keys. A checkpoint fills view slots from
-0 up, so there is no way to spell "wrist camera only" other than putting it in
-slot 0.
+Serving the same arm under a second dataset's keys is then one more `Convention`
+and one more pairing — no builder edit, no duplicated action width.
+
+Only the *pairing* is deployable, so `--robot` stays a single flag over
+`ROBOT_PRESETS` rather than becoming `--robot` + `--convention`. Separate flags
+would let an operator spell a combination nobody ever recorded, and a body served
+under a convention it was not recorded on is exactly the silent mismatch this
+mechanism exists to prevent.
+
+Validation runs when the module loads. `Convention.__post_init__` rejects
+duplicate wire keys and more keys than there are view slots;
+`Embodiment.__post_init__` rejects a camera count outside `1..len(VIEW_SLOTS)`;
+`RobotPreset.__post_init__` rejects a convention whose camera count disagrees
+with the body's. Slot names are *derived* from `image_keys` in order, so "base +
+right wrist" is not expressible at all — a checkpoint fills view slots from 0 up,
+and the only way to spell "wrist camera only" is to put it in slot 0.
 
 Add an entry to `ROBOT_ALIASES` if a deployment already says something else in
 its launch scripts; a rename should not break a running system.
@@ -303,6 +330,10 @@ a preset is named for the arm **and** the dataset convention whose keys it
 implements: `franka_libero`, not `libero` (a benchmark, not a robot) and not
 `franka` (ambiguous). A single-embodiment robot that owns its convention needs no
 suffix — `unitree_g1`.
+
+The `Embodiment`/`Convention` split is that naming rule made structural: the two
+halves of the name are the two halves of the preset, and `franka_droid` would
+reuse `FRANKA` rather than restating its width and builder.
 
 ### Step 5 — tests
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -294,6 +294,8 @@ MY_ARM = Embodiment(
     name="myarm",
     num_cameras=2,
     action_dim=7,               # None keeps full width when an encode step truncates
+    state_dim=8,                # how wide norm_stats["state"] has to be
+    action_width=7,             # how wide norm_stats["actions"] has to be
     builder=build_my_robot_policy,   # omit for the stock policy
     builder_kwargs={},          # constants the builder always receives
 )
@@ -331,6 +333,26 @@ duplicate wire keys and more keys than there are view slots;
 with the body's. Slot names are *derived* from `image_keys` in order, so "base +
 right wrist" is not expressible at all — a checkpoint fills view slots from 0 up,
 and the only way to spell "wrist camera only" is to put it in slot 0.
+
+**Fill in `state_dim` and `action_width`.** They are the only thing that lets
+the startup preflight (Step 6) tell your robot's `norm_stats.json` from some
+other robot's — leave them `None` and that check silently does nothing. They are
+two fields rather than one because a robot's state and action spaces need not
+match: LIBERO is 8-dim state / 7-dim EEF-delta action. `action_width` exists
+separately from `action_dim` because the two answer different questions —
+`action_dim` is a *loading* knob ("trim the model down to this"), `action_width`
+is a fact about the body ("this is how many columns its actions have"). A preset
+whose encode step owns the 32→N truncation sets `action_dim=None`, and `None` is
+not a width: G1 declares `action_dim=None, action_width=16`.
+
+**Set `norm_dtype="float64"` in `builder_kwargs` if the checkpoint came from
+openpi.** openpi parses `norm_stats.json` into float64 and never demotes it, so
+its whole chain runs in float64 whatever dtype the robot sends. Ours follows the
+input. The difference is ~1e-7 and invisible on the output side, but a robot that
+discretizes state into its prompt compares the normalized value against bin edges
+1/128 apart, and an element near an edge crosses it — different prompt, different
+tokens, different rollout. It is a per-body flag rather than a global default so
+that presets nobody has re-benchmarked keep their existing numbers exactly.
 
 Add an entry to `ROBOT_ALIASES` if a deployment already says something else in
 its launch scripts; a rename should not break a running system.
@@ -372,6 +394,33 @@ run on CPU with a mock model — no GPU, no checkpoint:
 python3 tests/test_robot_presets.py          # no GPU needed
 ```
 
+### Step 6 — check the preflight refuses the wrong checkpoint
+
+A preset and a checkpoint directory are two independent claims about the same
+robot, and until the preflight existed nothing compared them. `--robot myarm`
+pointed at another robot's checkpoint loads, serves, and returns well-shaped
+actions in a plausible numeric range that mean nothing; the only symptom is that
+the model "got worse". Run it against your checkpoint before you serve it:
+
+```bash
+python3 scripts/openpi_metadata_to_apxinf.py --model-dir "$CKPT" --robot <preset>
+```
+
+It reads the checkpoint's `norm_stats.json` widths and tokenizer, and — when the
+checkpoint carries openpi's `metadata.pt` — cross-checks your preset field by
+field against openpi's own serialized `TrainConfig` (camera wire keys,
+`discrete_state_input`, `adapt_to_pi`, `use_delta_joint_actions`,
+`action_horizon`, `max_token_len`). Exit status is 1 on any fatal finding, so it
+can gate a deployment. The same directory checks run inside
+`pi05_openpi_websocket_server.py` **before** the weights load, and refuse to
+start; `--skip-preflight` overrides that, and exists only to reproduce a
+known-bad configuration deliberately.
+
+Add cases to `tests/test_preflight.py` if your robot has a width rule the generic
+checks miss. The check that matters most is the boring one: a *correct*
+checkpoint must produce zero fatal findings, or operators will learn to pass
+`--skip-preflight` by reflex.
+
 ## Verification recipe
 
 Offline first, then one GPU pass. In order, because each step localizes a
@@ -380,20 +429,24 @@ different class of bug:
 ```bash
 # 1. contract + plumbing, CPU only, mock model
 python3 tests/test_robot_presets.py
+python3 -m pytest tests/test_preflight.py
 
-# 2. real checkpoint, native contract
+# 2. does the checkpoint agree with the preset? (seconds; no weights loaded)
+python3 scripts/openpi_metadata_to_apxinf.py --model-dir "$CKPT" --robot <preset>
+
+# 3. real checkpoint, native contract
 python3 scripts/pi05_openpi_websocket_server.py \
   --model-dir "$CKPT" --robot <preset> --precision bf16 --port 8000
 #    -> read the "serving robot=..." line; assert every field
 
-# 3. real transport, unmodified openpi client
+# 4. real transport, unmodified openpi client
 #    -> assert actions.shape == (meta["action_horizon"], meta["action_dim"])
 #    -> assert np.isfinite(actions).all()
 
-# 4. wrong-dialect rejection: send another preset's keys; it must raise
+# 5. wrong-dialect rejection: send another preset's keys; it must raise
 ```
 
-Step 3's shape assertion should read the shape **off the metadata**, not off a
+Step 4's shape assertion should read the shape **off the metadata**, not off a
 constant. A hard-coded expected shape tests your memory of the checkpoint rather
 than the server.
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -204,36 +204,54 @@ returns `data` unchanged when there is no state, so state-off serving degrades t
 ### Step 3 — the adapter
 
 `python/apxinf/apxinf/robots/<robot>.py`. One factory that loads the checkpoint
-through the generic `Pi05Policy.from_pretrained` and then splices the robot steps
-into the default pipelines:
+through `AutoPolicy` — so `config.json` decides which model it is, not this file
+— and then wraps the robot steps *around* whatever chain that policy has:
 
 ```python
-def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **kwargs):
-    base = Pi05Policy.from_pretrained(
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy, Policy
+
+def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **load_kwargs):
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,      # keep full model width; the encode step truncates
         state_key=state_key,
-        **kwargs,
+        **load_kwargs,
     )
-    input_pipeline = base.input_pipeline.insert_before(
-        "tokenize", ("<robot>_decode_state", <Robot>DecodeState(state_key))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(f"{type(base).__name__} has no with_adapter(); ...")
+    return base.with_adapter(
+        before=[("<robot>_decode_state", <Robot>DecodeState(state_key))],
+        after=[("<robot>_absolute", <Robot>AbsoluteActions(state_key)),
+               ("<robot>_encode",   <Robot>EncodeActions())],
+        action_dim=ROBOT_DIM,             # the width the encode step leaves behind
+        metadata={"robot": "<robot>"},
     )
-    output_pipeline = Pipeline([
-        ("unnormalize", base.output_pipeline["unnormalize"]),
-        ("<robot>_absolute", <Robot>AbsoluteActions(state_key)),
-        ("<robot>_encode", <Robot>EncodeActions()),
-    ])
-    return Pi05Policy(base.model, input_pipeline=..., output_pipeline=..., ...)
 ```
+
+The adapter names **no model class and no step inside the model's chain**. That
+is deliberate: a robot's requirement is an *ordering* — its steps run outside the
+model's, in both directions — not a claim about what those steps are called.
+`Pipeline.prepend`/`append` are the only editing verbs that express ordering
+without a name, and `with_adapter`
+([`ComposablePolicy`](../python/apxinf/apxinf/policies/base.py)) is how a policy
+exposes them. Reaching for `insert_before("tokenize", ...)` instead would make
+your robot depend on one model's private vocabulary, and on that model class by
+import.
 
 Two orderings matter and are easy to get wrong:
 
-* the decode-state step goes **before** `tokenize`, so discretized state (when
-  on) and the delta→absolute output step both see the decoded state;
+* the decode-state step goes **before** the model's whole input chain, so
+  discretized state (when on) and the delta→absolute output step both see the
+  decoded state;
 * unnormalize runs at **full model width**, before any truncation, so
-  delta→absolute sees the whole action. Pass `action_dim=None` into
-  `from_pretrained` and let the encode step truncate.
+  delta→absolute sees the whole action. Pass `action_dim=None` into the loader
+  and let the encode step truncate.
+
+Declare `action_dim=` only for the width a step you appended actually produces.
+Without the truncating step there is nothing to claim — inherit the model's own
+width instead of advertising one nothing emits.
 
 ### Step 4 — register the preset
 

--- a/doc/adding-an-embodiment.md
+++ b/doc/adding-an-embodiment.md
@@ -41,7 +41,7 @@ things and they never need to be equal.
 | | what it is | where it lives | on the wire? |
 |---|---|---|---|
 | **view slots** | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb` | `VIEW_SLOTS` in `policies/base.py` | never — the *order* is baked into the weights |
-| **wire keys** | `observation/image`, `images/cam_high`, … | a preset's `Convention` | yes — this is what the client sends |
+| **wire keys** | `observation/image`, `images/cam_high`, … | a `Convention` in `conventions.py` | yes — this is what the client sends |
 | **training feature names** | LeRobot `config.json` `input_features` | the checkpoint | no |
 
 A preset pairs each view slot with the wire key that fills it. `image_keys` is
@@ -221,7 +221,10 @@ through `AutoPolicy` — so `config.json` decides which model it is, not this fi
 from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy, Policy
 
-def build_<robot>_policy(model_dir, *, state_key=..., image_keys=..., **load_kwargs):
+# state_key / image_keys are required and have no defaults — they belong to the
+# dataset (Step 4), not to this body. A default here would mean the same arm,
+# re-recorded under new keys, silently keeps serving the old ones.
+def build_<robot>_policy(model_dir, *, state_key, image_keys, **load_kwargs):
     base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
@@ -265,7 +268,8 @@ width instead of advertising one nothing emits.
 
 ### Step 4 — register the preset
 
-One entry in `python/apxinf/apxinf/robots/presets.py`. This is the whole
+Two entries: a `Convention` in `python/apxinf/apxinf/conventions.py` and a body +
+pairing in `python/apxinf/apxinf/robots/presets.py`. That is the whole
 registration step — OpenPI's `training/config.py` equivalent.
 
 A preset is two halves, because the arm and the key convention vary
@@ -273,9 +277,19 @@ independently. An `Embodiment` is the **body**: camera count, deployable action
 width, which pre/post steps its actions need. It survives a change of dataset. A
 `Convention` is a **dataset's recording dialect**: the wire keys and the state
 routing that follows from how the data was recorded. It survives a change of
-robot.
+robot, which is why it lives in its own module and not under `robots/` — a
+dialect that lived in one robot's file could only ever be that robot's.
 
 ```python
+# apxinf/conventions.py — the dialect, independent of any arm
+MY_DATASET_KEYS = Convention(
+    name="mydataset",
+    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
+    state_key="observation/state",
+    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
+)
+
+# apxinf/robots/presets.py — the body, and the pairing
 MY_ARM = Embodiment(
     name="myarm",
     num_cameras=2,
@@ -284,17 +298,10 @@ MY_ARM = Embodiment(
     builder_kwargs={},          # constants the builder always receives
 )
 
-MY_DATASET_KEYS = Convention(
-    name="mydataset",
-    image_keys=("observation/image", "observation/wrist_image"),  # in view-slot order
-    state_key="observation/state",
-    discrete_state=False,       # False *drops* state entirely — not "keeps it raw"
-)
-
 MY_ROBOT = RobotPreset(
     name="myarm_mydataset",
     embodiment=MY_ARM,
-    convention=MY_DATASET_KEYS,
+    convention=conventions.MY_DATASET_KEYS,
     summary="MyArm, MyDataset keys: 2 cameras, 7-dim action",
 )
 
@@ -303,6 +310,13 @@ ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 
 Serving the same arm under a second dataset's keys is then one more `Convention`
 and one more pairing — no builder edit, no duplicated action width.
+
+If your robot lives in **your own package**, do not patch either file. Call
+`register_convention(...)` and `register_robot_preset(..., aliases=(...))` at
+your module scope; importing that module before the server starts is enough to
+make it `--robot <name>`. Re-registering an existing name needs an explicit
+`replace=True`, and an alias may never shadow a canonical preset name — a silent
+overwrite would change what a launch command already in production resolves to.
 
 Only the *pairing* is deployable, so `--robot` stays a single flag over
 `ROBOT_PRESETS` rather than becoming `--robot` + `--convention`. Separate flags
@@ -397,7 +411,10 @@ the encode step.
 1. **`discrete_state=False` drops state; it does not pass it through raw.**
    There is no third state. A joint-space robot served with `discrete_state=False`
    loses its proprioception silently, which also makes any delta→absolute step a
-   no-op (a delta cannot be resolved without current joint positions).
+   no-op (a delta cannot be resolved without current joint positions). This is
+   also why `state_key` is **required whenever it is read**: a wrong camera key
+   raises on the first inference, but a missing state key is silent, so the
+   policy refuses to be built with `discrete_state=True` and no key.
 2. **`image_keys` order is the view slot order.** Wrong order → right shape,
    wrong cameras, no error. This is why presets pair keys with slot names.
 3. **Truncate after unnormalize, not before.** Unnormalize at full model width so
@@ -429,6 +446,7 @@ the encode step.
    omission should fail at startup.
 2. **Robot steps are model-agnostic; adapters are where they meet a policy.**
    `processors/robots/` imports no policy symbols; `robots/` does the assembly.
+   Neither holds a wire key: those are a dataset's, and live in `conventions.py`.
 3. **Fail loudly with the served contract in the message.** Every error in this
    layer names what the server is actually serving, because the person reading it
    is comparing two dialects.
@@ -443,6 +461,7 @@ The Unitree G1 port is the reference implementation — it exercises every step,
 including the ones `franka_libero` skips:
 
 - `python/apxinf/apxinf/robots/presets.py` — the registry and both presets
+- `python/apxinf/apxinf/conventions.py` — the LIBERO and G1 wire dialects
 - `python/apxinf/apxinf/processors/robots/unitree_g1.py` — decode-state,
   delta→absolute, 32→16 encode
 - `python/apxinf/apxinf/robots/unitree_g1.py` — the adapter that splices them in

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -16,9 +16,11 @@ Three layers, kept deliberately decoupled:
   policy by ``config.json`` model type; :class:`~apxinf.policies.base.Policy` is
   the structural contract they all satisfy.
 * **robots** — the assembly layer (:mod:`apxinf.robots`). A ``build_*`` factory
-  binds one robot to a model policy by wiring its
-  :mod:`apxinf.processors.robots` steps into the policy pipelines. Depends
-  downward on both ``policies`` and ``processors``; neither depends back.
+  binds one robot to a model policy by wrapping its
+  :mod:`apxinf.processors.robots` steps *around* the policy's own chain, through
+  :class:`~apxinf.policies.base.ComposablePolicy`. It names no model class, so the
+  dependency is on a capability rather than on ``Pi05Policy``; ``policies`` and
+  ``processors`` never depend back.
 * **bindings** — :class:`Model` re-exports the ``apxinf_py`` PyO3 handle (L1
   bare-model inference; an internal L0 patches path exists but is private). It is
   the single public surface; you never import ``apxinf_py`` directly.
@@ -34,7 +36,7 @@ policy's ``from_pretrained`` pull in the ``apxinf_py`` binding.
 from __future__ import annotations
 
 from . import processors
-from .policies import AutoPolicy, Pi05Policy, Policy
+from .policies import AutoPolicy, ComposablePolicy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
     RobotPreset,
@@ -58,6 +60,7 @@ __all__ = [
     "processors",
     # policy contract (outward); BareModel (inward) lives in apxinf.policies
     "Policy",
+    "ComposablePolicy",
     # L2 policies
     "Pi05Policy",
     "AutoPolicy",

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -15,12 +15,18 @@ Three layers, kept deliberately decoupled:
   :class:`~apxinf.policies.auto.AutoPolicy` dispatches a checkpoint to its concrete
   policy by ``config.json`` model type; :class:`~apxinf.policies.base.Policy` is
   the structural contract they all satisfy.
+* :mod:`apxinf.conventions` — dataset **recording dialects**: the camera and
+  state wire keys a client sends, and whether state was recorded into the prompt.
+  A dialect is a property of the data, not of the arm or the weights, so it
+  depends on neither and both can change under it.
 * **robots** — the assembly layer (:mod:`apxinf.robots`). A ``build_*`` factory
   binds one robot to a model policy by wrapping its
   :mod:`apxinf.processors.robots` steps *around* the policy's own chain, through
   :class:`~apxinf.policies.base.ComposablePolicy`. It names no model class, so the
-  dependency is on a capability rather than on ``Pi05Policy``; ``policies`` and
-  ``processors`` never depend back.
+  dependency is on a capability rather than on ``Pi05Policy``; ``policies``,
+  ``processors`` and ``conventions`` never depend back. A
+  :class:`~apxinf.robots.presets.RobotPreset` pairs one body with one convention
+  and is the only deployable unit.
 * **bindings** — :class:`Model` re-exports the ``apxinf_py`` PyO3 handle (L1
   bare-model inference; an internal L0 patches path exists but is private). It is
   the single public surface; you never import ``apxinf_py`` directly.
@@ -35,15 +41,23 @@ policy's ``from_pretrained`` pull in the ``apxinf_py`` binding.
 
 from __future__ import annotations
 
-from . import processors
+from . import conventions, processors
+from .conventions import (
+    Convention,
+    available_conventions,
+    get_convention,
+    register_convention,
+)
 from .policies import AutoPolicy, ComposablePolicy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     build_unitree_g1_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from .processors import (
     GaussianNoise,
@@ -58,6 +72,7 @@ from .processors import (
 
 __all__ = [
     "processors",
+    "conventions",
     # policy contract (outward); BareModel (inward) lives in apxinf.policies
     "Policy",
     "ComposablePolicy",
@@ -66,11 +81,18 @@ __all__ = [
     "AutoPolicy",
     # robot adapters
     "build_unitree_g1_policy",
-    # robot presets (embodiment -> wire keys + pipelines), openpi's TrainConfig analogue
+    # dataset dialects (wire keys + state routing), independent of any body
+    "Convention",
+    "available_conventions",
+    "get_convention",
+    "register_convention",
+    # robot presets (body x convention -> wire contract), openpi's TrainConfig analogue
+    "Embodiment",
     "RobotPreset",
     "ROBOT_PRESETS",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
     # bindings (lazy)
     "Model",

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -48,7 +48,7 @@ from .conventions import (
     get_convention,
     register_convention,
 )
-from .policies import AutoPolicy, ComposablePolicy, Pi05Policy, Policy
+from .policies import AutoPolicy, ComposablePolicy, GrootN17Policy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
     Embodiment,
@@ -78,6 +78,7 @@ __all__ = [
     "ComposablePolicy",
     # L2 policies
     "Pi05Policy",
+    "GrootN17Policy",
     "AutoPolicy",
     # robot adapters
     "build_unitree_g1_policy",

--- a/python/apxinf/apxinf/checkpoints/__init__.py
+++ b/python/apxinf/apxinf/checkpoints/__init__.py
@@ -1,0 +1,53 @@
+"""Checkpoint-directory layout: which format, and where is each file.
+
+One place that answers "what shape is this checkpoint" for all three callers who
+need to know — the policy loader, the preflight checks, and the offline auditor —
+so a directory convention is written down once rather than guessed three times.
+
+    from apxinf.checkpoints import detect_checkpoint, require_norm_stats
+
+    layout = detect_checkpoint("~/airs/airs-model")
+    stats = require_norm_stats(layout)      # raises, naming every path tried
+    config_json = layout.config_json_text() # -> apxinf_py.Model.load(config_json=...)
+
+Run ``python -m apxinf.checkpoints <dir>`` to see the same answer as a report.
+Nothing here loads weights, imports torch, or touches the network.
+"""
+
+from __future__ import annotations
+
+from .layout import (
+    FORMATS,
+    LEROBOT,
+    NORM_STATS_NAME,
+    OPENPI_PYTORCH,
+    TOKENIZER_NAMES,
+    CheckpointError,
+    CheckpointLayout,
+    detect_checkpoint,
+    require_norm_stats,
+    resolve_tokenizer,
+)
+from .metadata import (
+    MetadataError,
+    read_metadata_pt,
+    repack_structure,
+    train_config_facts,
+)
+
+__all__ = [
+    "CheckpointError",
+    "CheckpointLayout",
+    "FORMATS",
+    "LEROBOT",
+    "MetadataError",
+    "NORM_STATS_NAME",
+    "OPENPI_PYTORCH",
+    "TOKENIZER_NAMES",
+    "detect_checkpoint",
+    "read_metadata_pt",
+    "repack_structure",
+    "require_norm_stats",
+    "resolve_tokenizer",
+    "train_config_facts",
+]

--- a/python/apxinf/apxinf/checkpoints/__init__.py
+++ b/python/apxinf/apxinf/checkpoints/__init__.py
@@ -6,7 +6,7 @@ so a directory convention is written down once rather than guessed three times.
 
     from apxinf.checkpoints import detect_checkpoint, require_norm_stats
 
-    layout = detect_checkpoint("~/airs/airs-model")
+    layout = detect_checkpoint(model_dir)
     stats = require_norm_stats(layout)      # raises, naming every path tried
     config_json = layout.config_json_text() # -> apxinf_py.Model.load(config_json=...)
 
@@ -25,6 +25,7 @@ from .layout import (
     CheckpointError,
     CheckpointLayout,
     detect_checkpoint,
+    has_layout_metadata,
     require_norm_stats,
     resolve_tokenizer,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "OPENPI_PYTORCH",
     "TOKENIZER_NAMES",
     "detect_checkpoint",
+    "has_layout_metadata",
     "read_metadata_pt",
     "repack_structure",
     "require_norm_stats",

--- a/python/apxinf/apxinf/checkpoints/__main__.py
+++ b/python/apxinf/apxinf/checkpoints/__main__.py
@@ -1,0 +1,7 @@
+"""``python -m apxinf.checkpoints <dir>`` — the standalone checkpoint inspector."""
+
+from __future__ import annotations
+
+from .layout import _main
+
+raise SystemExit(_main())

--- a/python/apxinf/apxinf/checkpoints/layout.py
+++ b/python/apxinf/apxinf/checkpoints/layout.py
@@ -53,6 +53,7 @@ __all__ = [
     "OPENPI_PYTORCH",
     "TOKENIZER_NAMES",
     "detect_checkpoint",
+    "has_layout_metadata",
     "require_norm_stats",
     "resolve_tokenizer",
 ]
@@ -190,7 +191,7 @@ def _resolve_norm_stats(
         parts = _asset_parts(asset_id)
         # openpi's official convention, written by train_pytorch.py.
         candidates.append(root.joinpath("assets", *parts, NORM_STATS_NAME))
-        # Some forks (RLinf) also drop a copy without the assets/ prefix.
+        # Some exporters also drop a copy without the assets/ prefix.
         candidates.append(root.joinpath(*parts, NORM_STATS_NAME))
     flat = root / NORM_STATS_NAME
     tried = (*candidates, flat)
@@ -207,6 +208,20 @@ def _resolve_norm_stats(
     if flat.is_file():
         return flat, tried, bool(candidates), tuple(notes)
     return None, tried, False, tuple(notes)
+
+
+def has_layout_metadata(model_dir) -> bool:
+    """True when the directory declares its own layout (``metadata.pt``/``config.json``).
+
+    Callers that must keep serving the hand-assembled flat directories that
+    predate this module — ``model.safetensors`` + ``norm_stats.json`` and nothing
+    that says what the checkpoint is — use this to decide whether
+    :func:`detect_checkpoint` has anything to work with. Detection itself refuses
+    to guess, which is right for a real checkpoint and wrong as a hard regression
+    for a directory that used to load.
+    """
+    root = Path(model_dir)
+    return (root / METADATA_NAME).is_file() or (root / CONFIG_NAME).is_file()
 
 
 def detect_checkpoint(
@@ -275,7 +290,7 @@ def detect_checkpoint(
             raise CheckpointError(f"{metadata_pt}: {exc}") from exc
         arch = dict(facts["arch"])
         if has_config:
-            # The customer's directory is exactly this: a hand-added config.json
+            # A shipped directory can be exactly this: a hand-added config.json
             # from a *different* training run sitting next to the real metadata.
             notes.append(
                 f"{config_json} is ignored — for an openpi export metadata.pt is the "

--- a/python/apxinf/apxinf/checkpoints/layout.py
+++ b/python/apxinf/apxinf/checkpoints/layout.py
@@ -1,0 +1,460 @@
+"""What shape is this checkpoint directory, and where is each file?
+
+Five directory layouts turn up in the field and only two of them matter here:
+
+``openpi_pytorch``
+    What ``scripts/train_pytorch.py`` writes and what ships to a customer:
+    ``model.safetensors`` + ``metadata.pt`` (+ ``optimizer.pt``) with the
+    statistics under ``assets/<asset_id>/norm_stats.json``. **There is no
+    config.json**, so every architecture constant has to come out of
+    ``metadata.pt``.
+
+``lerobot``
+    A HuggingFace robot-policy directory: ``config.json`` with ``"type": "pi05"``
+    plus ``model.safetensors``. LeRobot keeps normalization statistics inside
+    ``policy_preprocessor_step_<N>_normalizer_processor.safetensors`` rather than
+    a JSON file (and the official pi05 repo deleted even that), so a servable
+    LeRobot checkpoint needs a ``norm_stats.json`` supplied alongside it.
+
+The tensor names are **identical** between the two — 812 of them, exact set
+equality — so nothing about weight loading changes. Only the sidecar metadata
+differs, which is the entire job of this module.
+
+Why this is its own layer rather than a few lines in ``Pi05Policy.from_pretrained``:
+three callers need the same answer and only one of them may import the CUDA
+binding. :mod:`apxinf.robots.preflight` runs *before* anything heavy loads, and
+``scripts/openpi_metadata_to_apxinf.py`` runs on a laptop. Previously each of
+them hard-coded its own guess at the layout — ``norm_stats.json`` alone was
+spelled out in three places and ``metadata.pt`` was read in none of the serving
+ones.
+
+The failure this exists to prevent: a checkpoint directory that contains a
+*syntactically valid but semantically wrong* ``norm_stats.json`` loads without a
+single error and unnormalizes every action through the wrong physical range. So
+the resolver names every path it tried, logs the one it settled on, and refuses
+to guess when nothing matches.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from .metadata import MetadataError, read_metadata_pt, train_config_facts
+
+__all__ = [
+    "CheckpointError",
+    "CheckpointLayout",
+    "LEROBOT",
+    "NORM_STATS_NAME",
+    "OPENPI_PYTORCH",
+    "TOKENIZER_NAMES",
+    "detect_checkpoint",
+    "require_norm_stats",
+    "resolve_tokenizer",
+]
+
+LOGGER = logging.getLogger("apxinf.checkpoints")
+
+#: openpi's PyTorch training export. Authority: ``metadata.pt``.
+OPENPI_PYTORCH = "openpi_pytorch"
+#: A LeRobot / HuggingFace robot-policy directory. Authority: ``config.json``.
+LEROBOT = "lerobot"
+#: Accepted values of ``checkpoint_format=`` / ``--ckpt-format``.
+FORMATS = ("auto", OPENPI_PYTORCH, LEROBOT)
+
+NORM_STATS_NAME = "norm_stats.json"
+WEIGHTS_NAME = "model.safetensors"
+METADATA_NAME = "metadata.pt"
+CONFIG_NAME = "config.json"
+
+#: SentencePiece filenames a checkpoint may carry, in preference order. apxinf
+#: never downloads one: openpi pulls it from ``gs://big_vision`` and LeRobot from
+#: a gated HF repo, and a serving box is not assumed to reach either.
+TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
+
+_TOKENIZER_HELP = (
+    "The tokenizer is not distributed with any pi05 checkpoint — the same ~4 MB "
+    "SentencePiece model serves the whole PaliGemma family, so openpi downloads it "
+    "from gs://big_vision/paligemma_tokenizer.model at runtime and LeRobot pulls "
+    "google/paligemma-3b-pt-224 from the HF Hub (a gated repo: 401 without an "
+    "accepted licence). apxinf never downloads anything, so the file has to be put "
+    "in place once, by hand."
+)
+
+
+class CheckpointError(RuntimeError):
+    """The checkpoint directory is not a layout apxinf can serve, as-is."""
+
+
+@dataclass(frozen=True)
+class CheckpointLayout:
+    """Every path and constant resolved from one checkpoint directory."""
+
+    #: :data:`OPENPI_PYTORCH` or :data:`LEROBOT`.
+    format: str
+    root: Path
+    weights: Optional[Path]
+    config_json: Optional[Path]
+    metadata_pt: Optional[Path]
+    #: openpi's ``data.assets.asset_id or data.repo_id``; ``None`` for LeRobot.
+    asset_id: Optional[str] = None
+    asset_id_source: str = ""
+    #: The statistics file, or ``None`` when nothing matched — see
+    #: :func:`require_norm_stats` for the error a caller should raise.
+    norm_stats: Optional[Path] = None
+    #: Every candidate considered, in order, whether or not it existed.
+    norm_stats_tried: Tuple[Path, ...] = ()
+    #: True when the asset-path candidates all missed and the root file was used.
+    norm_stats_is_fallback: bool = False
+    #: ``Pi05Config::from_json_str``-shaped architecture overrides. Empty for
+    #: LeRobot, where the Rust loader reads ``config.json`` itself.
+    arch: Mapping[str, Any] = field(default_factory=dict)
+    #: Deployment facts from ``metadata.pt`` (cameras, delta convention, ...).
+    openpi: Mapping[str, Any] = field(default_factory=dict)
+    #: Human-readable observations worth surfacing but not worth failing on.
+    notes: Tuple[str, ...] = ()
+
+    def config_json_text(self) -> Optional[str]:
+        """The ``config_json=`` string to hand ``apxinf_py.Model.load``.
+
+        ``None`` means "let the Rust loader read ``config.json`` as before",
+        which is exactly right for a LeRobot directory.
+        """
+        return json.dumps(dict(self.arch), sort_keys=True) if self.arch else None
+
+    def describe(self) -> str:
+        """A multi-line report for a log line or the standalone inspector."""
+        lines = [
+            f"format:       {self.format}",
+            f"root:         {self.root}",
+            f"weights:      {self.weights if self.weights else '(missing)'}",
+        ]
+        if self.metadata_pt:
+            lines.append(f"metadata.pt:  {self.metadata_pt}")
+        if self.config_json:
+            lines.append(f"config.json:  {self.config_json}")
+        if self.asset_id:
+            lines.append(f"asset_id:     {self.asset_id!r} (from {self.asset_id_source})")
+        stats = self.norm_stats or "(none found)"
+        suffix = "  [ROOT FALLBACK]" if self.norm_stats_is_fallback else ""
+        lines.append(f"norm_stats:   {stats}{suffix}")
+        if len(self.norm_stats_tried) > 1:
+            for candidate in self.norm_stats_tried:
+                mark = "*" if candidate == self.norm_stats else ("+" if candidate.is_file() else "-")
+                lines.append(f"                {mark} {candidate}")
+        if self.arch:
+            rendered = ", ".join(f"{k}={v}" for k, v in sorted(self.arch.items()))
+            lines.append(f"architecture: {rendered}")
+        for key in ("exp_name", "global_step", "image_keys", "state_key",
+                    "adapt_to_pi", "use_delta_joint_actions", "default_prompt"):
+            value = self.openpi.get(key)
+            if value not in (None, (), ""):
+                lines.append(f"{(key + ':').ljust(13)} {value!r}")
+        for note in self.notes:
+            lines.append(f"note:         {note}")
+        return "\n".join(lines)
+
+
+def _asset_parts(asset_id: str) -> Tuple[str, ...]:
+    """Split an ``asset_id`` into path components, refusing traversal.
+
+    openpi's asset ids are often ``org/dataset``, which becomes nested
+    directories on disk. They come from a checkpoint we did not write, so a
+    ``..`` component would read outside the checkpoint directory.
+    """
+    parts = tuple(p for p in asset_id.split("/") if p)
+    if not parts or any(p in (".", "..") for p in parts):
+        raise CheckpointError(
+            f"asset_id {asset_id!r} is not a usable relative path; pass "
+            f"--norm-stats explicitly"
+        )
+    return parts
+
+
+def _resolve_norm_stats(
+    root: Path, asset_id: Optional[str], explicit
+) -> Tuple[Optional[Path], Tuple[Path, ...], bool, Tuple[str, ...]]:
+    """Find the statistics file. Returns ``(path, tried, is_fallback, notes)``."""
+    if explicit is not None:
+        path = Path(explicit)
+        if not path.is_file():
+            raise CheckpointError(f"norm_stats path {path} does not exist")
+        return path, (path,), False, ()
+
+    candidates = []
+    if asset_id:
+        parts = _asset_parts(asset_id)
+        # openpi's official convention, written by train_pytorch.py.
+        candidates.append(root.joinpath("assets", *parts, NORM_STATS_NAME))
+        # Some forks (RLinf) also drop a copy without the assets/ prefix.
+        candidates.append(root.joinpath(*parts, NORM_STATS_NAME))
+    flat = root / NORM_STATS_NAME
+    tried = (*candidates, flat)
+
+    notes = []
+    for candidate in candidates:
+        if candidate.is_file():
+            if flat.is_file():
+                notes.append(
+                    f"{flat} exists but is ignored; the asset path {candidate} wins"
+                )
+            return candidate, tried, False, tuple(notes)
+
+    if flat.is_file():
+        return flat, tried, bool(candidates), tuple(notes)
+    return None, tried, False, tuple(notes)
+
+
+def detect_checkpoint(
+    model_dir,
+    *,
+    checkpoint_format: Optional[str] = None,
+    asset_id: Optional[str] = None,
+    norm_stats=None,
+) -> CheckpointLayout:
+    """Identify ``model_dir``'s layout and resolve every file it implies.
+
+    ``checkpoint_format`` pins the answer instead of sniffing it (``"auto"`` and
+    ``None`` both sniff). ``asset_id`` overrides what ``metadata.pt`` says, for a
+    checkpoint whose assets were reorganized after export. ``norm_stats`` is an
+    explicit path that outranks every convention.
+
+    Raises :class:`CheckpointError` when the directory matches neither layout, or
+    when a pinned format's authoritative file is absent. A **missing
+    norm_stats.json is not raised here** — the layout records what was tried and
+    :func:`require_norm_stats` turns it into an error, so preflight can report it
+    alongside its other findings instead of one crash at a time.
+    """
+    root = Path(model_dir)
+    if not root.is_dir():
+        raise CheckpointError(f"checkpoint directory {root} does not exist")
+
+    metadata_pt = root / METADATA_NAME
+    config_json = root / CONFIG_NAME
+    has_metadata, has_config = metadata_pt.is_file(), config_json.is_file()
+
+    resolved = (checkpoint_format or "auto").lower()
+    if resolved not in FORMATS:
+        raise CheckpointError(
+            f"unknown checkpoint format {checkpoint_format!r}; expected one of {list(FORMATS)}"
+        )
+    if resolved == "auto":
+        if has_metadata:
+            resolved = OPENPI_PYTORCH
+        elif has_config:
+            resolved = LEROBOT
+        else:
+            present = sorted(p.name for p in root.iterdir())[:12]
+            raise CheckpointError(
+                f"{root} matches neither checkpoint layout apxinf can load:\n"
+                f"  {OPENPI_PYTORCH}: needs {METADATA_NAME} "
+                f"(+ assets/<asset_id>/{NORM_STATS_NAME})\n"
+                f"  {LEROBOT}: needs {CONFIG_NAME} (+ {NORM_STATS_NAME})\n"
+                f"the directory holds: {present}"
+            )
+
+    notes = []
+    arch: Dict[str, Any] = {}
+    facts: Dict[str, Any] = {}
+
+    if resolved == OPENPI_PYTORCH:
+        if not has_metadata:
+            raise CheckpointError(
+                f"checkpoint_format={OPENPI_PYTORCH!r} but {metadata_pt} does not "
+                f"exist; an openpi PyTorch export always carries it (see openpi "
+                f"scripts/train_pytorch.py). Pass checkpoint_format='{LEROBOT}' if "
+                f"this is a LeRobot directory."
+            )
+        try:
+            facts = train_config_facts(read_metadata_pt(metadata_pt))
+        except MetadataError as exc:
+            raise CheckpointError(f"{metadata_pt}: {exc}") from exc
+        arch = dict(facts["arch"])
+        if has_config:
+            # The customer's directory is exactly this: a hand-added config.json
+            # from a *different* training run sitting next to the real metadata.
+            notes.append(
+                f"{config_json} is ignored — for an openpi export metadata.pt is the "
+                f"authority for the architecture"
+            )
+    else:
+        if not has_config:
+            raise CheckpointError(
+                f"checkpoint_format={LEROBOT!r} but {config_json} does not exist"
+            )
+        if has_metadata:
+            notes.append(
+                f"{metadata_pt} is present but ignored because checkpoint_format="
+                f"{LEROBOT!r} was requested"
+            )
+        # arch stays empty on purpose: the Rust loader reads config.json itself,
+        # which is the behaviour LeRobot checkpoints already had.
+
+    effective_asset_id = asset_id or facts.get("asset_id")
+    asset_id_source = (
+        "explicit override" if asset_id else facts.get("asset_id_source", "") or ""
+    )
+
+    stats, tried, is_fallback, stats_notes = _resolve_norm_stats(
+        root, effective_asset_id, norm_stats
+    )
+    notes.extend(stats_notes)
+
+    if is_fallback:
+        LOGGER.warning(
+            "norm_stats: %s (openpi's path for asset_id=%r, from %s) does not exist — "
+            "falling back to the checkpoint root %s. Verify those statistics belong to "
+            "this robot: a wrong-but-valid file unnormalizes silently.",
+            tried[0],
+            effective_asset_id,
+            asset_id_source or "unknown",
+            stats,
+        )
+    elif stats is not None:
+        LOGGER.info("norm_stats: using %s", stats)
+
+    weights = root / WEIGHTS_NAME
+    if not weights.is_file():
+        notes.append(f"{weights} not found; pass an explicit checkpoint= path")
+
+    return CheckpointLayout(
+        format=resolved,
+        root=root,
+        weights=weights if weights.is_file() else None,
+        config_json=config_json if has_config else None,
+        metadata_pt=metadata_pt if has_metadata else None,
+        asset_id=effective_asset_id,
+        asset_id_source=asset_id_source,
+        norm_stats=stats,
+        norm_stats_tried=tried,
+        norm_stats_is_fallback=is_fallback,
+        arch=arch,
+        openpi={k: v for k, v in facts.items() if k != "arch"},
+        notes=tuple(notes),
+    )
+
+
+def require_norm_stats(layout: CheckpointLayout) -> Path:
+    """The statistics path, or a :class:`CheckpointError` naming every candidate."""
+    if layout.norm_stats is not None:
+        return layout.norm_stats
+
+    tried = "\n".join(f"  {path}" for path in layout.norm_stats_tried)
+    if layout.format == OPENPI_PYTORCH:
+        asset = layout.asset_id or "<unknown>"
+        where = layout.openpi.get("assets_dir")
+        origin = f" (openpi computed them under {where}{asset}/ on the training machine)" if where else ""
+        hint = (
+            f"openpi writes this file to assets/<asset_id>/{NORM_STATS_NAME} when "
+            f"training finishes (scripts/train_pytorch.py). This checkpoint's asset_id "
+            f"is {asset!r}, from {layout.asset_id_source or 'metadata.pt'}{origin}. Ask "
+            f"whoever exported it for assets/{asset}/{NORM_STATS_NAME}, place it there, "
+            f"or point --norm-stats at it. Do not substitute another run's file: the "
+            f"statistics are what map the model's output into the robot's physical "
+            f"range, so a wrong one produces in-range, meaningless actions and no error."
+        )
+    else:
+        example = '{"actions": {"q01": [...], "q99": [...]}, "state": {...}}'
+        hint = (
+            f"LeRobot does not ship a {NORM_STATS_NAME}: it keeps the statistics inside "
+            f"policy_preprocessor_step_<N>_normalizer_processor.safetensors — and the "
+            f"official pi05 repo deleted even that on 2025-09-24 — or in the source "
+            f"dataset's meta/stats.json. apxinf parses neither. Convert them into "
+            f"{example} and put it in the checkpoint root, or pass --norm-stats."
+        )
+    raise CheckpointError(
+        f"no {NORM_STATS_NAME} for {layout.root}; tried:\n{tried}\n{hint}"
+    )
+
+
+def resolve_tokenizer(model_dir, tokenizer_path=None, *, env: Optional[Mapping[str, str]] = None) -> Path:
+    """Locate the SentencePiece model: explicit path, then env, then the directory.
+
+    ``APXINF_TOKENIZER`` exists so one hand-placed file can serve every
+    checkpoint on a box without copying it into each directory.
+    """
+    import os
+
+    environ = os.environ if env is None else env
+    if tokenizer_path is not None:
+        path = Path(tokenizer_path)
+        if not path.is_file():
+            raise CheckpointError(f"tokenizer {path} does not exist")
+        return path
+
+    from_env = environ.get("APXINF_TOKENIZER")
+    if from_env:
+        path = Path(from_env)
+        if not path.is_file():
+            raise CheckpointError(f"APXINF_TOKENIZER={from_env} does not exist")
+        return path
+
+    root = Path(model_dir)
+    candidates = [root / name for name in TOKENIZER_NAMES]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    rendered = "\n".join(f"  {path}" for path in candidates)
+    raise CheckpointError(
+        f"no SentencePiece tokenizer for {root}; tried:\n{rendered}\n{_TOKENIZER_HELP}\n"
+        f"Put the file at {root / TOKENIZER_NAMES[1]}, or set APXINF_TOKENIZER, or pass "
+        f"--tokenizer. Both servers in a comparison must use the *same* file or their "
+        f"token ids are not comparable."
+    )
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    """``python -m apxinf.checkpoints <dir>`` — inspect a checkpoint, load nothing."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m apxinf.checkpoints",
+        description=(
+            "Report how apxinf will read a checkpoint directory: which layout it is, "
+            "which norm_stats.json will actually be used, and what architecture the "
+            "loader will be given. Reads no weights and needs neither torch nor CUDA."
+        ),
+    )
+    parser.add_argument("model_dir", type=Path)
+    parser.add_argument("--ckpt-format", choices=FORMATS, default="auto")
+    parser.add_argument("--asset-id", default=None)
+    parser.add_argument("--norm-stats", type=Path, default=None)
+    parser.add_argument("--tokenizer", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    try:
+        layout = detect_checkpoint(
+            args.model_dir,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
+        )
+    except CheckpointError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    print(layout.describe())
+    print(f"config_json:  {layout.config_json_text() or '(read config.json in the loader)'}")
+
+    status = 0
+    for label, resolve in (
+        ("norm_stats", lambda: require_norm_stats(layout)),
+        ("tokenizer", lambda: resolve_tokenizer(args.model_dir, args.tokenizer)),
+    ):
+        try:
+            resolve()
+        except CheckpointError as exc:
+            print(f"\nFAIL [{label}]: {exc}")
+            status = 1
+    if status == 0:
+        print("\nOK: this checkpoint has everything apxinf needs to serve it.")
+    return status
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(_main())

--- a/python/apxinf/apxinf/checkpoints/metadata.py
+++ b/python/apxinf/apxinf/checkpoints/metadata.py
@@ -1,0 +1,299 @@
+"""Read an openpi PyTorch export's ``metadata.pt`` **without torch**.
+
+``scripts/train_pytorch.py`` in openpi ends a run with::
+
+    torch.save({"global_step": ..., "config": dataclasses.asdict(train_config),
+                "timestamp": ...}, checkpoint_dir / "metadata.pt")
+
+so the checkpoint carries its own serving contract: action width, chunk length,
+token budget, whether state is discretized, which cameras the client sends, and
+— the field that matters most here — the ``asset_id`` that says where the real
+``norm_stats.json`` lives. Nothing in apxinf's serving path read it, which is
+why an openpi export silently fell back to :func:`Pi05Config::default` for its
+architecture and to a flat ``norm_stats.json`` for its statistics.
+
+**Why not just call torch.load.** ``metadata.pt`` is a config object graph, not
+weights, so needing a 2 GB dependency to read 30 kB of nested dicts is
+backwards: the preflight checks are supposed to run *before* anything heavy, and
+``scripts/openpi_metadata_to_apxinf.py`` is supposed to run on a laptop.
+``torch.save``'s modern format is a plain zip whose ``<archive>/data.pkl``
+member is an ordinary pickle, so the standard library can read it — provided the
+unpickler refuses to import the openpi/flax/jax classes the stream names, which
+are not installed here and would be arbitrary code execution if they were.
+
+**Security.** :class:`_RestrictedUnpickler` never imports anything outside
+:data:`_ALLOWED`, which is a set of explicit ``(module, name)`` pairs. Allowing a
+whole module — ``builtins`` especially — would resolve ``builtins.eval`` and
+hand a hostile checkpoint the process. Everything else becomes an inert
+:class:`_Opaque` subclass that records what it was and drops what it held.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import pickle
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+__all__ = [
+    "MetadataError",
+    "read_metadata_pt",
+    "repack_structure",
+    "train_config_facts",
+]
+
+#: openpi's flow-matching step count when ``model.num_steps`` is absent, which
+#: is every upstream export (only forks serialize it). Matches the Rust
+#: ``Pi05Config::default``, so an absent field is left for the loader to fill.
+DEFAULT_NUM_FLOW_STEPS = 10
+#: pi05's trained view-slot count when the repack transform names no cameras.
+#: Also the Rust default, for the same reason.
+DEFAULT_NUM_VIEWS = 3
+
+
+class MetadataError(RuntimeError):
+    """``metadata.pt`` is absent, is not a torch archive, or is not openpi's."""
+
+
+# Classes the pickle stream is allowed to actually instantiate. Explicit pairs,
+# never whole modules: see the module docstring.
+_ALLOWED = frozenset(
+    {
+        ("collections", "OrderedDict"),
+        ("collections", "defaultdict"),
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("pathlib", "PosixPath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "WindowsPath"),
+        ("pathlib", "PureWindowsPath"),
+    }
+)
+
+
+class _Opaque:
+    """Inert stand-in for a class we refuse to import.
+
+    Must be a **class**, not a factory function: the ``NEWOBJ`` opcode calls
+    ``cls.__new__(cls, *args)`` and rejects a non-type. The reduce arguments are
+    kept because ``Enum`` pickles as ``EnumClass(value)`` — so an enum a caller
+    does care about is still readable through :func:`unwrap`.
+    """
+
+    _qualname = "?"
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._args = args
+        obj._state: Any = None
+        return obj
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D107 - see __new__
+        pass
+
+    def __setstate__(self, state: Any) -> None:
+        self._state = state
+        if isinstance(state, dict):
+            # Keep the recorded reduce args reachable even if the state shadows
+            # them, so unwrap() has something to fall back on.
+            self.__dict__.update({k: v for k, v in state.items() if k != "_args"})
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<opaque {self._qualname}>"
+
+
+_STUBS: Dict[Tuple[str, str], type] = {}
+
+
+def _stub(module: str, name: str) -> type:
+    key = (module, name)
+    cls = _STUBS.get(key)
+    if cls is None:
+        cls = type(
+            name, (_Opaque,), {"__module__": module, "_qualname": f"{module}.{name}"}
+        )
+        _STUBS[key] = cls
+    return cls
+
+
+def unwrap(value: Any) -> Any:
+    """Reduce an :class:`_Opaque` to its payload where that is unambiguous.
+
+    An ``Enum`` reduces to ``(cls, (value,))``, so a single positional argument
+    is the enum's value. Anything else stays as-is; callers treat it as absent.
+    """
+    if isinstance(value, _Opaque) and len(getattr(value, "_args", ())) == 1:
+        return value._args[0]
+    return value
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module: str, name: str):  # noqa: D102
+        if (module, name) in _ALLOWED:
+            return getattr(importlib.import_module(module), name)
+        return _stub(module, name)
+
+    def persistent_load(self, pid):  # noqa: D102
+        # Tensor storages resolve through the persistent-id table. metadata.pt
+        # holds a config graph rather than weights, so nothing we read ever
+        # dereferences one; returning None keeps the stream parseable.
+        return None
+
+
+def read_metadata_pt(path) -> Dict[str, Any]:
+    """Return the whole ``metadata.pt`` payload dict (``global_step``/``config``/…)."""
+    path = Path(path)
+    if not path.is_file():
+        raise MetadataError(f"{path} does not exist")
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = [
+                name
+                for name in archive.namelist()
+                if name == "data.pkl" or name.endswith("/data.pkl")
+            ]
+            if not members:
+                raise MetadataError(
+                    f"{path} is a zip but has no data.pkl member, so it is not a "
+                    f"torch archive; it holds {archive.namelist()[:10]}"
+                )
+            # Shortest name = the top-level record, not something nested.
+            raw = archive.read(min(members, key=len))
+    except zipfile.BadZipFile as exc:
+        raise MetadataError(
+            f"{path} is not a zip-format torch archive ({exc}). It was probably "
+            f"written with _use_new_zipfile_serialization=False, which this "
+            f"torch-free reader does not support; read it with torch instead."
+        ) from exc
+
+    payload = _RestrictedUnpickler(io.BytesIO(raw)).load()
+    if not isinstance(payload, Mapping):
+        raise MetadataError(
+            f"{path} unpickled to {type(payload).__name__}, expected a dict"
+        )
+    return dict(payload)
+
+
+def repack_structure(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
+
+    openpi's repack transform is written *inbound* — ``{wire_key: dataset_column}``
+    — so its keys are exactly what the client puts on the network, which is what
+    an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
+    """
+    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
+    for entry in inputs:
+        structure = entry.get("structure") if isinstance(entry, Mapping) else None
+        if isinstance(structure, Mapping):
+            return dict(structure)
+    return {}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    value = unwrap(value)
+    # bool is an int subclass; a flag is never a width.
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_text(value: Any) -> Optional[str]:
+    value = unwrap(value)
+    if value is None or isinstance(value, _Opaque):
+        return None
+    text = str(value)
+    return text or None
+
+
+def train_config_facts(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Split the serialized ``TrainConfig`` into architecture + deployment facts.
+
+    Returns ``{"arch": {...}, ...}`` where ``arch`` is already in the JSON shape
+    ``Pi05Config::from_json_str`` accepts (it takes openpi's field names as
+    aliases), and the remaining keys are what preflight and the preset diff need.
+    """
+    config = payload.get("config")
+    if not isinstance(config, Mapping):
+        raise MetadataError(
+            f"metadata.pt has no 'config' dict (keys: {sorted(payload)}); it was "
+            f"not written by openpi's train_pytorch.py"
+        )
+    model = config.get("model") if isinstance(config.get("model"), Mapping) else {}
+    data = config.get("data") if isinstance(config.get("data"), Mapping) else {}
+
+    # --- guards. These are architecture facts apxinf's pi05 runtime hard-codes,
+    #     so a checkpoint that disagrees cannot be served at all -- better to say
+    #     so here than to load 7.5 GB of weights into the wrong graph.
+    pi05 = unwrap(model.get("pi05"))
+    if pi05 is not None and not isinstance(pi05, _Opaque) and not pi05:
+        raise MetadataError(
+            "metadata.pt says pi05=False: this is a pi0 checkpoint, and apxinf's "
+            "pi05 path (discrete state in the prompt, quantile norm) cannot serve it"
+        )
+    for field, expected in (
+        ("paligemma_variant", "gemma_2b"),
+        ("action_expert_variant", "gemma_300m"),
+    ):
+        got = _as_text(model.get(field))
+        if got is not None and got != expected:
+            raise MetadataError(
+                f"metadata.pt says {field}={got!r}, but apxinf's pi05 runtime is "
+                f"built for {expected!r}; the weights would not match the graph"
+            )
+
+    # --- architecture, in Pi05Config::from_json_str's vocabulary. Only fields
+    #     the checkpoint actually states go in here: an absent one has to fall
+    #     through to the loader's own default rather than be asserted, or the
+    #     report would present a guess as a fact.
+    arch: Dict[str, Any] = {}
+    for field in ("action_dim", "action_horizon", "max_token_len"):
+        value = _as_int(model.get(field))
+        if value is not None:
+            arch[field] = value
+    # ``num_steps`` is the flow-matching Euler step count. Upstream openpi does
+    # not serialize it (it is DEFAULT_NUM_FLOW_STEPS by construction, which is
+    # also the loader's default); the RLinf fork does.
+    num_steps = _as_int(model.get("num_steps"))
+    if num_steps is not None:
+        arch["num_flow_steps"] = num_steps
+
+    structure = repack_structure(data)
+    images = structure.get("images")
+    image_keys = tuple(images) if isinstance(images, Mapping) else ()
+    if image_keys:
+        arch["num_views"] = len(image_keys)
+
+    discrete = unwrap(model.get("discrete_state_input"))
+    if isinstance(discrete, bool):
+        arch["discrete_state_input"] = discrete
+
+    # --- where the statistics live. openpi's own resolution order, verbatim:
+    #     `asset_id = data.assets.asset_id or data.repo_id` (openpi config.py).
+    assets = data.get("assets") if isinstance(data.get("assets"), Mapping) else {}
+    asset_id = _as_text(assets.get("asset_id"))
+    asset_id_source = "data.assets.asset_id"
+    if asset_id is None:
+        asset_id = _as_text(data.get("repo_id"))
+        asset_id_source = "data.repo_id"
+    if asset_id is None:
+        asset_id_source = ""
+
+    return {
+        "arch": arch,
+        "asset_id": asset_id,
+        "asset_id_source": asset_id_source,
+        # Where openpi computed them on the *training* machine. Useless as a
+        # path here, but it is the string to quote when asking for the file.
+        "assets_dir": _as_text(assets.get("assets_dir")),
+        "image_keys": image_keys,
+        "state_key": _as_text(structure.get("state")),
+        "adapt_to_pi": unwrap(data.get("adapt_to_pi")),
+        "use_delta_joint_actions": unwrap(data.get("use_delta_joint_actions")),
+        "discrete_state_input": discrete if isinstance(discrete, bool) else None,
+        "default_prompt": _as_text(data.get("default_prompt")),
+        "exp_name": _as_text(config.get("exp_name")) or _as_text(config.get("name")),
+        "global_step": _as_int(payload.get("global_step")),
+    }

--- a/python/apxinf/apxinf/checkpoints/metadata.py
+++ b/python/apxinf/apxinf/checkpoints/metadata.py
@@ -255,7 +255,7 @@ def train_config_facts(payload: Mapping[str, Any]) -> Dict[str, Any]:
             arch[field] = value
     # ``num_steps`` is the flow-matching Euler step count. Upstream openpi does
     # not serialize it (it is DEFAULT_NUM_FLOW_STEPS by construction, which is
-    # also the loader's default); the RLinf fork does.
+    # also the loader's default); some forks do.
     num_steps = _as_int(model.get("num_steps"))
     if num_steps is not None:
         arch["num_flow_steps"] = num_steps

--- a/python/apxinf/apxinf/conventions.py
+++ b/python/apxinf/apxinf/conventions.py
@@ -1,0 +1,160 @@
+"""Recording conventions: what a dataset's client calls things on the wire.
+
+The third axis of the robot / dataset / model split, and the one that had no
+home. A **convention** is a dialect: the camera wire keys in model view-slot
+order, the state key, the prompt key, and whether state was recorded into the
+prompt. It is a property of *how data was recorded*, not of the arm that
+recorded it and not of the weights that consume it.
+
+Keeping it here rather than in :mod:`apxinf.robots` is the point. LIBERO's keys
+describe a Franka today and would describe any arm recorded the same way; the
+same Franka under DROID's keys is a second convention, not a second body. A
+convention that lived in a robot's module could only ever be that robot's, and
+the G1's keys used to live in ``processors/robots/unitree_g1.py`` — a *dataset*
+fact defined inside a *body*'s processing steps, which is exactly the coupling
+this module removes.
+
+What a convention may depend on:
+
+* :data:`~apxinf.policies.base.VIEW_SLOTS` — model vocabulary, needed to say
+  which slot each camera key fills. That is a one-way read of a naming table; no
+  policy class is imported and no model is loaded.
+
+What it must not depend on: any robot body (an action width, a camera count, a
+builder) and any policy implementation. Nothing in this module imports either.
+
+A convention alone is not deployable — pairing it with an
+:class:`~apxinf.robots.presets.Embodiment` is, and
+:class:`~apxinf.robots.presets.RobotPreset` is where the two are validated
+against each other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .policies.base import VIEW_SLOTS
+
+__all__ = [
+    "Convention",
+    "LIBERO",
+    "UNITREE_G1",
+    "CONVENTIONS",
+    "available_conventions",
+    "get_convention",
+    "register_convention",
+]
+
+
+@dataclass(frozen=True)
+class Convention:
+    """A dataset's recording convention: what the client calls things.
+
+    Everything here is a string on the network, plus the one routing decision
+    that follows from how the data was recorded. It survives a change of robot.
+    Nothing here knows an action width or a camera count.
+    """
+
+    #: Convention name (a dataset, or an integrator's dialect).
+    name: str
+    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
+    image_keys: Tuple[str, ...]
+    #: Wire key of the proprioceptive state vector.
+    state_key: str
+    #: Wire key of the task instruction. ``prompt`` is openpi's protocol-level
+    #: name rather than any one dataset's, which is why it has a default here.
+    prompt_key: str = "prompt"
+    #: Whether state is discretized into the prompt. Off means state is *dropped*
+    #: — there is no third option where it is passed through raw.
+    discrete_state: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.image_keys:
+            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
+        if len(self.image_keys) > len(VIEW_SLOTS):
+            raise ValueError(
+                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
+                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
+            )
+        if len(set(self.image_keys)) != len(self.image_keys):
+            raise ValueError(
+                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
+            )
+
+    @property
+    def num_cameras(self) -> int:
+        """Cameras this convention names — cross-checked against a body's count."""
+        return len(self.image_keys)
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs — the pairing, for logs and review.
+
+        Derived rather than written by hand: a checkpoint fills view slots from 0
+        up, so "base + right wrist" is not a thing to spell wrong.
+        """
+        return tuple(zip(VIEW_SLOTS, self.image_keys))
+
+
+#: LIBERO (the 7-DoF sim benchmark), mirroring openpi's ``LiberoInputs``: flat
+#: ``observation/...`` keys. State is dropped, matching the numerics of the
+#: existing serving link.
+LIBERO = Convention(
+    name="libero",
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+    discrete_state=False,
+)
+
+#: The ``pi05_UnitreeG1`` fine-tune's dialect, from its
+#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``
+#: (spelled as a path for :func:`~apxinf.processors.transforms.lookup_key`), a
+#: flat top-level ``state`` rather than LIBERO's ``observation/state``, and state
+#: discretized into the prompt.
+UNITREE_G1 = Convention(
+    name="unitree_g1",
+    image_keys=("images/cam_high", "images/cam_left_wrist", "images/cam_right_wrist"),
+    state_key="state",
+    discrete_state=True,
+)
+
+#: Name -> convention. A registry rather than a module-level lookup so a
+#: third-party dialect can join it without editing this file
+#: (:func:`register_convention`).
+CONVENTIONS: Dict[str, Convention] = {c.name: c for c in (LIBERO, UNITREE_G1)}
+
+
+def available_conventions() -> Tuple[str, ...]:
+    """Registered convention names, for error messages and ``--help`` text."""
+    return tuple(CONVENTIONS)
+
+
+def get_convention(name: str) -> Convention:
+    """Look up a convention by name, with a listing in the error."""
+    try:
+        return CONVENTIONS[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown convention {name!r}; known: {list(available_conventions())}"
+        ) from None
+
+
+def register_convention(convention: Convention, *, replace: bool = False) -> Convention:
+    """Add ``convention`` to the registry and return it, for use at module scope.
+
+    Lets a deployment that speaks its own dialect register it from its own
+    package instead of patching this file. Re-registering a name is an error
+    unless ``replace=True``, because a silent overwrite would change what an
+    already-written preset resolves to.
+    """
+    if not isinstance(convention, Convention):
+        raise TypeError(f"expected a Convention, got {type(convention).__name__}")
+    existing = CONVENTIONS.get(convention.name)
+    if existing is not None and not replace:
+        raise ValueError(
+            f"convention {convention.name!r} is already registered "
+            f"(image_keys={list(existing.image_keys)}); pass replace=True to override it"
+        )
+    CONVENTIONS[convention.name] = convention
+    return convention

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -4,7 +4,8 @@ This package owns everything policy-related, mirroring how :mod:`apxinf.processo
 owns its own steps and :class:`~apxinf.processors.base.ProcessorStep`. It is split
 into a **stable** outer layer and a **volatile** inner one:
 
-* :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts.
+* :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts,
+  plus :class:`ComposablePolicy`, the opt-in seam a robot adapter wraps.
 * :mod:`~apxinf.policies.registry` — the ``model_type -> policy class`` registry.
 * :mod:`~apxinf.policies.auto` — :class:`AutoPolicy`, dispatch by ``config.json`` type.
 * :mod:`~apxinf.policies.impls` — the concrete per-model policies (``pi05``, ...),
@@ -24,7 +25,7 @@ inside ``from_pretrained`` — so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .auto import AutoPolicy
-from .base import BareModel, Policy
+from .base import BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
@@ -33,6 +34,7 @@ from .impls import Pi05Policy
 __all__ = [
     "Policy",
     "BareModel",
+    "ComposablePolicy",
     "AutoPolicy",
     "register_policy",
     "get_policy",

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -5,7 +5,8 @@ owns its own steps and :class:`~apxinf.processors.base.ProcessorStep`. It is spl
 into a **stable** outer layer and a **volatile** inner one:
 
 * :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts,
-  plus :class:`ComposablePolicy`, the opt-in seam a robot adapter wraps.
+  plus :class:`ComposablePolicy` (the opt-in seam a robot adapter wraps) and
+  :data:`VIEW_SLOTS` (the camera slot names the weights consume, in order).
 * :mod:`~apxinf.policies.registry` — the ``model_type -> policy class`` registry.
 * :mod:`~apxinf.policies.auto` — :class:`AutoPolicy`, dispatch by ``config.json`` type.
 * :mod:`~apxinf.policies.impls` — the concrete per-model policies (``pi05``, ...),
@@ -25,7 +26,7 @@ inside ``from_pretrained`` — so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .auto import AutoPolicy
-from .base import BareModel, ComposablePolicy, Policy
+from .base import VIEW_SLOTS, BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
@@ -35,6 +36,7 @@ __all__ = [
     "Policy",
     "BareModel",
     "ComposablePolicy",
+    "VIEW_SLOTS",
     "AutoPolicy",
     "register_policy",
     "get_policy",

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -30,7 +30,7 @@ from .base import VIEW_SLOTS, BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
-from .impls import Pi05Policy
+from .impls import GrootN17Policy, Pi05Policy
 
 __all__ = [
     "Policy",
@@ -42,5 +42,5 @@ __all__ = [
     "get_policy",
     "available_policies",
     "Pi05Policy",
+    "GrootN17Policy",
 ]
-

--- a/python/apxinf/apxinf/policies/auto.py
+++ b/python/apxinf/apxinf/policies/auto.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from .base import Policy
 from .registry import available_policies, get_policy
+from ..checkpoints import OPENPI_PYTORCH, CheckpointError, detect_checkpoint
 
 __all__ = ["AutoPolicy"]
 
@@ -55,6 +56,22 @@ class AutoPolicy:
 def _read_model_type(model_dir: Path) -> str:
     config_path = model_dir / "config.json"
     if not config_path.is_file():
+        # An openpi PyTorch export has no config.json at all — its model type
+        # lives in metadata.pt, which is exactly what an openpi_pytorch layout
+        # means. Without this, every such checkpoint had to be served with an
+        # explicit model_type= even though the directory does say what it is.
+        try:
+            layout = detect_checkpoint(model_dir)
+        except CheckpointError as exc:
+            raise FileNotFoundError(
+                f"AutoPolicy: no config.json in {model_dir} and its layout could not "
+                f"be identified ({exc}); pass model_type= explicitly "
+                f"(known: {available_policies()})"
+            ) from exc
+        if layout.format == OPENPI_PYTORCH:
+            # train_config_facts already refused anything that is not pi05
+            # (pi05=False, or a backbone this runtime is not built for).
+            return "pi05"
         raise FileNotFoundError(
             f"AutoPolicy: no config.json in {model_dir}; pass model_type= explicitly "
             f"(known: {available_policies()})"

--- a/python/apxinf/apxinf/policies/base.py
+++ b/python/apxinf/apxinf/policies/base.py
@@ -14,6 +14,9 @@ points other layers code against:
 * :class:`ComposablePolicy` — the narrow extra capability a policy needs before
   an *outer* layer (a robot adapter) can wrap steps around its chain. Optional:
   a policy is a perfectly good :class:`Policy` without it.
+* :data:`VIEW_SLOTS` — the camera slot names a checkpoint's weights consume, in
+  order. Model vocabulary, kept here so a policy and a robot preset can both
+  name a slot without importing each other.
 
 It exists to pin these contracts *now*, before a second model lands, so the
 layout is set for whoever adds one. They intentionally stay tiny: extract richer
@@ -34,7 +37,22 @@ from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, runtime_che
 
 import numpy as np
 
-__all__ = ["Policy", "BareModel", "ComposablePolicy"]
+__all__ = ["Policy", "BareModel", "ComposablePolicy", "VIEW_SLOTS"]
+
+#: Camera view slots, in the order a checkpoint's weights consume them, as named
+#: by openpi's ``model.IMAGE_KEYS``.
+#:
+#: These are **model** vocabulary, not wire keys and not a dataset's convention.
+#: A checkpoint's ``num_views`` says how many of these it was trained on; the
+#: *order* is baked into the weights, and nothing here ever crosses the network.
+#: They live in this module rather than in a robot preset or in ``pi05.py``
+#: because both sides need to agree on them without either importing the other:
+#: a policy uses them to name the cameras it wants when the caller does not, and
+#: a robot preset uses them to say which slot each of its wire keys fills.
+#:
+#: The pi05 family shares this vocabulary. A model with a different camera layout
+#: declares its own rather than stretching this tuple.
+VIEW_SLOTS = ("base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb")
 
 
 @runtime_checkable

--- a/python/apxinf/apxinf/policies/base.py
+++ b/python/apxinf/apxinf/policies/base.py
@@ -11,6 +11,9 @@ points other layers code against:
   ``GrootPolicy``). Downstream consumers (the websocket server, the
   :class:`~apxinf.policies.auto.AutoPolicy` registry, a lerobot adaptor) code
   against this, never a concrete class.
+* :class:`ComposablePolicy` — the narrow extra capability a policy needs before
+  an *outer* layer (a robot adapter) can wrap steps around its chain. Optional:
+  a policy is a perfectly good :class:`Policy` without it.
 
 It exists to pin these contracts *now*, before a second model lands, so the
 layout is set for whoever adds one. They intentionally stay tiny: extract richer
@@ -27,11 +30,11 @@ anything beyond the two guaranteed ones.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Protocol, runtime_checkable
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, runtime_checkable
 
 import numpy as np
 
-__all__ = ["Policy", "BareModel"]
+__all__ = ["Policy", "BareModel", "ComposablePolicy"]
 
 
 @runtime_checkable
@@ -89,4 +92,48 @@ class Policy(Protocol):
 
     def close(self) -> None:
         """Release any underlying model resources."""
+        ...
+
+
+@runtime_checkable
+class ComposablePolicy(Protocol):
+    """A :class:`Policy` an outer layer can wrap without knowing its internals.
+
+    This is the seam between the **robot** layer and the **model** layer. A robot
+    adapter (``apxinf.robots.unitree_g1``) has to run its own steps around the
+    model's — decode the wire state before anything model-specific reads it, turn
+    the model's delta actions into absolute joint targets after unnormalization.
+    That is an *ordering* requirement and nothing more: outside, in both
+    directions, exactly the way openpi's ``data_transforms`` sit outside its
+    ``model_transforms``.
+
+    Without this method the only way to express it is to reach into the concrete
+    policy — import ``Pi05Policy``, address its steps by name
+    (``insert_before("tokenize", ...)``), and rebuild it. That makes every robot
+    adapter depend on one model class and on that class's private step names.
+    :meth:`with_adapter` states the ordering instead, so the robot layer imports
+    no model and the model layer knows about no robot.
+
+    Only this one method is promoted, and only because real code calls it. The
+    rest of the composition surface (``input_pipeline``, ``output_pipeline``,
+    ``model``) stays private to the concrete class until a second model shows
+    what is genuinely shared.
+    """
+
+    def with_adapter(
+        self,
+        *,
+        before: Sequence[Any] = (),
+        after: Sequence[Any] = (),
+        action_dim: Optional[int] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "Policy":
+        """Return a policy running ``before`` ahead of, and ``after`` behind, its own chain.
+
+        Each entry is a ``(name, step)`` pair (a
+        :data:`~apxinf.processors.base.StepSpec`). ``action_dim`` declares the
+        deployable width the wrapped chain now emits, since an appended step may
+        change it; ``metadata`` is merged over the inherited description. The
+        returned policy shares the underlying model handle — do not close both.
+        """
         ...

--- a/python/apxinf/apxinf/policies/impls/__init__.py
+++ b/python/apxinf/apxinf/policies/impls/__init__.py
@@ -18,5 +18,6 @@ inside ``from_pretrained``, so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .pi05 import Pi05Policy
+from .groot_n17 import GrootN17Policy
 
-__all__ = ["Pi05Policy"]
+__all__ = ["Pi05Policy", "GrootN17Policy"]

--- a/python/apxinf/apxinf/policies/impls/groot_n17.py
+++ b/python/apxinf/apxinf/policies/impls/groot_n17.py
@@ -1,0 +1,167 @@
+"""Native ApxInf policy for the frozen NVIDIA GR00T N1.7 LIBERO profile."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+
+from ..registry import register_policy
+from ...processors.transforms import lookup_key
+
+__all__ = ["GrootN17Policy"]
+
+_IMAGE_TOKEN = 151655
+_STATE_KEYS = ("x", "y", "z", "roll", "pitch", "yaw", "gripper")
+_ACTION_KEYS = ("x", "y", "z", "roll", "pitch", "yaw", "gripper")
+
+
+@register_policy("Gr00tN1d7")
+class GrootN17Policy:
+    """One- or two-view LIBERO policy backed only by ApxInf CUDA execution."""
+
+    def __init__(self, model, tokenizer, statistics: Mapping, *,
+                 image_keys: Sequence[str] = ("observation/image", "observation/wrist_image"),
+                 state_prefix: str = "observation/state", prompt_key: str = "prompt"):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.statistics = statistics
+        self.image_keys = tuple(image_keys)
+        if len(self.image_keys) not in (1, 2):
+            raise ValueError("GrootN17Policy requires one or two image keys")
+        self.state_prefix = state_prefix.rstrip("/")
+        self.prompt_key = prompt_key
+        self.metadata = {"model_type": "Gr00tN1d7", "action_horizon": 16,
+            "action_dim": 7, "model_action_horizon": 40, "model_action_dim": 132,
+            "num_views": len(self.image_keys), "image_size": [256, 256],
+            "image_keys": list(self.image_keys),
+            "prompt_key": prompt_key, "state_keys": list(_STATE_KEYS),
+            "precision": "bf16", "cuda_graph": "whole-model"}
+
+    @classmethod
+    def from_pretrained(cls, model_dir, *, backbone_dir=None, model=None,
+                        device="cuda:0", precision="bf16", image_keys=None,
+                        state_prefix="observation/state", prompt_key="prompt", seed=0, **kwargs):
+        if kwargs:
+            raise TypeError(f"unsupported GR00T policy options: {sorted(kwargs)}")
+        model_dir = Path(model_dir)
+        if model is None:
+            import apxinf_py
+            selected_keys = tuple(image_keys or ("observation/image", "observation/wrist_image"))
+            model = apxinf_py.Model.load("Gr00tN1d7", model_dir, device=device,
+                                         precision=precision, num_views=len(selected_keys),
+                                         sampling_seed=int(seed))
+        tokenizer_root = Path(backbone_dir) if backbone_dir is not None else model_dir
+        try:
+            from tokenizers import Tokenizer
+        except ImportError as exc:
+            raise ImportError("GrootN17Policy requires `pip install apxinf[groot]`") from exc
+        tokenizer_file = tokenizer_root / "tokenizer.json"
+        if not tokenizer_file.is_file():
+            raise FileNotFoundError(
+                f"GR00T tokenizer not found at {tokenizer_file}; pass backbone_dir=Cosmos-Reason2-2B")
+        tokenizer = Tokenizer.from_file(str(tokenizer_file))
+        stats_path = model_dir / "statistics.json"
+        statistics = json.loads(stats_path.read_text())["libero_sim"]
+        return cls(model, tokenizer, statistics,
+                   image_keys=image_keys or ("observation/image", "observation/wrist_image"),
+                   state_prefix=state_prefix, prompt_key=prompt_key)
+
+    def infer(self, observation: Mapping, *, noise: np.ndarray | None = None):
+        started = time.perf_counter()
+        missing = [key for key in (*self.image_keys, self.prompt_key)
+                   if not _has_key(observation, key)]
+        if missing:
+            raise KeyError(f"GrootN17Policy missing observation keys: {missing}")
+        images = np.ascontiguousarray(
+            np.stack([_prepare_image(lookup_key(observation, key)) for key in self.image_keys]),
+            dtype=np.uint8,
+        )
+        prompt = str(lookup_key(observation, self.prompt_key))
+        token_ids = self._token_ids(prompt)
+        state = self._state(observation)
+        model_started = time.perf_counter()
+        normalized = self.model.infer_rgb(
+            images,
+            "nhwc",
+            np.asarray(token_ids, dtype=np.uint32),
+            **({"noise": np.ascontiguousarray(noise, dtype=np.float32)} if noise is not None else {}),
+            state=np.ascontiguousarray(state[None], dtype=np.float32),
+        )
+        model_ms = (time.perf_counter() - model_started) * 1000.0
+        normalized = np.asarray(normalized, dtype=np.float32)[:16, :7]
+        actions = self._decode(normalized)
+        return {"actions": actions, "normalized_actions": normalized,
+                "token_ids": np.asarray(token_ids, dtype=np.uint32),
+                "timing": {"model_ms": model_ms,
+                           "total_ms": (time.perf_counter() - started) * 1000.0},
+                "metadata": self.metadata}
+
+    __call__ = infer
+
+    def _token_ids(self, prompt: str) -> list[int]:
+        prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False).ids
+        if len(prompt_ids) != 5:
+            raise ValueError(
+                f"GR00T validated CUDA graph accepts a five-token instruction, got {len(prompt_ids)}")
+        ids = [151644, 872, 198, 151652] + [_IMAGE_TOKEN] * 64 + [151653]
+        if len(self.image_keys) == 2:
+            ids += [151652] + [_IMAGE_TOKEN] * 64 + [151653]
+        ids += prompt_ids + [151645, 198]
+        assert len(ids) == (76 if len(self.image_keys) == 1 else 142)
+        return ids
+
+    def _state(self, observation: Mapping) -> np.ndarray:
+        values = []
+        stats = self.statistics["state"]
+        for key in _STATE_KEYS:
+            path = f"{self.state_prefix}/{key}"
+            if not _has_key(observation, path):
+                raise KeyError(f"GrootN17Policy missing state key {path!r}")
+            raw = np.asarray(lookup_key(observation, path), dtype=np.float32).reshape(-1)
+            low = np.asarray(stats[key]["q01"], dtype=np.float32)
+            high = np.asarray(stats[key]["q99"], dtype=np.float32)
+            values.extend(np.clip(2.0 * (raw - low) / (high - low + 1e-6) - 1.0, -1.0, 1.0))
+        output = np.zeros(132, dtype=np.float32)
+        output[:len(values)] = values
+        return output
+
+    def _decode(self, normalized: np.ndarray) -> np.ndarray:
+        output = np.empty_like(normalized)
+        stats = self.statistics["action"]
+        for index, key in enumerate(_ACTION_KEYS):
+            low = float(stats[key]["q01"][0]); high = float(stats[key]["q99"][0])
+            output[:, index] = (normalized[:, index] + 1.0) * 0.5 * (high - low) + low
+        return output
+
+    @property
+    def action_dim(self): return 7
+
+    @property
+    def action_horizon(self): return 16
+
+    def close(self):
+        close = getattr(self.model, "close", None)
+        if callable(close): close()
+
+
+def _prepare_image(value) -> np.ndarray:
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError("GrootN17Policy requires `pip install apxinf[groot]`") from exc
+    image = np.asarray(value)
+    while image.ndim > 3: image = image[0]
+    image = cv2.resize(image.astype(np.uint8), (256, 256), interpolation=cv2.INTER_AREA)
+    # The frozen checkpoint uses the newer shortest-edge/crop-fraction path:
+    # int(256 * .95) = 243, centered at offset 6, then resized to 256.
+    image = cv2.resize(image[6:249, 6:249], (256, 256), interpolation=cv2.INTER_AREA)
+    return np.ascontiguousarray(image, dtype=np.uint8)
+
+
+def _has_key(mapping: Mapping, path: str) -> bool:
+    try: lookup_key(mapping, path); return True
+    except (KeyError, TypeError): return False

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -23,13 +23,21 @@ returns the **unnormalized-domain** chunk. The intermediate normalized action is
 also returned (``normalized_actions``) so the layering invariant
 ``L2 minus unnormalize == L1`` can be checked directly.
 
-**State injection (opt-in, off by default):** ``observation/state`` is dropped by
-default so the numerics match today's serving link. Enable it with
-``discrete_state=True``: the raw state is first mapped to ``[-1, 1]`` by a
-``state_normalizer`` (a :class:`~apxinf.processors.Normalizer` over
-``norm_stats["state"]`` by default), then discretized into the prompt — matching
-openpi's "normalize then discretize" order. This path does **not** assume the
-incoming state is already in ``[-1, 1]``.
+**State injection (opt-in, off by default):** state is dropped by default so the
+numerics match today's serving link. Enable it with ``discrete_state=True``: the
+raw state is first mapped to ``[-1, 1]`` by a ``state_normalizer`` (a
+:class:`~apxinf.processors.Normalizer` over ``norm_stats["state"]`` by default),
+then discretized into the prompt — matching openpi's "normalize then discretize"
+order. This path does **not** assume the incoming state is already in ``[-1, 1]``.
+
+**This module names no dataset's wire keys.** ``image_keys`` falls back to the
+model's own :data:`~apxinf.policies.base.VIEW_SLOTS`, and ``state_key`` has no
+fallback at all — it is required exactly when state is read and may stay ``None``
+when state is dropped. ``("observation/image", "observation/wrist_image")`` and
+``"observation/state"`` used to be the defaults here, which is LIBERO's dialect
+applied to every checkpoint: a G1 checkpoint served bare ran LIBERO's contract
+and looked like an accuracy problem. Wire keys belong to
+:mod:`apxinf.conventions`; a robot preset pairs one with a body.
 
 This module registers ``Pi05Policy`` under ``model_type="pi05"`` so
 :class:`~apxinf.policies.auto.AutoPolicy` can dispatch to it.
@@ -77,7 +85,9 @@ from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
 
-_STATE_KEY = "observation/state"
+#: ``prompt`` is openpi's *protocol*-level name for the instruction field — every
+#: dialect on this wire uses it — so unlike the camera and state keys it is not
+#: any one dataset's convention and keeps a default here.
 _PROMPT_KEY = "prompt"
 
 
@@ -93,7 +103,7 @@ class Pi05Policy:
         output_pipeline: Pipeline,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         action_dim: Optional[int] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ):
@@ -115,6 +125,16 @@ class Pi05Policy:
         tokenizer = getattr(tokenize, "tokenizer", None)
         self.discrete_state = bool(getattr(tokenizer, "discrete_state", False))
         state_normalized = getattr(tokenize, "state_normalizer", None) is not None
+        if self.discrete_state and self.state_key is None:
+            # The chain reads state but nothing says from where. Left alone this
+            # would serve a policy whose published state_key is null while its
+            # tokenizer quietly injects nothing — proprioception lost in silence.
+            raise ValueError(
+                "Pi05Policy: this chain discretizes state into the prompt but no "
+                "state_key was given. Name the wire key your client sends (see "
+                "apxinf.conventions, or a robot preset), or build the policy with "
+                "discrete_state=False to drop state deliberately."
+            )
 
         # Kept apart from the derived half so ``with_adapter`` can carry the
         # caller's description forward while the rewired policy recomputes what
@@ -168,7 +188,7 @@ class Pi05Policy:
         noise: Optional[GaussianNoise] = None,
         state_normalizer: Optional[Normalizer] = None,
         image_keys: Optional[Sequence[str]] = None,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
     ) -> Tuple[Pipeline, Pipeline]:
         """Assemble the default ``(input_pipeline, output_pipeline)`` from parts.
 
@@ -182,6 +202,12 @@ class Pi05Policy:
         :data:`~apxinf.policies.base.VIEW_SLOTS`, because this layer has no
         business guessing anyone's wire keys — see :func:`_default_image_keys`.
         A real deployment states them, usually via a robot preset.
+
+        ``state_key`` has no such fallback and none is possible: there is no
+        model-side vocabulary for a state key the way ``VIEW_SLOTS`` is one for
+        cameras. It is therefore required exactly when it is read — i.e. when
+        ``state_normalizer`` / the tokenizer put state into the prompt — and may
+        stay ``None`` when state is dropped, in which case nothing looks it up.
 
         A deployment with *fewer* cameras than the checkpoint declares is served
         by loading with ``num_views=`` (``--num-views`` on the server), which
@@ -248,7 +274,7 @@ class Pi05Policy:
         image_pipeline: Optional[Pipeline] = None,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         num_views: Optional[int] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "Pi05Policy":
@@ -276,7 +302,9 @@ class Pi05Policy:
         validator accepts). State injection is off by default; with
         ``discrete_state=True`` a state normalizer is built from
         ``norm_stats[state_norm_key]`` to map raw state to ``[-1, 1]`` before it is
-        discretized into the prompt.
+        discretized into the prompt, and ``state_key`` becomes **required** —
+        there is no dataset-neutral name to fall back to, and guessing one would
+        drop proprioception silently.
 
         ``num_views`` loads the checkpoint for fewer cameras than it declares, for
         a deployment that has fewer. It must equal ``len(image_keys)``. This drops
@@ -295,6 +323,16 @@ class Pi05Policy:
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
         """
         model_dir = Path(model_dir)
+        if discrete_state and state_key is None:
+            # Caught here rather than deeper in Tokenize so the message can name
+            # the two flags the caller actually passed. discrete_state=True with
+            # no key would inject nothing and publish state_key=null.
+            raise ValueError(
+                "Pi05Policy.from_pretrained: discrete_state=True needs a state_key — "
+                "the wire key your client sends state under (see apxinf.conventions, "
+                "or use a robot preset via build_robot_policy). Pass "
+                "discrete_state=False to drop state instead."
+            )
         if unnormalizer is not None and action_dim is not None and int(action_dim) != unnormalizer.width:
             # Both name the deployable width; an injected map already fixes it, so
             # a disagreeing action_dim would silently lose to the injection.
@@ -389,7 +427,7 @@ class Pi05Policy:
         seed: int = 0,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
-        state_key: str = _STATE_KEY,
+        state_key: Optional[str] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         warn: bool = True,
     ) -> "Pi05Policy":

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -45,7 +45,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 import numpy as np
 
 from ..._tactics import resolve_pi05_tactics
-from ..base import BareModel
+from ..base import VIEW_SLOTS, BareModel
 from ...processors import (
     GaussianNoise,
     ImageStack,
@@ -77,7 +77,6 @@ from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
 
-_DEFAULT_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
 _STATE_KEY = "observation/state"
 _PROMPT_KEY = "prompt"
 
@@ -92,7 +91,7 @@ class Pi05Policy:
         *,
         input_pipeline: Pipeline,
         output_pipeline: Pipeline,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
         state_key: str = _STATE_KEY,
         action_dim: Optional[int] = None,
@@ -101,7 +100,9 @@ class Pi05Policy:
         self.model = model
         self.input_pipeline = input_pipeline
         self.output_pipeline = output_pipeline
-        self.image_keys = tuple(image_keys)
+        self.image_keys = tuple(
+            image_keys if image_keys is not None else _default_image_keys(model.num_views)
+        )
         self.prompt_key = prompt_key
         self.state_key = state_key
         self.action_dim_out = (
@@ -166,7 +167,7 @@ class Pi05Policy:
         image_pipeline: Optional[Pipeline] = None,
         noise: Optional[GaussianNoise] = None,
         state_normalizer: Optional[Normalizer] = None,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         state_key: str = _STATE_KEY,
     ) -> Tuple[Pipeline, Pipeline]:
         """Assemble the default ``(input_pipeline, output_pipeline)`` from parts.
@@ -177,12 +178,19 @@ class Pi05Policy:
         fewer. Absent cameras are never sent, so there is no padding: the model
         runs the real view shape directly.
 
+        Omitting ``image_keys`` names the cameras after the model's own
+        :data:`~apxinf.policies.base.VIEW_SLOTS`, because this layer has no
+        business guessing anyone's wire keys — see :func:`_default_image_keys`.
+        A real deployment states them, usually via a robot preset.
+
         A deployment with *fewer* cameras than the checkpoint declares is served
         by loading with ``num_views=`` (``--num-views`` on the server), which
         drops the trailing view slots at load time rather than zero-filling them
         per request.
         """
-        image_keys = tuple(image_keys)
+        image_keys = tuple(
+            image_keys if image_keys is not None else _default_image_keys(model.num_views)
+        )
         if len(image_keys) != model.num_views:
             fix = (
                 f"load with num_views={len(image_keys)} to serve fewer cameras "
@@ -238,7 +246,7 @@ class Pi05Policy:
         discrete_state: bool = False,
         state_norm_key: str = "state",
         image_pipeline: Optional[Pipeline] = None,
-        image_keys: Sequence[str] = _DEFAULT_IMAGE_KEYS,
+        image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
         state_key: str = _STATE_KEY,
         num_views: Optional[int] = None,
@@ -418,7 +426,9 @@ class Pi05Policy:
             reset_sampling(int(seed))
 
         if image_keys is None:
-            image_keys = _synthetic_image_keys(model.num_views)
+            # Resolved here rather than left to the two consumers below, so the
+            # published metadata and the ImageStack step cannot drift apart.
+            image_keys = _default_image_keys(model.num_views)
 
         input_pipeline, output_pipeline = cls.default_pipelines(
             model,
@@ -625,18 +635,26 @@ class Pi05Policy:
         )
 
 
-def _synthetic_image_keys(num_views: int) -> Tuple[str, ...]:
-    """Generate exactly ``num_views`` camera keys for a checkpoint-free policy.
+def _default_image_keys(num_views: int) -> Tuple[str, ...]:
+    """Name exactly ``num_views`` cameras when the caller names none.
 
-    Reuses the default ``image``/``wrist_image`` names for the first two views and
-    appends ``image_2``, ``image_3``, ... beyond that, so ``default_pipelines``'
+    Returns the model's own :data:`~apxinf.policies.base.VIEW_SLOTS` vocabulary,
+    truncated to the loaded view count, so the fallback describes the *model*
+    rather than some dataset. That is the whole point of not having a default
+    here: ``("observation/image", "observation/wrist_image")`` used to be it, and
+    those are LIBERO's wire keys — as *the* default they silently applied to
+    every checkpoint, so a G1 checkpoint served bare ran LIBERO's contract and
+    looked like an accuracy problem. Slot names cannot masquerade as anyone's
+    wire keys: a client sending LIBERO keys against this fallback gets a
+    ``KeyError`` naming both sides, which is the loud failure we want.
+
+    Beyond the declared slots the names continue as ``view_3_rgb``, ... so the
     ``len(image_keys) == model.num_views`` contract holds for any view count.
     """
-    base = list(_DEFAULT_IMAGE_KEYS)
-    if num_views <= len(base):
-        return tuple(base[:num_views])
-    extra = [f"observation/image_{i}" for i in range(len(base), num_views)]
-    return tuple(base + extra)
+    if num_views <= len(VIEW_SLOTS):
+        return tuple(VIEW_SLOTS[:num_views])
+    extra = [f"view_{index}_rgb" for index in range(len(VIEW_SLOTS), num_views)]
+    return tuple(VIEW_SLOTS) + tuple(extra)
 
 
 def _resolve_tokenizer(model_dir: Path, tokenizer_path) -> Path:

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -12,7 +12,11 @@ between its input and output transforms.
 This makes the whole pre/post chain reorderable, insertable, and replaceable
 through the ordinary ``Pipeline`` machinery — a custom high-performance resize or
 tokenizer drops in with ``input_pipeline.replace(...)`` / ``insert_after(...)``
-without forking the framework.
+without forking the framework. Those verbs address steps *by name*, so they are
+for callers who know this chain. A caller who only needs to run steps **around**
+it — a robot adapter — uses :meth:`Pi05Policy.with_adapter`
+(:class:`~apxinf.policies.base.ComposablePolicy`) instead and stays ignorant of
+what the chain contains.
 
 Domain contract: the model returns a **normalized-domain** action; this policy
 returns the **unnormalized-domain** chunk. The intermediate normalized action is
@@ -56,6 +60,7 @@ from ...processors import (
     Trim,
     Unnormalizer,
 )
+from ...processors.base import StepSpec
 from ...processors.transforms import (
     ACTIONS,
     NOISE,
@@ -110,7 +115,30 @@ class Pi05Policy:
         self.discrete_state = bool(getattr(tokenizer, "discrete_state", False))
         state_normalized = getattr(tokenize, "state_normalizer", None) is not None
 
+        # Kept apart from the derived half so ``with_adapter`` can carry the
+        # caller's description forward while the rewired policy recomputes what
+        # it actually serves.
+        self._extra_metadata = dict(metadata) if metadata else {}
         self.metadata = {
+            **self._derived_metadata(model, input_pipeline, output_pipeline, state_normalized),
+            **self._extra_metadata,
+        }
+
+    def _derived_metadata(
+        self,
+        model: BareModel,
+        input_pipeline: Pipeline,
+        output_pipeline: Pipeline,
+        state_normalized: bool,
+    ) -> dict:
+        """The part of ``metadata`` this policy computes from its own wiring.
+
+        Split out because :meth:`with_adapter` inherits the caller-supplied half
+        of ``metadata`` but must let the rewired policy recompute this half —
+        carrying the old ``action_dim`` or pipeline names forward would publish a
+        wire contract the new policy does not serve.
+        """
+        return {
             "model_type": "pi05",
             "action_horizon": model.action_horizon,
             "action_dim": self.action_dim_out,
@@ -124,7 +152,6 @@ class Pi05Policy:
             "state_normalized": state_normalized,
             "input_pipeline": input_pipeline.names,
             "output_pipeline": output_pipeline.names,
-            **(dict(metadata) if metadata else {}),
         }
 
     # --- construction ------------------------------------------------------
@@ -204,6 +231,7 @@ class Pi05Policy:
         tactics=None,
         tokenizer_path=None,
         norm_key: str = "actions",
+        unnormalizer: Optional[Unnormalizer] = None,
         action_dim: Optional[int] = None,
         action_horizon: Optional[int] = None,
         seed: int = 0,
@@ -227,7 +255,13 @@ class Pi05Policy:
         ``state_norm_key``) — only this method knows ``model_dir``.
 
         ``action_dim`` trims the unnormalizer to the task's action width (e.g. 7
-        for LIBERO); ``None`` keeps the full vector. ``action_horizon`` overrides
+        for LIBERO); ``None`` keeps the full vector. ``unnormalizer`` supplies the
+        quantile map directly instead of reading ``norm_stats`` from disk — for a
+        shape/plumbing run on a stand-in checkpoint whose statistics belong to a
+        different robot (pass a full-width identity), where reading the file would
+        silently apply the wrong scale. It is mutually exclusive with
+        ``action_dim``, since an injected map already fixes the width.
+        ``action_horizon`` overrides
         the checkpoint's chunk length: ``None`` runs the native ``config.json``
         value, an explicit value outranks it (the horizon is a sequence length,
         not a weight dimension, so the same weights run at any horizon the config
@@ -253,6 +287,14 @@ class Pi05Policy:
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
         """
         model_dir = Path(model_dir)
+        if unnormalizer is not None and action_dim is not None and int(action_dim) != unnormalizer.width:
+            # Both name the deployable width; an injected map already fixes it, so
+            # a disagreeing action_dim would silently lose to the injection.
+            raise ValueError(
+                f"Pi05Policy.from_pretrained: action_dim={action_dim} conflicts with the "
+                f"supplied unnormalizer's width {unnormalizer.width}; the injected map "
+                "already sets the deployable width, so pass only one"
+            )
         if model is None:
             import apxinf_py  # lazy: processor-only users never import the binding
 
@@ -296,7 +338,11 @@ class Pi05Policy:
             max_token_len=model.max_token_len if hasattr(model, "max_token_len") else 200,
             discrete_state=discrete_state,
         )
-        unnormalizer = Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+        unnormalizer = (
+            unnormalizer
+            if unnormalizer is not None
+            else Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+        )
         state_normalizer = (
             Normalizer.from_norm_stats(model_dir, key=state_norm_key) if discrete_state else None
         )
@@ -389,6 +435,48 @@ class Pi05Policy:
             state_key=state_key,
             action_dim=width,
             metadata={"weights": "synthetic", **(dict(metadata) if metadata else {})},
+        )
+
+    # --- composition -------------------------------------------------------
+
+    def with_adapter(
+        self,
+        *,
+        before: Sequence[StepSpec] = (),
+        after: Sequence[StepSpec] = (),
+        action_dim: Optional[int] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "Pi05Policy":
+        """Return a copy running ``before`` ahead of, and ``after`` behind, this chain.
+
+        Implements :class:`~apxinf.policies.base.ComposablePolicy`. This is how a
+        robot adapter wires its body-specific steps without importing this class
+        or naming any step inside it: ``before`` lands ahead of ``image_stack``
+        (so it sees the raw client observation and can rewrite it before anything
+        model-specific reads it) and ``after`` lands behind ``unnormalize`` (so it
+        sees deployable-domain actions). That nesting is openpi's
+        ``data_transforms`` outside ``model_transforms``, and it is the whole of
+        what a robot needs from a model.
+
+        ``after`` steps receive the post-input observation alongside the actions
+        (see :meth:`infer`), so a delta→absolute step reads the same decoded
+        state the ``before`` steps produced.
+
+        ``action_dim`` declares the deployable width the appended steps leave
+        behind — pass it whenever ``after`` changes the width, since the derived
+        value would otherwise report this policy's pre-adapter width. The model
+        handle is **shared**, not reloaded: this is a rewiring, not a second load,
+        so only one of the two policies should be ``close()``d.
+        """
+        return type(self)(
+            self.model,
+            input_pipeline=self.input_pipeline.prepend(*before),
+            output_pipeline=self.output_pipeline.append(*after),
+            image_keys=self.image_keys,
+            prompt_key=self.prompt_key,
+            state_key=self.state_key,
+            action_dim=self.action_dim_out if action_dim is None else int(action_dim),
+            metadata={**self._extra_metadata, **(dict(metadata) if metadata else {})},
         )
 
     # --- inference ---------------------------------------------------------

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -45,6 +45,7 @@ This module registers ``Pi05Policy`` under ``model_type="pi05"`` so
 
 from __future__ import annotations
 
+import logging
 import time
 import warnings
 from pathlib import Path
@@ -53,6 +54,13 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 import numpy as np
 
 from ..._tactics import resolve_pi05_tactics
+from ...checkpoints import (
+    CheckpointError,
+    detect_checkpoint,
+    has_layout_metadata,
+    require_norm_stats,
+    resolve_tokenizer,
+)
 from ..base import VIEW_SLOTS, BareModel
 from ...processors import (
     GaussianNoise,
@@ -84,6 +92,8 @@ from ...processors.transforms import (
 from ..registry import register_policy
 
 __all__ = ["Pi05Policy"]
+
+_LOGGER = logging.getLogger("apxinf.policies.pi05")
 
 #: ``prompt`` is openpi's *protocol*-level name for the instruction field — every
 #: dialect on this wire uses it — so unlike the camera and state keys it is not
@@ -277,6 +287,9 @@ class Pi05Policy:
         prompt_key: str = _PROMPT_KEY,
         state_key: Optional[str] = None,
         num_views: Optional[int] = None,
+        checkpoint_format: Optional[str] = None,
+        asset_id: Optional[str] = None,
+        norm_stats=None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "Pi05Policy":
         """Build the **default** policy from a checkpoint directory.
@@ -329,6 +342,19 @@ class Pi05Policy:
         A checkpoint-local ``tactics.json`` takes precedence over source-tree
         defaults, so normal Python and serving callers share the same routing.
 
+        ``checkpoint_format`` / ``asset_id`` / ``norm_stats`` control how the
+        directory is read (see :mod:`apxinf.checkpoints`). By default the layout
+        is detected: an openpi PyTorch export declares its architecture in
+        ``metadata.pt`` and keeps its statistics under
+        ``assets/<asset_id>/norm_stats.json``, and both are picked up without any
+        flag. ``checkpoint_format`` pins the answer instead of sniffing it,
+        ``asset_id`` overrides the one the checkpoint names (for assets moved
+        after export), and ``norm_stats`` is an explicit path that outranks every
+        convention. The first two make detection strict — an unreadable layout
+        raises rather than falling back — because both assert that the directory
+        *has* a layout. ``norm_stats`` does not: it names a single file, so it
+        also works on a flat directory that declares nothing about itself.
+
         For a **fully custom** pre/post chain, do not funnel it through here:
         build the parts yourself and use :meth:`default_pipelines` +
         :meth:`__init__` (or mutate ``policy.input_pipeline`` after construction).
@@ -352,6 +378,27 @@ class Pi05Policy:
                 f"supplied unnormalizer's width {unnormalizer.width}; the injected map "
                 "already sets the deployable width, so pass only one"
             )
+
+        # Read the directory's own account of itself before touching a weight.
+        # A hand-assembled flat directory (model.safetensors + norm_stats.json,
+        # nothing that says what it is) predates this layer and still loads:
+        # detection has nothing to work with there, so it is skipped rather than
+        # turned into a hard failure. Naming a format or an asset_id does assert
+        # a real layout, so detection runs and its errors propagate. ``norm_stats``
+        # deliberately does not: it names one file, not a directory shape, and it
+        # is exactly what a flat directory needs when its statistics live
+        # elsewhere.
+        layout = None
+        if checkpoint_format or asset_id or has_layout_metadata(model_dir):
+            layout = detect_checkpoint(
+                model_dir,
+                checkpoint_format=checkpoint_format,
+                asset_id=asset_id,
+                norm_stats=norm_stats,
+            )
+            for note in layout.notes:
+                _LOGGER.info("checkpoint %s: %s", model_dir, note)
+
         if model is None:
             import apxinf_py  # lazy: processor-only users never import the binding
 
@@ -362,6 +409,7 @@ class Pi05Policy:
                 model_dir=model_dir,
                 override=Path(tactics) if tactics is not None else None,
             )
+            config_json = layout.config_json_text() if layout is not None else None
             model = apxinf_py.Model.load(
                 model_name,
                 ckpt,
@@ -369,6 +417,10 @@ class Pi05Policy:
                 precision=precision,
                 **({"calibration": str(calibration)} if calibration else {}),
                 **({"tactics": str(tactics)} if tactics else {}),
+                # An openpi export has no config.json, so without this the Rust
+                # loader silently ran Pi05Config::default(). The constants come
+                # from the checkpoint's own metadata.pt.
+                **({"config_json": config_json} if config_json else {}),
                 **({"action_horizon": int(action_horizon)} if action_horizon else {}),
                 **({"num_views": int(num_views)} if num_views is not None else {}),
                 sampling_seed=int(seed),
@@ -395,15 +447,33 @@ class Pi05Policy:
             max_token_len=model.max_token_len if hasattr(model, "max_token_len") else 200,
             discrete_state=discrete_state,
         )
+        # Resolved once, and only when a file is actually read: an injected
+        # unnormalizer with state dropped is a deliberate no-statistics path, and
+        # demanding the file there would break a stand-in checkpoint run. An
+        # explicit path still works with no layout at all, which is the flat
+        # directory whose statistics were handed over separately.
+        needs_stats = unnormalizer is None or discrete_state
+        if not needs_stats:
+            stats_path = None
+        elif layout is not None:
+            stats_path = require_norm_stats(layout)
+        elif norm_stats is not None:
+            stats_path = Path(norm_stats)
+            if not stats_path.is_file():
+                raise CheckpointError(f"norm_stats path {stats_path} does not exist")
+        else:
+            stats_path = None
         unnormalizer = (
             unnormalizer
             if unnormalizer is not None
             else Unnormalizer.from_norm_stats(
-                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype
+                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype, path=stats_path
             )
         )
         state_normalizer = (
-            Normalizer.from_norm_stats(model_dir, key=state_norm_key, dtype=norm_dtype)
+            Normalizer.from_norm_stats(
+                model_dir, key=state_norm_key, dtype=norm_dtype, path=stats_path
+            )
             if discrete_state
             else None
         )
@@ -711,11 +781,11 @@ def _default_image_keys(num_views: int) -> Tuple[str, ...]:
 
 
 def _resolve_tokenizer(model_dir: Path, tokenizer_path) -> Path:
-    if tokenizer_path is not None:
-        return Path(tokenizer_path)
-    candidates = (model_dir / "tokenizer.model", model_dir / "paligemma_tokenizer.model")
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    rendered = ", ".join(str(path) for path in candidates)
-    raise FileNotFoundError(f"no SentencePiece tokenizer found under {model_dir}; checked {rendered}")
+    """Locate the SentencePiece model: explicit path, ``APXINF_TOKENIZER``, then the dir.
+
+    Delegates to :func:`apxinf.checkpoints.resolve_tokenizer` so the "where do I
+    get this file" message is written once. No pi05 checkpoint ships a tokenizer
+    — openpi downloads it from GCS and LeRobot from a gated HF repo — so the
+    error has to name both sources, and apxinf downloads neither.
+    """
+    return resolve_tokenizer(model_dir, tokenizer_path)

--- a/python/apxinf/apxinf/policies/impls/pi05.py
+++ b/python/apxinf/apxinf/policies/impls/pi05.py
@@ -271,6 +271,7 @@ class Pi05Policy:
         seed: int = 0,
         discrete_state: bool = False,
         state_norm_key: str = "state",
+        norm_dtype: Optional[str] = None,
         image_pipeline: Optional[Pipeline] = None,
         image_keys: Optional[Sequence[str]] = None,
         prompt_key: str = _PROMPT_KEY,
@@ -305,6 +306,16 @@ class Pi05Policy:
         discretized into the prompt, and ``state_key`` becomes **required** —
         there is no dataset-neutral name to fall back to, and guessing one would
         drop proprioception silently.
+
+        ``norm_dtype`` pins the dtype both normalizers compute in; the default
+        follows the input, so a float32 observation is normalized in float32.
+        ``"float64"`` reproduces openpi, which parses ``norm_stats.json`` into
+        float64 and never demotes it. The difference is ~1e-7 either way and is
+        invisible on the output side, but on the input side normalization feeds
+        the state discretizer, whose bins are 1/128 apart: an element near a bin
+        edge crosses it, and the prompt — hence the entire rollout — changes.
+        A checkpoint whose statistics came from openpi wants ``"float64"``; the
+        preset table sets it per embodiment.
 
         ``num_views`` loads the checkpoint for fewer cameras than it declares, for
         a deployment that has fewer. It must equal ``len(image_keys)``. This drops
@@ -387,10 +398,14 @@ class Pi05Policy:
         unnormalizer = (
             unnormalizer
             if unnormalizer is not None
-            else Unnormalizer.from_norm_stats(model_dir, key=norm_key, dims=action_dim)
+            else Unnormalizer.from_norm_stats(
+                model_dir, key=norm_key, dims=action_dim, dtype=norm_dtype
+            )
         )
         state_normalizer = (
-            Normalizer.from_norm_stats(model_dir, key=state_norm_key) if discrete_state else None
+            Normalizer.from_norm_stats(model_dir, key=state_norm_key, dtype=norm_dtype)
+            if discrete_state
+            else None
         )
         reset_sampling = getattr(model, "reset_sampling", None)
         if callable(reset_sampling):

--- a/python/apxinf/apxinf/processors/base.py
+++ b/python/apxinf/apxinf/processors/base.py
@@ -12,7 +12,10 @@ Design (mirrors the PRD's "narrow interface, thick module" goal):
   loaded SentencePiece model) is shared by shallow copy, not rebuilt.
 * :class:`Pipeline` chains named steps left-to-right, threading one value
   through, and supports whole-step replacement and per-step parameter override
-  while leaving the other steps untouched.
+  while leaving the other steps untouched. It also composes: ``prepend`` /
+  ``append`` wrap a chain from outside without naming anything inside it, which
+  is how one layer (a robot adapter) wraps another's chain (a model's pre/post
+  steps) without depending on its internals.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ import abc
 import copy
 from typing import Any, Iterable, Sequence, Tuple, Union
 
-__all__ = ["ProcessorStep", "Pipeline"]
+__all__ = ["ProcessorStep", "Pipeline", "StepSpec"]
 
 
 class ProcessorStep(abc.ABC):
@@ -136,6 +139,31 @@ class Pipeline:
             if step_name == name:
                 return i
         raise KeyError(f"Pipeline has no step named {name!r}; have {self.names}")
+
+    # --- composition: wrap a chain without knowing its steps -----------------
+    #
+    # ``prepend``/``append`` are the only editing verbs that do not name an
+    # existing step. That distinction is load-bearing: an *outer* layer (a robot
+    # adapter wrapping a model's pre/post chain) has an **ordering** requirement
+    # — "run before everything the model does" — not a *naming* one. Expressed
+    # with ``insert_before("tokenize", ...)`` it would have to know that the
+    # chain contains a step called ``tokenize``, which is the model's private
+    # business and changes when the model does. These two verbs let the outer
+    # layer state the ordering directly and stay ignorant of the inner names.
+
+    def prepend(self, *specs: StepSpec) -> "Pipeline":
+        """Return a new pipeline running ``specs``, in order, before every current step.
+
+        Names must not collide with the existing ones (``Pipeline.__init__``
+        rejects duplicates), so a wrapper cannot silently shadow an inner step.
+        """
+        return Pipeline([self._normalize(spec) for spec in specs] + list(self._steps))
+
+    def append(self, *specs: StepSpec) -> "Pipeline":
+        """Return a new pipeline running ``specs``, in order, after every current step."""
+        return Pipeline(list(self._steps) + [self._normalize(spec) for spec in specs])
+
+    # --- editing: address one existing step by name --------------------------
 
     def replace(self, name: str, step: ProcessorStep) -> "Pipeline":
         """Return a new pipeline with the whole step ``name`` swapped out."""

--- a/python/apxinf/apxinf/processors/normalize.py
+++ b/python/apxinf/apxinf/processors/normalize.py
@@ -36,15 +36,26 @@ _QUANTILE = "quantile"
 _MEAN_STD = "mean_std"
 
 
-def load_norm_stats(model_dir, key: str = "actions") -> dict:
+def load_norm_stats(model_dir=None, key: str = "actions", *, path=None) -> dict:
     """Return the raw stats dict for ``key`` (e.g. ``"actions"``/``"state"``).
 
     Handles both the nested ``{"norm_stats": {...}}`` and flat top-level layouts.
+
+    ``path`` names the file directly and is what callers should pass: an openpi
+    PyTorch export keeps its statistics at ``assets/<asset_id>/norm_stats.json``,
+    not in the checkpoint root, so :func:`apxinf.checkpoints.detect_checkpoint`
+    resolves the path and hands it over here. ``model_dir`` remains for the flat
+    layout — it just means ``<model_dir>/norm_stats.json``.
     """
-    document = json.loads((Path(model_dir) / "norm_stats.json").read_text())
+    if path is None:
+        if model_dir is None:
+            raise TypeError("load_norm_stats needs either model_dir or path")
+        path = Path(model_dir) / "norm_stats.json"
+    path = Path(path)
+    document = json.loads(path.read_text())
     stats = document.get("norm_stats", document)
     if key not in stats:
-        raise KeyError(f"norm_stats.json has no entry {key!r}; keys: {sorted(stats)}")
+        raise KeyError(f"{path} has no entry {key!r}; keys: {sorted(stats)}")
     return stats[key]
 
 
@@ -185,8 +196,8 @@ def _finite(array: np.ndarray, who: str) -> np.ndarray:
     return array
 
 
-def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype):
-    stats = load_norm_stats(model_dir, key)
+def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path=None):
+    stats = load_norm_stats(model_dir, key, path=path)
     if mode == _QUANTILE:
         return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps, dtype=dtype)
     return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps, dtype=dtype)
@@ -212,8 +223,9 @@ class Unnormalizer(ProcessorStep):
         self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
+    def from_norm_stats(cls, model_dir=None, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None, *, path=None):
+        """Build from a ``norm_stats.json``; ``path`` names the file directly."""
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path)
 
     @property
     def width(self) -> int:
@@ -250,8 +262,9 @@ class Normalizer(ProcessorStep):
         self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
+    def from_norm_stats(cls, model_dir=None, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None, *, path=None):
+        """Build from a ``norm_stats.json``; ``path`` names the file directly."""
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype, path)
 
     @property
     def width(self) -> int:

--- a/python/apxinf/apxinf/processors/normalize.py
+++ b/python/apxinf/apxinf/processors/normalize.py
@@ -12,6 +12,11 @@ lerobot's ``Normalizer``:
 Both steps broadcast over the trailing axis, so a ``[horizon, dim]`` action
 chunk unnormalizes in one call. :meth:`from_norm_stats` reads the quantiles /
 moments straight out of a checkpoint's ``norm_stats.json``.
+
+Widths follow OpenPI's asymmetry: :class:`Unnormalizer` accepts an array *wider*
+than its stats and passes the extra tail through unchanged (a checkpoint's stats
+are the robot's width, the model emits its padded width), while
+:class:`Normalizer` requires an exact match.
 """
 
 from __future__ import annotations
@@ -44,7 +49,10 @@ def load_norm_stats(model_dir, key: str = "actions") -> dict:
 
 
 def _as_vector(values: Sequence[float], name: str, dims: Optional[int]) -> np.ndarray:
-    vector = np.asarray(values, dtype=np.float32)
+    # Kept at float64 (the dtype norm_stats.json parses to). The compute dtype is
+    # decided per call in :meth:`_AffineStats._check`, which downcasts these to
+    # float32 for float32 inputs -- bit-identical to storing them as float32.
+    vector = np.asarray(values, dtype=np.float64)
     if vector.ndim != 1:
         raise ValueError(f"{name} must be rank 1, got shape {vector.shape}")
     if dims is not None:
@@ -57,12 +65,15 @@ def _as_vector(values: Sequence[float], name: str, dims: Optional[int]) -> np.nd
 class _AffineStats:
     """Shared statistics + the two-mode affine math for (un)normalization."""
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
         if mode not in (_QUANTILE, _MEAN_STD):
             raise ValueError(f"mode must be {_QUANTILE!r} or {_MEAN_STD!r}, got {mode!r}")
         self.mode = mode
         self.dims = None if dims is None else int(dims)
         self.eps = float(eps)
+        self.dtype = None if dtype is None else np.dtype(dtype)
+        # dtype -> (q01, q99, mean, std) downcast to that dtype; see _stats_as.
+        self._cast_cache: dict = {}
         if mode == _QUANTILE:
             if q01 is None or q99 is None:
                 raise ValueError("quantile mode requires q01 and q99")
@@ -86,31 +97,86 @@ class _AffineStats:
     def width(self) -> int:
         return (self.q01 if self.mode == _QUANTILE else self.mean).size
 
-    def _check(self, array: np.ndarray, who: str) -> np.ndarray:
-        array = np.asarray(array, dtype=np.float32)
-        if array.shape[-1] != self.width:
+    def _check(self, array: np.ndarray, who: str, *, allow_wider: bool = False) -> tuple:
+        """Coerce ``array`` and the stats to a common compute dtype, checking width.
+
+        The default dtype is ``result_type(array, float32)``: float32 in stays
+        float32 (bit-identical to the previous float32-only implementation,
+        because the stats are downcast *before* the arithmetic), while float64 in
+        stays float64. That matters for the pi05 prompt path -- openpi's numpy
+        input chain runs in float64, so a float32 state would discretize to a
+        different bin whenever a normalized value lands within ~1e-7 of a bin
+        edge. An explicit ``dtype=`` pins the compute dtype regardless of the
+        input, which is how a caller reproduces openpi's *output* chain: there
+        the stats stay float64 (they are parsed from JSON and never downcast), so
+        a float32 action array is promoted rather than the stats demoted.
+
+        ``allow_wider`` mirrors openpi's asymmetry: its ``Unnormalize`` widens
+        narrow stats by passing the tail through, its ``Normalize`` does not (a
+        wider array there is a broadcast error). See :meth:`unnormalize`.
+        """
+        array = np.asarray(array)
+        dtype = self.dtype if self.dtype is not None else np.result_type(array.dtype, np.float32)
+        array = array.astype(dtype, copy=False)
+        got = array.shape[-1]
+        if got < self.width or (got != self.width and not allow_wider):
             raise ValueError(
                 f"{who}: last dim must be {self.width}, got array shape {array.shape}"
             )
-        return array
+        return array, dtype
+
+    def _stats_as(self, dtype):
+        cached = self._cast_cache.get(dtype)
+        if cached is None:
+            cached = tuple(
+                None if v is None else v.astype(dtype, copy=False)
+                for v in (self.q01, self.q99, self.mean, self.std)
+            )
+            self._cast_cache[dtype] = cached
+        return cached
 
     def unnormalize(self, array: np.ndarray) -> np.ndarray:
-        array = self._check(array, "Unnormalizer")
+        """Map back to physical units, **passing a wider array's tail through**.
+
+        A checkpoint's ``norm_stats`` is computed from the dataset, so it is the
+        *robot's* width (16 for a Unitree G1) while the model emits its padded
+        width (32). openpi's ``Unnormalize._unnormalize_quantile`` handles that by
+        unnormalizing the head and concatenating ``x[..., dim:]`` verbatim; the
+        padded tail is unused downstream, so the passthrough exists to keep the
+        chain running rather than to produce meaningful numbers. Without it the
+        G1 path cannot serve a real 16-wide ``norm_stats.json`` at all.
+        """
+        array, dtype = self._check(array, "Unnormalizer", allow_wider=True)
+        head, tail = array[..., : self.width], array[..., self.width :]
+        q01, q99, mean, std = self._stats_as(dtype)
+        scalar = dtype.type
         if self.mode == _QUANTILE:
-            span = (self.q99 - self.q01 + np.float32(self.eps)) / np.float32(2.0)
-            out = (array + np.float32(1.0)) * span + self.q01
+            span = (q99 - q01 + scalar(self.eps)) / scalar(2.0)
+            out = (head + scalar(1.0)) * span + q01
         else:
-            out = array * self.std + self.mean
-        return _finite(out.astype(np.float32, copy=False), "Unnormalizer")
+            out = head * std + mean
+        if tail.shape[-1]:
+            out = np.concatenate([out, tail], axis=-1)
+        return _finite(out.astype(dtype, copy=False), "Unnormalizer")
 
     def normalize(self, array: np.ndarray) -> np.ndarray:
-        array = self._check(array, "Normalizer")
+        """Map to the normalized domain. Width must match exactly.
+
+        No tail passthrough here, matching openpi: its ``Normalize`` slices the
+        stats to the array width, which broadcast-fails on an array *wider* than
+        the stats. The input chain never hits that case anyway --
+        ``PadStatesAndActions`` runs after ``Normalize``, so state is still the
+        robot's width when it is normalized.
+        """
+        array, dtype = self._check(array, "Normalizer")
+        q01, q99, mean, std = self._stats_as(dtype)
+        scalar = dtype.type
         if self.mode == _QUANTILE:
-            span = self.q99 - self.q01 + np.float32(self.eps)
-            out = np.float32(2.0) * (array - self.q01) / span - np.float32(1.0)
+            span = q99 - q01 + scalar(self.eps)
+            out = scalar(2.0) * (array - q01) / span - scalar(1.0)
         else:
-            out = (array - self.mean) / self.std
-        return _finite(out.astype(np.float32, copy=False), "Normalizer")
+            out = (array - mean) / std
+        return _finite(out.astype(dtype, copy=False), "Normalizer")
 
 
 def _finite(array: np.ndarray, who: str) -> np.ndarray:
@@ -119,25 +185,35 @@ def _finite(array: np.ndarray, who: str) -> np.ndarray:
     return array
 
 
-def _from_norm_stats(cls, model_dir, key, mode, dims, eps):
+def _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype):
     stats = load_norm_stats(model_dir, key)
     if mode == _QUANTILE:
-        return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps)
-    return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps)
+        return cls(q01=stats["q01"], q99=stats["q99"], mode=mode, dims=dims, eps=eps, dtype=dtype)
+    return cls(mean=stats["mean"], std=stats["std"], mode=mode, dims=dims, eps=eps, dtype=dtype)
 
 
 class Unnormalizer(ProcessorStep):
-    """Map a normalized-domain array back to physical units (last axis)."""
+    """Map a normalized-domain array back to physical units (last axis).
 
-    PARAMS = ("eps",)
+    An array wider than :attr:`width` keeps its tail unchanged, mirroring
+    OpenPI — see :meth:`_AffineStats.unnormalize`. A narrower one is an error.
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
-        self._stats = _AffineStats(q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps)
+    ``dtype`` pins the compute dtype; the default follows the input (see
+    :meth:`_AffineStats._check`).
+    """
+
+    PARAMS = ("eps", "dtype")
+
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
+        self._stats = _AffineStats(
+            q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps, dtype=dtype
+        )
         self.eps = self._stats.eps
+        self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps)
+    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
 
     @property
     def width(self) -> int:
@@ -149,23 +225,33 @@ class Unnormalizer(ProcessorStep):
     def _apply_overrides(self, overrides: dict) -> None:
         super()._apply_overrides(overrides)
         # ``with_overrides`` shallow-copied us, so ``_stats`` is still shared with
-        # the original; copy it before tweaking eps to avoid mutating the source.
+        # the original; copy it before tweaking the knobs to avoid mutating the
+        # source. ``_cast_cache`` is keyed by dtype, so sharing it stays correct.
         self._stats = copy.copy(self._stats)
         self._stats.eps = self.eps
+        self.dtype = None if self.dtype is None else np.dtype(self.dtype)
+        self._stats.dtype = self.dtype
 
 
 class Normalizer(ProcessorStep):
-    """Map a physical-units array to the normalized domain (last axis)."""
+    """Map a physical-units array to the normalized domain (last axis).
 
-    PARAMS = ("eps",)
+    ``dtype`` pins the compute dtype; the default follows the input (see
+    :meth:`_AffineStats._check`).
+    """
 
-    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6):
-        self._stats = _AffineStats(q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps)
+    PARAMS = ("eps", "dtype")
+
+    def __init__(self, *, q01=None, q99=None, mean=None, std=None, mode=_QUANTILE, dims=None, eps=1e-6, dtype=None):
+        self._stats = _AffineStats(
+            q01=q01, q99=q99, mean=mean, std=std, mode=mode, dims=dims, eps=eps, dtype=dtype
+        )
         self.eps = self._stats.eps
+        self.dtype = self._stats.dtype
 
     @classmethod
-    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6):
-        return _from_norm_stats(cls, model_dir, key, mode, dims, eps)
+    def from_norm_stats(cls, model_dir, key: str = "actions", mode: str = _QUANTILE, dims=None, eps=1e-6, dtype=None):
+        return _from_norm_stats(cls, model_dir, key, mode, dims, eps, dtype)
 
     @property
     def width(self) -> int:
@@ -178,3 +264,5 @@ class Normalizer(ProcessorStep):
         super()._apply_overrides(overrides)
         self._stats = copy.copy(self._stats)
         self._stats.eps = self.eps
+        self.dtype = None if self.dtype is None else np.dtype(self.dtype)
+        self._stats.dtype = self.dtype

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -20,7 +20,13 @@ camera rename + CHW->HWC       ``image_keys`` config + ``ParseImage`` (already
 ===========================  ==============================================
 
 These steps are model-agnostic — they reference no policy symbols and vary only
-with the G1 body. The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
+with the G1 body. They are also **dataset-agnostic**: the G1 client's wire keys
+(``images/cam_high``, a flat ``state``) are a recording convention, so they live
+in :mod:`apxinf.conventions` and reach these steps as arguments. What is left
+here is arithmetic that changes only if the hardware does — the 16-DoF layout,
+the delta mask, the gripper and joint-sign conventions.
+
+The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
 adapter wraps them around whichever policy the checkpoint turns out to be, using
 :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter`; it names no model
 class either.
@@ -46,22 +52,9 @@ __all__ = [
     "UnitreeG1DecodeState",
     "UnitreeG1AbsoluteActions",
     "UnitreeG1EncodeActions",
-    "G1_CAMERAS",
-    "G1_STATE_KEY",
     "G1_ROBOT_DIM",
     "G1_DELTA_MASK",
 ]
-
-#: G1 camera **wire keys**, ordered base / left-wrist / right-wrist to match the
-#: model's view slots (openpi ``base_0_rgb`` / ``left_wrist_0_rgb`` /
-#: ``right_wrist_0_rgb``). These are the keys an unmodified openpi G1 client
-#: sends, i.e. the nested ``obs["images"]["cam_high"]`` layout, spelled as a path
-#: for :func:`~apxinf.processors.transforms.lookup_key`.
-G1_CAMERAS = ("images/cam_high", "images/cam_left_wrist", "images/cam_right_wrist")
-
-#: G1 state wire key. openpi's G1 client sends a flat top-level ``"state"``, not
-#: LIBERO's ``"observation/state"``.
-G1_STATE_KEY = "state"
 
 #: G1 state/action layout: [L-arm 7, L-gripper 1, R-arm 7, R-gripper 1].
 G1_ROBOT_DIM = 16
@@ -111,9 +104,14 @@ class UnitreeG1DecodeState(ProcessorStep):
     and the delta->absolute output step both see the decoded state. Operates on a
     shallow copy of the observation so the caller's dict is left untouched. A
     no-op when no state is present (state-off serving).
+
+    ``state_key`` is required and has no default: which key carries state is a
+    property of the *convention* the data was recorded under
+    (:mod:`apxinf.conventions`), not of this body, and a default here would be
+    one dataset's dialect built into a robot's arithmetic.
     """
 
-    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 
@@ -138,9 +136,11 @@ class UnitreeG1AbsoluteActions(ProcessorStep):
     decoded state; gripper dims are already absolute and pass through. Reads the
     unnormalized ``actions`` and the decoded ``observation`` state threaded in by
     ``Pi05Policy.infer``. A no-op when state is absent (delta cannot be resolved).
+    ``state_key`` is required for the same reason as in
+    :class:`UnitreeG1DecodeState`.
     """
 
-    def __init__(self, state_key: str = G1_STATE_KEY, *, observation_key: str = OBSERVATION):
+    def __init__(self, state_key: str, *, observation_key: str = OBSERVATION):
         self.state_key = state_key
         self.observation_key = observation_key
 

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -21,7 +21,9 @@ camera rename + CHW->HWC       ``image_keys`` config + ``ParseImage`` (already
 
 These steps are model-agnostic — they reference no policy symbols and vary only
 with the G1 body. The :func:`~apxinf.robots.unitree_g1.build_unitree_g1_policy`
-adapter assembles them with a :class:`~apxinf.policies.impls.pi05.Pi05Policy`.
+adapter wraps them around whichever policy the checkpoint turns out to be, using
+:meth:`~apxinf.policies.base.ComposablePolicy.with_adapter`; it names no model
+class either.
 
 .. note::
    The joint-flip mask and gripper transforms in the integrator's file are

--- a/python/apxinf/apxinf/processors/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/processors/robots/unitree_g1.py
@@ -66,8 +66,14 @@ def _joint_flip_mask() -> np.ndarray:
 
     All ``+1`` in the integrator's file (a documented placeholder). Kept as the
     hook for real left/right mirror calibration.
+
+    Integer dtype on purpose, matching openpi's ``np.array([1, 1, ...])``: these
+    are exact signs, and the ``int64 * float32 -> float64`` promotion is what
+    puts openpi's whole G1 input chain in float64. Reproducing it is what makes
+    our discretized prompt bit-identical to theirs (see
+    :func:`~apxinf.processors.tokenize.discretize_state`).
     """
-    return np.ones(G1_ROBOT_DIM, dtype=np.float32)
+    return np.ones(G1_ROBOT_DIM, dtype=np.int64)
 
 
 def _gripper_to_angular(value: np.ndarray) -> np.ndarray:
@@ -122,7 +128,11 @@ class UnitreeG1DecodeState(ProcessorStep):
         raw = lookup_key(observation, self.state_key, None)
         if raw is None:
             return data
-        state = np.asarray(raw, dtype=np.float32) * _joint_flip_mask()
+        raw = np.asarray(raw)
+        # Promote to at least float32 before the flip so an integer state cannot
+        # be truncated by the gripper clip (openpi has no such guard). The int64
+        # flip mask then promotes the product to float64, matching openpi.
+        state = raw.astype(np.result_type(raw.dtype, np.float32), copy=False) * _joint_flip_mask()
         idx = list(_GRIPPER_INDICES)
         state[idx] = _gripper_to_angular(state[idx])
         data[self.observation_key] = set_key(observation, self.state_key, state)
@@ -149,9 +159,13 @@ class UnitreeG1AbsoluteActions(ProcessorStep):
         state = lookup_key(observation, self.state_key, None)
         if state is None:
             return data
-        actions = np.asarray(data[ACTIONS], dtype=np.float32).copy()
-        state = np.asarray(state, dtype=np.float32)[:G1_ROBOT_DIM]
-        offset = np.where(G1_DELTA_MASK, state, 0.0)
+        # Both operands keep their own dtype: openpi's output chain is float64
+        # end to end (its stats are float64 and its flip mask is int64), so
+        # coercing either side to float32 here would reintroduce the ~2e-7
+        # divergence the rest of the G1 path was aligned to remove (A15).
+        actions = np.array(data[ACTIONS], copy=True)
+        state = np.asarray(state)[:G1_ROBOT_DIM]
+        offset = np.where(G1_DELTA_MASK, state, state.dtype.type(0))
         actions[:, :G1_ROBOT_DIM] = actions[:, :G1_ROBOT_DIM] + offset
         data[ACTIONS] = actions
         return data
@@ -165,7 +179,13 @@ class UnitreeG1EncodeActions(ProcessorStep):
     """
 
     def __call__(self, data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        actions = np.asarray(data[ACTIONS], dtype=np.float32)[:, :G1_ROBOT_DIM] * _joint_flip_mask()
+        # No dtype coercion, in either direction. The +-1 flip is exact in any
+        # float dtype, but the int64 mask promotes a float32 input to float64 --
+        # which is precisely what openpi's ``_encode_actions`` does, so its G1
+        # server puts float64 actions on the wire. Matching that keeps the two
+        # servers' outputs comparable bit for bit (A15); an openpi G1 client
+        # reads the dtype off the msgpack payload either way.
+        actions = np.asarray(data[ACTIONS])[:, :G1_ROBOT_DIM] * _joint_flip_mask()
         idx = list(_GRIPPER_INDICES)
         actions[:, idx] = _gripper_from_angular(actions[:, idx])
         data[ACTIONS] = np.ascontiguousarray(actions)

--- a/python/apxinf/apxinf/processors/tokenize.py
+++ b/python/apxinf/apxinf/processors/tokenize.py
@@ -9,7 +9,7 @@ State injection (proprioception) is a **reserved** capability, matching the Rust
 ``pi05_prompt`` / ``discretize_state`` path but **off by default** so behavior is
 identical to the current serving link. When ``discrete_state=True`` the prompt
 becomes ``"Task: {task}, State: {s0 s1 ...};\nAction: "`` with the state
-discretized to ``0..=255`` — see :func:`discretize_state`. sentencepiece is
+discretized to ``-1..=255`` — see :func:`discretize_state`. sentencepiece is
 imported lazily so the rest of the processor library stays importable without it.
 """
 
@@ -24,16 +24,46 @@ from .base import ProcessorStep
 __all__ = ["PromptTokenizer", "SyntheticTokenizer", "discretize_state", "build_prompt"]
 
 
-def discretize_state(state: Sequence[float]) -> np.ndarray:
-    """Discretize a normalized state to ``uint8`` bins in ``0..=255``.
+#: The 256 bin edges openpi discretizes against, ``linspace(-1, 1, 257)[:-1]``.
+#: Every edge is ``-1 + i/128``, exact in binary floating point, so a comparison
+#: against one is exact — which is the whole reason :func:`discretize_state`
+#: compares instead of computing an index.
+_BIN_EDGES = np.linspace(-1.0, 1.0, 256 + 1)[:-1]
 
-    Matches NumPy ``digitize(state, linspace(-1, 1, 257)[:-1]) - 1`` with
-    saturation, i.e. the Rust ``discretize_state``:
-    ``clamp(floor((v + 1) * 128), 0, 255)``.
+
+def discretize_state(state: Sequence[float]) -> np.ndarray:
+    """Discretize a normalized state into the pi05 prompt's integer bins.
+
+    Reproduces NumPy ``digitize(state, linspace(-1, 1, 257)[:-1]) - 1``
+    *exactly*, including its **signed underflow bin**: ``digitize`` returns ``0``
+    for ``v < -1``, so the bin is ``-1``. openpi writes that ``-1`` verbatim into
+    the prompt (``models/tokenizer.py``), so it is a value the model saw during
+    training and must not be clamped away — hence ``int16``, not ``uint8``.
+    Values ``>= 1`` do saturate, to ``255``.
+
+    Normalized state *does* leave ``[-1, 1]`` on real hardware, because q01/q99
+    come from the training split; on the customer's own G1 validation set 7 of
+    3200 elements underflow. Clamping them to ``0`` changes the prompt string,
+    hence the token ids, hence the whole rollout.
+
+    Implemented as a search over the edges rather than the arithmetic
+    ``floor((v + 1) * 128)``, because that expression is not equal to
+    ``digitize`` for every input. Adding ``1.0`` to a value just under an edge in
+    ``[-1, -0.5)`` moves it into a coarser binade and the sum rounds *up* onto
+    the edge, putting it one bin too high::
+
+        v = nextafter(-0.4921875, -inf)     # one ulp below bin edge 65
+        v + 1.0 == 0.5078125                # exactly, by round-half-to-even
+        floor((v + 1.0) * 128) == 65        # wrong
+        digitize(v, edges) - 1  == 64       # right
+
+    ``searchsorted(..., side="right")`` is what ``digitize`` calls for increasing
+    bins, so this is the same comparison openpi makes, with no arithmetic on
+    ``v`` to round.
     """
     values = np.asarray(state, dtype=np.float64)
-    bins = np.floor((values + 1.0) * 128.0)
-    return np.clip(bins, 0, 255).astype(np.uint8)
+    bins = np.searchsorted(_BIN_EDGES, values, side="right") - 1
+    return bins.astype(np.int16)
 
 
 def _clean_task(prompt: str) -> str:

--- a/python/apxinf/apxinf/processors/transforms.py
+++ b/python/apxinf/apxinf/processors/transforms.py
@@ -214,7 +214,12 @@ class Tokenize(ProcessorStep):
             observation = _require(data, self.observation_key, "Tokenize")
             state = lookup_key(observation, self.state_key, None)
             if self.state_normalizer is not None and state is not None:
-                state = self.state_normalizer(np.asarray(state, dtype=np.float32))
+                # No dtype coercion: the state only ever reaches the model as
+                # prompt tokens, and openpi normalizes/discretizes it in whatever
+                # dtype its own transforms produced (float64 for adapt_to_pi
+                # robots). Forcing float32 here shifts values by ~1e-7, which is
+                # enough to land on the other side of a discretization bin edge.
+                state = self.state_normalizer(np.asarray(state))
             data[TOKEN_IDS] = self.tokenizer(prompt, state=state)
         else:
             data[TOKEN_IDS] = self.tokenizer(prompt)

--- a/python/apxinf/apxinf/processors/transforms.py
+++ b/python/apxinf/apxinf/processors/transforms.py
@@ -26,7 +26,7 @@ steps' keys.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping, Sequence
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
 import numpy as np
 
@@ -178,17 +178,30 @@ class Tokenize(ProcessorStep):
     Mirrors the policy's old state routing: when the tokenizer runs in
     ``discrete_state`` mode and a ``state_normalizer`` is set, the raw state is
     first mapped to ``[-1, 1]`` before discretization; otherwise state is dropped.
+
+    ``state_key`` has no default. It names a *dataset's* wire key, and this layer
+    has no business guessing one: ``"observation/state"`` used to be the default,
+    which is LIBERO's dialect quietly applied to every robot. ``None`` is allowed
+    only when the tokenizer does not read state at all, and is rejected when it
+    does — dropping proprioception silently is the failure this guards.
     """
 
     def __init__(
         self,
         tokenizer,
         state_normalizer=None,
-        state_key: str = "observation/state",
+        state_key: Optional[str] = None,
         *,
         observation_key: str = OBSERVATION,
         prompt_key: str = PROMPT,
     ):
+        if state_key is None and getattr(tokenizer, "discrete_state", False):
+            raise ValueError(
+                "Tokenize: the tokenizer discretizes state into the prompt but no "
+                "state_key was given, so there is no key to read it from. Name the "
+                "wire key your client sends (see apxinf.conventions), or use a "
+                "tokenizer with discrete_state=False to drop state deliberately."
+            )
         self.tokenizer = tokenizer
         self.state_normalizer = state_normalizer
         self.state_key = state_key

--- a/python/apxinf/apxinf/robots/__init__.py
+++ b/python/apxinf/apxinf/robots/__init__.py
@@ -7,11 +7,14 @@ A *robot adapter* binds that generic core to one robot by wiring the robot's
 :class:`~apxinf.processors.Pipeline` and loading its checkpoint / norm_stats.
 
 This is the top assembly layer: it depends *downward* on both
-:mod:`apxinf.policies` (the model) and :mod:`apxinf.processors` (the steps).
-Neither depends back on it, so adding a robot never touches the policy or
-processor packages — you write steps under ``processors/robots/`` and a
-``build_*`` factory here, then register both in :mod:`apxinf.robots.presets` so
-they are reachable as ``--robot <name>`` at serving time.
+:mod:`apxinf.policies` (the model) and :mod:`apxinf.processors` (the steps), and
+sideways on :mod:`apxinf.conventions` (the dataset dialect a preset pairs with a
+body). None of them depends back, so adding a robot never touches the policy,
+processor, or convention packages — you write steps under ``processors/robots/``
+and a ``build_*`` factory here, then register both in :mod:`apxinf.robots.presets`
+(or from your own package via
+:func:`~apxinf.robots.presets.register_robot_preset`) so they are reachable as
+``--robot <name>`` at serving time.
 """
 
 from __future__ import annotations
@@ -19,19 +22,25 @@ from __future__ import annotations
 from .presets import (
     ROBOT_PRESETS,
     VIEW_SLOTS,
+    Convention,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
     "build_unitree_g1_policy",
+    "Embodiment",
+    "Convention",
     "RobotPreset",
     "ROBOT_PRESETS",
     "VIEW_SLOTS",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
 ]

--- a/python/apxinf/apxinf/robots/__init__.py
+++ b/python/apxinf/apxinf/robots/__init__.py
@@ -19,6 +19,7 @@ and a ``build_*`` factory here, then register both in :mod:`apxinf.robots.preset
 
 from __future__ import annotations
 
+from .preflight import Finding, check_checkpoint, format_findings
 from .presets import (
     ROBOT_PRESETS,
     VIEW_SLOTS,
@@ -43,4 +44,7 @@ __all__ = [
     "get_robot_preset",
     "register_robot_preset",
     "build_robot_policy",
+    "Finding",
+    "check_checkpoint",
+    "format_findings",
 ]

--- a/python/apxinf/apxinf/robots/preflight.py
+++ b/python/apxinf/apxinf/robots/preflight.py
@@ -1,0 +1,282 @@
+"""Startup checks: does this checkpoint actually match the preset serving it?
+
+A checkpoint directory and a ``--robot`` preset are two independent claims about
+the same robot, and nothing forces them to agree. Serve a Unitree G1 checkpoint
+with a LIBERO ``norm_stats.json`` and ``--action-dim 7`` and every layer accepts
+it: the weights load, the tokenizer runs, the unnormalizer finds ``q01``/``q99``
+of *some* width, the server publishes an action shape, and the robot receives 7
+plausible-looking floats per step that mean nothing. The only visible symptom is
+that the model "got worse" — which reads as a model problem, gets escalated as a
+model problem, and is not one.
+
+That exact combination shipped. This module is the check that would have refused
+it, phrased as a list of :class:`Finding` s rather than an exception, so a caller
+can report all of them at once instead of fixing them one crash at a time.
+
+**What is checked here** is what can be read from the checkpoint *directory* with
+the standard library: ``norm_stats.json`` widths and keys, and the tokenizer
+file. The richer cross-check against openpi's own ``metadata.pt`` (its serialized
+``TrainConfig``: ``adapt_to_pi``, ``use_delta_joint_actions``, the repack wire
+keys, ``discrete_state_input``) needs torch to unpickle and lives in
+``scripts/openpi_metadata_to_apxinf.py``, which calls this module and adds to it.
+
+**What is deliberately not checked here** is anything already enforced elsewhere:
+``len(image_keys) == model.num_views`` raises inside
+:class:`~apxinf.policies.impls.pi05.Pi05Policy`, and the unnormalizer's own width
+rules live in :mod:`apxinf.processors.normalize`. Duplicating them would mean two
+places to keep in step.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from .presets import RobotPreset, get_robot_preset
+
+__all__ = ["Finding", "FAIL", "WARN", "INFO", "check_checkpoint", "format_findings"]
+
+#: A mismatch that makes the served actions meaningless. Refuse to start.
+FAIL = "FAIL"
+#: A mismatch that is survivable but is very likely not what the operator meant.
+WARN = "WARN"
+#: Context worth printing, not a problem.
+INFO = "INFO"
+
+_ORDER = {FAIL: 0, WARN: 1, INFO: 2}
+
+#: Tokenizer filenames :func:`apxinf.policies.impls.pi05._resolve_tokenizer`
+#: looks for. Kept as a literal rather than imported so this module stays
+#: importable without the CUDA binding that ``pi05`` pulls in.
+TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One check result: its severity, what it looked at, and what to do."""
+
+    level: str
+    check: str
+    detail: str
+    #: What the operator should change. Empty for :data:`INFO`.
+    remedy: str = ""
+
+    def __str__(self) -> str:
+        line = f"[{self.level:4}] {self.check}: {self.detail}"
+        return f"{line}\n         -> {self.remedy}" if self.remedy else line
+
+
+def _width(stats: dict, key: str) -> Optional[int]:
+    """Length of any one of the four stat vectors, or ``None`` if unreadable."""
+    for name in ("q01", "q99", "mean", "std"):
+        value = stats.get(name)
+        if isinstance(value, (list, tuple)):
+            return len(value)
+    return None
+
+
+def _check_norm_stats(
+    model_dir: Path, preset: RobotPreset, *, norm_key: str, discrete_state: bool
+) -> List[Finding]:
+    """The A1 check: are the shipped statistics this robot's statistics?"""
+    path = model_dir / "norm_stats.json"
+    if not path.exists():
+        return [
+            Finding(
+                FAIL,
+                "norm_stats.json",
+                f"missing from {model_dir}",
+                "unnormalization has no statistics to use; ship the file with the checkpoint",
+            )
+        ]
+    try:
+        document = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        return [Finding(FAIL, "norm_stats.json", f"unreadable: {exc}", "fix or re-export the file")]
+
+    stats = document.get("norm_stats", document)
+    findings: List[Finding] = []
+
+    # Width per key against what the preset says the robot is. This is the check
+    # that catches a G1 checkpoint carrying LIBERO statistics: 16-dim robot,
+    # 8/7-dim stats. Both directions are fatal -- too narrow and the unnormalizer
+    # refuses the array outright, too wide and it silently unnormalizes dimensions
+    # the robot does not have.
+    for key, expected in (
+        (norm_key, preset.action_width),
+        ("state", preset.state_dim if discrete_state else None),
+    ):
+        if expected is None:
+            continue
+        entry = stats.get(key)
+        if not isinstance(entry, dict):
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}]",
+                    f"absent; file has {sorted(stats)}",
+                    f"{preset.name} needs {key!r} statistics"
+                    + ("" if key == norm_key else " because state is discretized into the prompt"),
+                )
+            )
+            continue
+        got = _width(entry, key)
+        if got is None:
+            findings.append(
+                Finding(FAIL, f"norm_stats[{key!r}]", "has no vector-valued stat", "re-export"),
+            )
+        elif got != expected:
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}] width",
+                    f"{got}, but preset {preset.name!r} is a {expected}-dim robot",
+                    f"these statistics are not this robot's. Serving them maps the "
+                    f"model's output through the wrong physical range -- the actions "
+                    f"stay in range and stay wrong. Point --model-dir at a checkpoint "
+                    f"whose norm_stats.json is {expected} wide.",
+                )
+            )
+        else:
+            findings.append(Finding(INFO, f"norm_stats[{key!r}] width", f"{got}, matches preset"))
+
+        # pi05 is always quantile-normalized (openpi derives this from the model
+        # type, not from any file: `use_quantile_norm = model_type != PI0`), so
+        # q01/q99 are the stats that actually get used. openpi asserts their
+        # presence; apxinf's Unnormalizer would raise a KeyError instead.
+        if isinstance(entry, dict) and not ("q01" in entry and "q99" in entry):
+            findings.append(
+                Finding(
+                    FAIL,
+                    f"norm_stats[{key!r}] quantiles",
+                    f"no q01/q99; has {sorted(entry)}",
+                    "pi05 always unnormalizes with quantiles regardless of what any "
+                    "config says (openpi training/config.py: use_quantile_norm = "
+                    "model_type != PI0). mean/std alone cannot serve this checkpoint.",
+                )
+            )
+    return findings
+
+
+def _check_tokenizer(model_dir: Path, tokenizer_path) -> List[Finding]:
+    """The A14 check: is there a tokenizer to load, and is it the *same* one?"""
+    if tokenizer_path is not None:
+        path = Path(tokenizer_path)
+        if not path.exists():
+            return [
+                Finding(FAIL, "tokenizer", f"--tokenizer {path} does not exist", "fix the path")
+            ]
+        return [Finding(INFO, "tokenizer", f"{path} (explicit)")]
+
+    found = [name for name in TOKENIZER_NAMES if (model_dir / name).exists()]
+    if found:
+        return [Finding(INFO, "tokenizer", f"{model_dir / found[0]}")]
+    return [
+        Finding(
+            FAIL,
+            "tokenizer",
+            f"none of {list(TOKENIZER_NAMES)} in {model_dir}",
+            "the checkpoint does not carry its tokenizer. openpi downloads "
+            "paligemma_tokenizer.model at runtime, so a checkpoint exported from it "
+            "will not have one. Copy it into the checkpoint directory or pass "
+            "--tokenizer. Both servers must use the *same* file or their token ids "
+            "are not comparable.",
+        )
+    ]
+
+
+def _check_cameras(preset: RobotPreset, image_keys: Sequence[str]) -> List[Finding]:
+    """Camera count and ordering against the preset's declared view slots."""
+    keys = tuple(image_keys)
+    if keys == preset.image_keys:
+        return [Finding(INFO, "cameras", f"{len(keys)} views, preset keys unchanged")]
+    if len(keys) != preset.num_views:
+        return [
+            Finding(
+                WARN,
+                "cameras",
+                f"serving {len(keys)} views {list(keys)} but preset {preset.name!r} "
+                f"declares {preset.num_views} {list(preset.image_keys)}",
+                "the checkpoint was trained with a fixed number of view slots; pass "
+                "--num-views to load it for fewer, or drop the --image-keys override",
+            )
+        ]
+    return [
+        Finding(
+            WARN,
+            "cameras",
+            f"--image-keys overrides the preset: {list(keys)} instead of "
+            f"{list(preset.image_keys)}",
+            "entry i fills model view slot i, so a reordered tuple silently feeds "
+            "the wrong camera to each slot. Confirm the order matches "
+            f"{[slot for slot, _ in preset.slots]}.",
+        )
+    ]
+
+
+def check_checkpoint(
+    model_dir,
+    robot: str,
+    *,
+    norm_key: str = "actions",
+    discrete_state: Optional[bool] = None,
+    image_keys: Optional[Sequence[str]] = None,
+    action_dim: Optional[int] = None,
+    tokenizer_path=None,
+) -> Tuple[Finding, ...]:
+    """Check a checkpoint directory against the preset that will serve it.
+
+    Takes the *resolved* serving knobs (what the server settled on after applying
+    its overrides), not the raw command line, so what is checked is what will
+    actually run. Returns findings sorted most-severe first; an empty tuple is
+    impossible because passing checks are reported as :data:`INFO`.
+    """
+    model_dir = Path(model_dir)
+    preset = get_robot_preset(robot)
+    discrete = preset.discrete_state if discrete_state is None else bool(discrete_state)
+    keys = preset.image_keys if image_keys is None else tuple(image_keys)
+
+    findings = [
+        *_check_norm_stats(model_dir, preset, norm_key=norm_key, discrete_state=discrete),
+        *_check_tokenizer(model_dir, tokenizer_path),
+        *_check_cameras(preset, keys),
+    ]
+
+    if action_dim is not None and preset.action_width is not None and action_dim != preset.action_width:
+        findings.append(
+            Finding(
+                WARN,
+                "action_dim",
+                f"--action-dim {action_dim} overrides preset {preset.name!r}'s "
+                f"{preset.action_width}",
+                "a width the robot does not have gets truncated or padded somewhere "
+                "downstream without an error. Drop the flag unless the deployed "
+                "client genuinely expects this width.",
+            )
+        )
+    if discrete and not preset.discrete_state:
+        findings.append(
+            Finding(INFO, "discrete_state", "enabled by override; preset default is off")
+        )
+    elif not discrete and preset.discrete_state:
+        findings.append(
+            Finding(
+                WARN,
+                "discrete_state",
+                f"disabled by override, but preset {preset.name!r} discretizes state "
+                "into the prompt",
+                "state is not merely un-discretized, it is *dropped*: the model sees "
+                "no proprioception, and any delta->absolute output step becomes a "
+                "no-op because it has no base to add.",
+            )
+        )
+
+    return tuple(sorted(findings, key=lambda f: _ORDER.get(f.level, 3)))
+
+
+def format_findings(findings: Sequence[Finding], *, include_info: bool = True) -> str:
+    """Render findings for a log or a terminal, most severe first."""
+    shown = [f for f in findings if include_info or f.level != INFO]
+    return "\n".join(str(f) for f in shown)

--- a/python/apxinf/apxinf/robots/preflight.py
+++ b/python/apxinf/apxinf/robots/preflight.py
@@ -14,10 +14,11 @@ it, phrased as a list of :class:`Finding` s rather than an exception, so a calle
 can report all of them at once instead of fixing them one crash at a time.
 
 **What is checked here** is what can be read from the checkpoint *directory* with
-the standard library: ``norm_stats.json`` widths and keys, and the tokenizer
-file. The richer cross-check against openpi's own ``metadata.pt`` (its serialized
-``TrainConfig``: ``adapt_to_pi``, ``use_delta_joint_actions``, the repack wire
-keys, ``discrete_state_input``) needs torch to unpickle and lives in
+the standard library: which layout it is, where its ``norm_stats.json`` actually
+lives, that file's widths and keys, and the tokenizer. Nothing loads a weight and
+nothing imports torch or the CUDA binding, so these checks run before the
+expensive part of startup — and on a laptop. The richer cross-check against the
+preset's own wire keys and delta convention lives in
 ``scripts/openpi_metadata_to_apxinf.py``, which calls this module and adds to it.
 
 **What is deliberately not checked here** is anything already enforced elsewhere:
@@ -35,6 +36,14 @@ from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 from .presets import RobotPreset, get_robot_preset
+from ..checkpoints import (
+    CheckpointError,
+    CheckpointLayout,
+    TOKENIZER_NAMES,
+    detect_checkpoint,
+    has_layout_metadata,
+    require_norm_stats,
+)
 
 __all__ = ["Finding", "FAIL", "WARN", "INFO", "check_checkpoint", "format_findings"]
 
@@ -46,11 +55,6 @@ WARN = "WARN"
 INFO = "INFO"
 
 _ORDER = {FAIL: 0, WARN: 1, INFO: 2}
-
-#: Tokenizer filenames :func:`apxinf.policies.impls.pi05._resolve_tokenizer`
-#: looks for. Kept as a literal rather than imported so this module stays
-#: importable without the CUDA binding that ``pi05`` pulls in.
-TOKENIZER_NAMES = ("tokenizer.model", "paligemma_tokenizer.model")
 
 
 @dataclass(frozen=True)
@@ -77,27 +81,105 @@ def _width(stats: dict, key: str) -> Optional[int]:
     return None
 
 
-def _check_norm_stats(
-    model_dir: Path, preset: RobotPreset, *, norm_key: str, discrete_state: bool
-) -> List[Finding]:
-    """The A1 check: are the shipped statistics this robot's statistics?"""
-    path = model_dir / "norm_stats.json"
-    if not path.exists():
-        return [
+def _check_layout(layout: CheckpointLayout) -> List[Finding]:
+    """Report what the directory says it is, before anything reads it.
+
+    The layout decides which ``norm_stats.json`` gets used, so an operator who
+    can see the chosen path can spot the wrong-statistics failure by eye — which
+    is the one failure mode this whole module exists for.
+    """
+    findings = [Finding(INFO, "checkpoint layout", f"{layout.format} ({layout.root})")]
+    if layout.asset_id:
+        findings.append(
             Finding(
-                FAIL,
-                "norm_stats.json",
-                f"missing from {model_dir}",
-                "unnormalization has no statistics to use; ship the file with the checkpoint",
+                INFO,
+                "asset_id",
+                f"{layout.asset_id!r} (from {layout.asset_id_source or 'metadata.pt'})",
             )
-        ]
+        )
+    if layout.arch:
+        rendered = ", ".join(f"{k}={v}" for k, v in sorted(layout.arch.items()))
+        findings.append(Finding(INFO, "architecture", f"from metadata.pt: {rendered}"))
+    for note in layout.notes:
+        findings.append(Finding(INFO, "checkpoint layout", note))
+    return findings
+
+
+def _check_norm_stats(
+    model_dir: Path,
+    preset: RobotPreset,
+    *,
+    norm_key: str,
+    discrete_state: bool,
+    layout: Optional[CheckpointLayout] = None,
+    norm_stats=None,
+) -> List[Finding]:
+    """Are the shipped statistics this robot's statistics?
+
+    ``layout`` supplies the resolved path. An openpi export keeps its statistics
+    under ``assets/<asset_id>/``, so reading ``<model_dir>/norm_stats.json``
+    unconditionally is how the wrong file got checked *and* served: whatever a
+    previous run happened to leave in the root. With no layout — a flat directory
+    that declares nothing — ``norm_stats`` still names the file directly, which
+    is what :meth:`Pi05Policy.from_pretrained` does in the same situation.
+    """
+    findings: List[Finding] = []
+    if layout is not None:
+        try:
+            path = require_norm_stats(layout)
+        except CheckpointError as exc:
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    str(exc),
+                    "unnormalization has no statistics to use; ship the file with the "
+                    "checkpoint or point --norm-stats at it",
+                )
+            ]
+        if layout.norm_stats_is_fallback:
+            findings.append(
+                Finding(
+                    WARN,
+                    "norm_stats.json",
+                    f"using the checkpoint root {path} because {layout.norm_stats_tried[0]} "
+                    f"(openpi's path for asset_id={layout.asset_id!r}) does not exist",
+                    "verify these statistics belong to this robot. A file from another "
+                    "run is syntactically valid and unnormalizes silently; the width "
+                    "check below is the only thing that would catch it.",
+                )
+            )
+        else:
+            findings.append(Finding(INFO, "norm_stats.json", str(path)))
+    elif norm_stats is not None:
+        path = Path(norm_stats)
+        if not path.is_file():
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    f"--norm-stats {path} does not exist",
+                    "fix the path",
+                )
+            ]
+        findings.append(Finding(INFO, "norm_stats.json", f"{path} (explicit)"))
+    else:
+        path = model_dir / "norm_stats.json"
+        if not path.exists():
+            return [
+                Finding(
+                    FAIL,
+                    "norm_stats.json",
+                    f"missing from {model_dir}",
+                    "unnormalization has no statistics to use; ship the file with the checkpoint",
+                )
+            ]
     try:
         document = json.loads(path.read_text())
     except (OSError, ValueError) as exc:
         return [Finding(FAIL, "norm_stats.json", f"unreadable: {exc}", "fix or re-export the file")]
 
     stats = document.get("norm_stats", document)
-    findings: List[Finding] = []
 
     # Width per key against what the preset says the robot is. This is the check
     # that catches a G1 checkpoint carrying LIBERO statistics: 16-dim robot,
@@ -161,7 +243,7 @@ def _check_norm_stats(
 
 
 def _check_tokenizer(model_dir: Path, tokenizer_path) -> List[Finding]:
-    """The A14 check: is there a tokenizer to load, and is it the *same* one?"""
+    """Is there a tokenizer to load, and is it the *same* one both servers use?"""
     if tokenizer_path is not None:
         path = Path(tokenizer_path)
         if not path.exists():
@@ -225,6 +307,9 @@ def check_checkpoint(
     image_keys: Optional[Sequence[str]] = None,
     action_dim: Optional[int] = None,
     tokenizer_path=None,
+    checkpoint_format: Optional[str] = None,
+    asset_id: Optional[str] = None,
+    norm_stats=None,
 ) -> Tuple[Finding, ...]:
     """Check a checkpoint directory against the preset that will serve it.
 
@@ -232,14 +317,57 @@ def check_checkpoint(
     its overrides), not the raw command line, so what is checked is what will
     actually run. Returns findings sorted most-severe first; an empty tuple is
     impossible because passing checks are reported as :data:`INFO`.
+
+    ``checkpoint_format`` / ``asset_id`` / ``norm_stats`` are the same knobs
+    :meth:`~apxinf.policies.impls.pi05.Pi05Policy.from_pretrained` takes, and must
+    be passed through identically — this is a preflight for *that* load, so
+    checking a different file than the one that will be served defeats the point.
     """
     model_dir = Path(model_dir)
     preset = get_robot_preset(robot)
     discrete = preset.discrete_state if discrete_state is None else bool(discrete_state)
     keys = preset.image_keys if image_keys is None else tuple(image_keys)
 
+    # A directory that declares nothing about itself is the hand-assembled flat
+    # layout that predates this check; it still loads, so it is still checked,
+    # just against <model_dir>/norm_stats.json (or --norm-stats, which names one
+    # file rather than asserting a directory shape). A detection failure is
+    # reported rather than raised: preflight's whole contract is to list every
+    # problem. This mirrors Pi05Policy.from_pretrained exactly — a preflight that
+    # resolves a different file than the load would is worse than none.
+    layout: Optional[CheckpointLayout] = None
+    layout_findings: List[Finding] = []
+    if checkpoint_format or asset_id or has_layout_metadata(model_dir):
+        try:
+            layout = detect_checkpoint(
+                model_dir,
+                checkpoint_format=checkpoint_format,
+                asset_id=asset_id,
+                norm_stats=norm_stats,
+            )
+        except CheckpointError as exc:
+            layout_findings.append(
+                Finding(
+                    FAIL,
+                    "checkpoint layout",
+                    str(exc),
+                    "apxinf cannot tell what this directory is, so it cannot tell "
+                    "which files to read; pass --ckpt-format, or fix the directory",
+                )
+            )
+        else:
+            layout_findings.extend(_check_layout(layout))
+
     findings = [
-        *_check_norm_stats(model_dir, preset, norm_key=norm_key, discrete_state=discrete),
+        *layout_findings,
+        *_check_norm_stats(
+            model_dir,
+            preset,
+            norm_key=norm_key,
+            discrete_state=discrete,
+            layout=layout,
+            norm_stats=norm_stats,
+        ),
         *_check_tokenizer(model_dir, tokenizer_path),
         *_check_cameras(preset, keys),
     ]

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -72,6 +72,7 @@ from .. import conventions
 from ..conventions import Convention
 from ..policies.auto import AutoPolicy
 from ..policies.base import VIEW_SLOTS, Policy
+from ..processors.robots.unitree_g1 import G1_ROBOT_DIM
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
@@ -109,6 +110,18 @@ class Embodiment:
     #: Deployable action width. ``None`` keeps the model's full vector — correct
     #: when a robot output step does the truncation itself (G1's 32→16 encode).
     action_dim: Optional[int] = None
+    #: Width of this body's state vector, i.e. how wide ``norm_stats["state"]``
+    #: has to be. A fact about the hardware, so it does not follow
+    #: :attr:`action_dim`: a robot's state and action spaces need not match
+    #: (Franka under LIBERO has 8-dim state and a 7-dim EEF-delta action).
+    #: ``None`` means this body makes no claim and the check is skipped.
+    state_dim: Optional[int] = None
+    #: Width of this body's action vector, i.e. how wide ``norm_stats["actions"]``
+    #: has to be. Distinct from :attr:`action_dim`, which is a *loading* knob
+    #: saying what to trim the model down to: the G1 declares ``action_dim=None``
+    #: because ``UnitreeG1EncodeActions`` owns the truncation, but its actions are
+    #: still 16 wide and its statistics must be. ``None`` skips the check.
+    action_width: Optional[int] = None
     #: Factory that loads the checkpoint and wires this robot's pre/post steps.
     builder: Callable[..., Policy] = _build_generic
     #: Extra keyword arguments the builder always receives.
@@ -119,6 +132,20 @@ class Embodiment:
             raise ValueError(
                 f"Embodiment {self.name!r}: num_cameras={self.num_cameras} is outside "
                 f"1..{len(VIEW_SLOTS)}, the view slots {VIEW_SLOTS} a checkpoint fills"
+            )
+        if (
+            self.action_dim is not None
+            and self.action_width is not None
+            and self.action_dim > self.action_width
+        ):
+            # Trimming is a slice of the statistics, so it cannot ask for more
+            # columns than the body's actions have. Getting this pair backwards
+            # would make the preflight check the wrong width and pass a
+            # checkpoint that the unnormalizer then fails on, mid-serve.
+            raise ValueError(
+                f"Embodiment {self.name!r}: action_dim={self.action_dim} trims wider "
+                f"than action_width={self.action_width}, but action_width is how many "
+                "columns this body's actions (and its norm_stats) have"
             )
 
     @property
@@ -200,6 +227,14 @@ class RobotPreset:
         return self.embodiment.action_dim
 
     @property
+    def state_dim(self) -> Optional[int]:
+        return self.embodiment.state_dim
+
+    @property
+    def action_width(self) -> Optional[int]:
+        return self.embodiment.action_width
+
+    @property
     def builder(self) -> Callable[..., Policy]:
         return self.embodiment.builder
 
@@ -261,18 +296,36 @@ class RobotPreset:
 #: Franka Emika Panda, 7-DoF arm + parallel gripper, 2-camera rig. Its whole port
 #: is a table row: the checkpoint already emits absolute actions at the deployable
 #: width, so no robot pre/post step is needed and the generic builder serves it.
-FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7)
+#: ``state_dim`` is 8 rather than 7 — LIBERO records EEF pose + gripper on the
+#: state side and 6 EEF deltas + gripper on the action side.
+FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7, state_dim=8, action_width=7)
 
 #: Unitree G1 humanoid: dual-arm + 2 dexterous hands, 16 DoF laid out
 #: ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, 3 cameras. ``action_dim``
 #: stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16 truncation
-#: after delta→absolute has seen the full-width action.
+#: after delta→absolute has seen the full-width action; ``action_width`` is still
+#: 16, because that is how wide the body's actions and its statistics are.
 UNITREE_G1_BODY = Embodiment(
     name="unitree_g1",
     num_cameras=3,
     action_dim=None,
+    state_dim=G1_ROBOT_DIM,
+    action_width=G1_ROBOT_DIM,
     builder=build_unitree_g1_policy,
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+    builder_kwargs={
+        "use_delta_joint_actions": True,
+        "adapt_to_pi": True,
+        # openpi parses norm_stats.json into float64 and never demotes it, so its
+        # whole G1 chain — normalize state, discretize it into the prompt,
+        # unnormalize the action — runs in float64. Ours follows the input dtype
+        # (float32) unless told otherwise. The output-side gap is ~2e-7 rad and
+        # harmless, but on the input side the very next thing after normalizing
+        # is a comparison against bin edges 1/128 apart: an element sitting near
+        # an edge lands in a different bin, which changes the prompt text, the
+        # token ids, and the whole rollout. Match openpi rather than explain the
+        # divergence later.
+        "norm_dtype": "float64",
+    },
 )
 
 #: --- deployable pairings -----------------------------------------------------

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -120,6 +120,50 @@ class RobotPreset:
         """Cameras this preset sends; must equal the checkpoint's ``num_views``."""
         return len(self.slots)
 
+    @property
+    def has_robot_steps(self) -> bool:
+        """Whether this preset wires robot-specific pre/post steps.
+
+        ``False`` for a preset the generic builder serves, whose entire contract
+        is its wire keys and action width. A caller that *cannot* run
+        :attr:`builder` — the checkpoint-free synthetic path — uses this to say
+        what it dropped rather than publishing the preset name unqualified.
+        """
+        return self.builder is not _build_generic
+
+    def synthetic_gaps(
+        self, *, discrete_state: bool, served_action_dim: int
+    ) -> Tuple[str, ...]:
+        """What a checkpoint-free (random-weights) server cannot honour here.
+
+        The synthetic path reproduces this preset's wire keys and view count
+        exactly and nothing else: its tokenizer emits a fixed token stream and
+        never reads state, and :attr:`builder` never runs. Each returned string
+        names one gap, for a startup warning — a synthetic server publishing this
+        preset's name unqualified would be the silent embodiment mismatch
+        ``--robot`` exists to prevent.
+        """
+        gaps = []
+        if discrete_state:
+            gaps.append(
+                "discrete_state=True — the synthetic tokenizer ignores state, so the "
+                "served metadata says discrete_state=False"
+            )
+        if self.has_robot_steps:
+            gap = (
+                f"its robot pre/post steps — {self.builder.__name__} never runs, so no "
+                "state decode, delta->absolute or action re-encode is wired"
+            )
+            if self.action_dim is None:
+                # action_dim=None means an output step owns the truncation (G1's
+                # 32->16 encode). Without that step the full model vector ships.
+                gap += (
+                    f"; the served action_dim is the model's full {served_action_dim}, "
+                    "not the width that skipped step would emit"
+                )
+            gaps.append(gap)
+        return tuple(gaps)
+
     def describe(self) -> str:
         """Human-readable slot→wire-key mapping, for ``--help`` and startup logs."""
         rendered = ", ".join(f"{slot}={key}" for slot, key in self.slots)
@@ -204,8 +248,11 @@ def build_robot_policy(
     stack without editing the preset (and without touching the client).
 
     The resulting wire contract is published in the policy ``metadata``
-    (``robot`` / ``image_keys`` / ``state_key`` / ``discrete_state``), which the
-    server pushes on connect, so a client can assert it rather than guess.
+    (``robot`` / ``robot_steps`` / ``image_keys`` / ``state_key`` /
+    ``discrete_state``), which the server pushes on connect, so a client can
+    assert it rather than guess. ``robot_steps`` says whether this robot's
+    pre/post steps are actually wired, so a server that serves the preset's keys
+    without its arithmetic cannot pass for the real thing.
     """
     preset = get_robot_preset(robot)
     keys = tuple(image_keys) if image_keys is not None else preset.image_keys
@@ -221,6 +268,7 @@ def build_robot_policy(
         action_dim=width,
         metadata={
             "robot": preset.name,
+            "robot_steps": preset.has_robot_steps,
             "robot_slots": [list(pair) for pair in zip(VIEW_SLOTS, keys)],
             **(dict(metadata) if metadata else {}),
         },

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -38,6 +38,22 @@ is named for the arm *and* the dataset convention whose keys it implements:
 ``franka_libero``, not ``libero`` (a benchmark, not a robot) and not ``franka``
 (ambiguous). Single-embodiment robots that own their convention need no suffix —
 ``unitree_g1``.
+
+**Two halves, one flag.** That naming rule is an admission, so the dataclasses
+follow it: an :class:`Embodiment` is the body (camera count, action width, which
+pre/post steps its actions need) and a :class:`Convention` is a dataset's
+recording dialect (the wire keys, and whether state was recorded into the
+prompt). Neither knows the other; they vary independently, which is the point —
+the same Franka under DROID's keys is a second :class:`Convention`, not a second
+body, and re-recording the G1 changes no :class:`Embodiment` field.
+
+A :class:`RobotPreset` names one *pairing*, and only the pairing is deployable.
+``--robot`` stays a single flag over that registry rather than becoming
+``--robot`` + ``--convention``: separate flags would let an operator spell a
+combination nobody ever recorded, and a body served under a convention it was not
+recorded on is exactly the silent mismatch this whole mechanism exists to
+prevent. The pairing is validated when the module loads — a convention naming
+three cameras cannot be attached to a two-camera body.
 """
 
 from __future__ import annotations
@@ -52,6 +68,8 @@ from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
     "VIEW_SLOTS",
+    "Embodiment",
+    "Convention",
     "RobotPreset",
     "ROBOT_PRESETS",
     "ROBOT_ALIASES",
@@ -67,69 +85,173 @@ def _build_generic(model_dir, **kwargs) -> Policy:
 
 
 @dataclass(frozen=True)
-class RobotPreset:
-    """One embodiment's serving contract: wire keys + action width + builder."""
+class Embodiment:
+    """A robot body: how many cameras it has, and what its actions mean.
 
-    #: Registry name, used as ``--robot <name>``.
+    Everything here is a fact about hardware. It survives a change of dataset:
+    re-record the G1 under a different key convention and this is unchanged.
+    Nothing here is a string that goes on the network.
+    """
+
+    #: Robot name, used in the served metadata and in preset names.
     name: str
-    #: ``(view slot, wire key)`` pairs in model slot order. The slot name is
-    #: documentation and validation; only the wire key goes on the network.
-    slots: Tuple[Tuple[str, str], ...]
-    #: Wire key of the proprioceptive state vector.
-    state_key: str
-    #: Wire key of the task instruction.
-    prompt_key: str = "prompt"
+    #: Cameras this body carries; must equal the checkpoint's ``num_views``.
+    num_cameras: int
     #: Deployable action width. ``None`` keeps the model's full vector — correct
     #: when a robot output step does the truncation itself (G1's 32→16 encode).
     action_dim: Optional[int] = None
-    #: Whether state is discretized into the prompt. Off means state is *dropped*.
-    discrete_state: bool = False
     #: Factory that loads the checkpoint and wires this robot's pre/post steps.
     builder: Callable[..., Policy] = _build_generic
-    #: One-line description for ``--help`` and the served metadata.
-    summary: str = ""
     #: Extra keyword arguments the builder always receives.
     builder_kwargs: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.slots:
-            raise ValueError(f"RobotPreset {self.name!r}: at least one camera slot is required")
-        if len(self.slots) > len(VIEW_SLOTS):
+        if not 1 <= self.num_cameras <= len(VIEW_SLOTS):
             raise ValueError(
-                f"RobotPreset {self.name!r}: {len(self.slots)} slots exceeds pi05's "
-                f"{len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
+                f"Embodiment {self.name!r}: num_cameras={self.num_cameras} is outside "
+                f"1..{len(VIEW_SLOTS)}, the view slots {VIEW_SLOTS} a checkpoint fills"
             )
-        expected = VIEW_SLOTS[: len(self.slots)]
-        declared = tuple(slot for slot, _ in self.slots)
-        if declared != expected:
+
+    @property
+    def has_robot_steps(self) -> bool:
+        """Whether this body needs pre/post arithmetic beyond naming its keys.
+
+        ``False`` for a body the generic builder serves, whose entire contract is
+        its wire keys and action width. A caller that *cannot* run :attr:`builder`
+        — the checkpoint-free synthetic path — uses this to say what it dropped
+        rather than publishing the preset name unqualified.
+        """
+        return self.builder is not _build_generic
+
+
+@dataclass(frozen=True)
+class Convention:
+    """A dataset's recording convention: what the client calls things.
+
+    Everything here is a string on the network, plus the one routing decision
+    that follows from how the data was recorded. It survives a change of robot:
+    LIBERO's keys describe a Franka today and would describe any arm recorded the
+    same way. Nothing here knows an action width or a camera count.
+    """
+
+    #: Convention name (a dataset or an integrator's dialect).
+    name: str
+    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
+    image_keys: Tuple[str, ...]
+    #: Wire key of the proprioceptive state vector.
+    state_key: str
+    #: Wire key of the task instruction.
+    prompt_key: str = "prompt"
+    #: Whether state is discretized into the prompt. Off means state is *dropped*.
+    discrete_state: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.image_keys:
+            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
+        if len(self.image_keys) > len(VIEW_SLOTS):
             raise ValueError(
-                f"RobotPreset {self.name!r}: slots must be a prefix of {VIEW_SLOTS} in "
-                f"order (a checkpoint fills view slots from 0 up), got {declared}"
+                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
+                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
             )
-        wire = [key for _, key in self.slots]
-        if len(set(wire)) != len(wire):
-            raise ValueError(f"RobotPreset {self.name!r}: duplicate camera wire keys {wire}")
+        if len(set(self.image_keys)) != len(self.image_keys):
+            raise ValueError(
+                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
+            )
+
+    @property
+    def num_cameras(self) -> int:
+        """Cameras this convention names — cross-checked against the body's."""
+        return len(self.image_keys)
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs — the pairing, for logs and review."""
+        return tuple(zip(VIEW_SLOTS, self.image_keys))
+
+
+@dataclass(frozen=True)
+class RobotPreset:
+    """One deployable pairing: a body recorded under a convention.
+
+    The two halves are separable because they vary independently — the same
+    Franka arm under LIBERO's and DROID's keys is one :class:`Embodiment` and two
+    :class:`Convention`\\ s — but they are validated *together*, because only the
+    pair is deployable: a convention naming three cameras cannot serve a two-camera
+    body, and nothing else in the system will notice if it tries.
+
+    This stays one ``--robot`` flag. Splitting the flag too would let an operator
+    spell combinations that were never recorded, which is the silent mismatch the
+    flag exists to prevent; the registry below decides which pairings are real.
+    """
+
+    #: Registry name, used as ``--robot <name>``. Spelled ``<arm>_<convention>``
+    #: when the arm is shared, bare when the body owns its convention.
+    name: str
+    #: The body being served.
+    embodiment: Embodiment
+    #: The key convention its client speaks.
+    convention: Convention
+    #: One-line description for ``--help`` and the served metadata.
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if self.convention.num_cameras != self.embodiment.num_cameras:
+            raise ValueError(
+                f"RobotPreset {self.name!r}: convention {self.convention.name!r} names "
+                f"{self.convention.num_cameras} cameras but embodiment "
+                f"{self.embodiment.name!r} has {self.embodiment.num_cameras}; a "
+                "convention can only be paired with a body it was recorded on"
+            )
+
+    # --- the pairing's flat contract ---------------------------------------
+    #
+    # Delegating properties rather than a rename: this is what the server, the
+    # metadata and the tests read, and which half a field came from is not their
+    # business. They also keep every existing caller working unchanged.
 
     @property
     def image_keys(self) -> Tuple[str, ...]:
         """Camera wire keys in model slot order — what ``ImageStack`` consumes."""
-        return tuple(key for _, key in self.slots)
+        return self.convention.image_keys
+
+    @property
+    def state_key(self) -> str:
+        return self.convention.state_key
+
+    @property
+    def prompt_key(self) -> str:
+        return self.convention.prompt_key
+
+    @property
+    def discrete_state(self) -> bool:
+        return self.convention.discrete_state
+
+    @property
+    def slots(self) -> Tuple[Tuple[str, str], ...]:
+        """``(view slot, wire key)`` pairs in model slot order."""
+        return self.convention.slots
+
+    @property
+    def action_dim(self) -> Optional[int]:
+        return self.embodiment.action_dim
+
+    @property
+    def builder(self) -> Callable[..., Policy]:
+        return self.embodiment.builder
+
+    @property
+    def builder_kwargs(self) -> Mapping[str, Any]:
+        return self.embodiment.builder_kwargs
 
     @property
     def num_views(self) -> int:
         """Cameras this preset sends; must equal the checkpoint's ``num_views``."""
-        return len(self.slots)
+        return self.embodiment.num_cameras
 
     @property
     def has_robot_steps(self) -> bool:
-        """Whether this preset wires robot-specific pre/post steps.
-
-        ``False`` for a preset the generic builder serves, whose entire contract
-        is its wire keys and action width. A caller that *cannot* run
-        :attr:`builder` — the checkpoint-free synthetic path — uses this to say
-        what it dropped rather than publishing the preset name unqualified.
-        """
-        return self.builder is not _build_generic
+        """Whether this preset wires robot-specific pre/post steps."""
+        return self.embodiment.has_robot_steps
 
     def synthetic_gaps(
         self, *, discrete_state: bool, served_action_dim: int
@@ -170,35 +292,64 @@ class RobotPreset:
         return f"{self.name}: {rendered}; state={self.state_key}"
 
 
-#: Franka Panda under LIBERO's key convention (the 7-DoF sim benchmark):
-#: 2 cameras, 7-dim action. Mirrors openpi ``LiberoInputs``. State is dropped by
-#: default, matching the numerics of the existing serving link.
+#: --- bodies -----------------------------------------------------------------
+
+#: Franka Emika Panda, 7-DoF arm + parallel gripper, 2-camera rig. Its whole port
+#: is a table row: the checkpoint already emits absolute actions at the deployable
+#: width, so no robot pre/post step is needed and the generic builder serves it.
+FRANKA = Embodiment(name="franka", num_cameras=2, action_dim=7)
+
+#: Unitree G1 humanoid: dual-arm + 2 dexterous hands, 16 DoF laid out
+#: ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, 3 cameras. ``action_dim``
+#: stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16 truncation
+#: after delta→absolute has seen the full-width action.
+UNITREE_G1_BODY = Embodiment(
+    name="unitree_g1",
+    num_cameras=3,
+    action_dim=None,
+    builder=build_unitree_g1_policy,
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+#: --- key conventions ---------------------------------------------------------
+
+#: LIBERO's recording convention (the 7-DoF sim benchmark). Mirrors openpi
+#: ``LiberoInputs``: flat ``observation/...`` keys. State is dropped by default,
+#: matching the numerics of the existing serving link.
+LIBERO_KEYS = Convention(
+    name="libero",
+    image_keys=("observation/image", "observation/wrist_image"),
+    state_key="observation/state",
+    discrete_state=False,
+)
+
+#: The ``pi05_UnitreeG1`` fine-tune's convention, from its
+#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``,
+#: a flat ``state``, discretized into the prompt.
+UNITREE_G1_KEYS = Convention(
+    name="unitree_g1",
+    image_keys=tuple(G1_CAMERAS),
+    state_key=G1_STATE_KEY,
+    discrete_state=True,
+)
+
+#: --- deployable pairings -----------------------------------------------------
+
+#: Franka Panda under LIBERO's keys: 2 cameras, 7-dim action.
 FRANKA_LIBERO = RobotPreset(
     name="franka_libero",
-    slots=(
-        ("base_0_rgb", "observation/image"),
-        ("left_wrist_0_rgb", "observation/wrist_image"),
-    ),
-    state_key="observation/state",
-    action_dim=7,
-    discrete_state=False,
+    embodiment=FRANKA,
+    convention=LIBERO_KEYS,
     summary="Franka Panda, LIBERO keys: 2 cameras, 7-dim action (6 EEF deltas + gripper)",
 )
 
-#: Unitree G1 (humanoid, dual-arm + 2 dexterous hands): 3 cameras, 16-dim action.
-#: Mirrors the ``pi05_UnitreeG1`` fine-tune's ``unitreeG1Inputs``/``Outputs``: the
-#: client sends the nested ``obs["images"][...]`` layout and a flat ``"state"``.
-#: ``action_dim`` stays ``None`` because ``UnitreeG1EncodeActions`` does the 32→16
-#: truncation after delta→absolute has seen the full-width action.
+#: Unitree G1 under its own convention — a single-embodiment robot that owns its
+#: keys, so body and convention share a name and the preset needs no suffix.
 UNITREE_G1 = RobotPreset(
     name="unitree_g1",
-    slots=tuple(zip(VIEW_SLOTS, G1_CAMERAS)),
-    state_key=G1_STATE_KEY,
-    action_dim=None,
-    discrete_state=True,
-    builder=build_unitree_g1_policy,
+    embodiment=UNITREE_G1_BODY,
+    convention=UNITREE_G1_KEYS,
     summary="Unitree G1: 3 cameras, 16-DoF state, delta joint actions, 32->16 encode",
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
 #: Name -> preset. Add an embodiment here once its steps and factory exist; that

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -11,19 +11,24 @@ launch flag on both sides rather than a code edit on ours:
     openpi:  serve_policy.py --policy.config pi05_UnitreeG1_groundwire
     apxinf:  pi05_openpi_websocket_server.py --robot unitree_g1
 
-**Why a table and not a default.** ``Pi05Policy``'s ``_DEFAULT_IMAGE_KEYS`` is
-LIBERO's wire contract. As *the* default it silently applied to every checkpoint,
-so a G1 checkpoint served without extra arguments ran LIBERO's keys, dropped
-state, and skipped the G1 delta→absolute and 32→16 steps — every symptom of a
-"model accuracy problem" with nothing in the logs. A preset makes the embodiment
-an explicit, named choice.
+**Why a table and not a default.** ``Pi05Policy`` used to default ``image_keys``
+to ``("observation/image", "observation/wrist_image")`` — LIBERO's wire contract,
+living in the model layer as *the* default for every checkpoint. A G1 checkpoint
+served without extra arguments therefore ran LIBERO's keys, dropped state, and
+skipped the G1 delta→absolute and 32→16 steps — every symptom of a "model
+accuracy problem" with nothing in the logs. The policy now names its cameras
+after its own :data:`~apxinf.policies.base.VIEW_SLOTS` when the caller names
+none, so no dataset's convention can pass for a model default; a preset makes the
+embodiment an explicit, named choice.
 
 **Why slot names.** ``image_keys`` is order-significant: entry ``i`` is stacked
 into model view slot ``i``, which the checkpoint trained as openpi's
 ``base_0_rgb`` / ``left_wrist_0_rgb`` / ``right_wrist_0_rgb``. A tuple written in
 the wrong order still stacks, still has the right shape, and silently feeds the
 wrong camera to each slot. Pairing every wire key with the slot it fills makes
-that order reviewable instead of positional.
+that order reviewable instead of positional. The slot vocabulary itself is a
+*model* fact, so it is imported from :mod:`apxinf.policies.base` rather than
+restated here.
 
 **Naming rule: ``<arm>_<convention>``.** The arm alone does not determine the
 contract — LIBERO and DROID are both Franka Panda, yet LIBERO sends
@@ -41,7 +46,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 from ..policies.auto import AutoPolicy
-from ..policies.base import Policy
+from ..policies.base import VIEW_SLOTS, Policy
 from ..processors.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY
 from .unitree_g1 import build_unitree_g1_policy
 
@@ -54,11 +59,6 @@ __all__ = [
     "get_robot_preset",
     "build_robot_policy",
 ]
-
-#: pi05 model view slots in order, as named by openpi's ``model.IMAGE_KEYS``.
-#: A checkpoint's ``num_views`` is how many of these its weights were trained on;
-#: the names are openpi's convention, the *order* is baked into the weights.
-VIEW_SLOTS = ("base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb")
 
 
 def _build_generic(model_dir, **kwargs) -> Policy:

--- a/python/apxinf/apxinf/robots/presets.py
+++ b/python/apxinf/apxinf/robots/presets.py
@@ -41,11 +41,14 @@ is named for the arm *and* the dataset convention whose keys it implements:
 
 **Two halves, one flag.** That naming rule is an admission, so the dataclasses
 follow it: an :class:`Embodiment` is the body (camera count, action width, which
-pre/post steps its actions need) and a :class:`Convention` is a dataset's
-recording dialect (the wire keys, and whether state was recorded into the
-prompt). Neither knows the other; they vary independently, which is the point —
-the same Franka under DROID's keys is a second :class:`Convention`, not a second
-body, and re-recording the G1 changes no :class:`Embodiment` field.
+pre/post steps its actions need) and a
+:class:`~apxinf.conventions.Convention` is a dataset's recording dialect (the
+wire keys, and whether state was recorded into the prompt). Neither knows the
+other; they vary independently, which is the point — the same Franka under
+DROID's keys is a second convention, not a second body, and re-recording the G1
+changes no :class:`Embodiment` field. Conventions live in
+:mod:`apxinf.conventions` rather than here, because a dialect is not a robot's
+property: this module imports them, never the reverse.
 
 A :class:`RobotPreset` names one *pairing*, and only the pairing is deployable.
 ``--robot`` stays a single flag over that registry rather than becoming
@@ -54,16 +57,21 @@ combination nobody ever recorded, and a body served under a convention it was no
 recorded on is exactly the silent mismatch this whole mechanism exists to
 prevent. The pairing is validated when the module loads — a convention naming
 three cameras cannot be attached to a two-camera body.
+
+**Registering from outside.** :func:`register_robot_preset` adds an entry from
+another package, so a third-party robot does not have to patch this file to
+become ``--robot <name>``.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
 
+from .. import conventions
+from ..conventions import Convention
 from ..policies.auto import AutoPolicy
 from ..policies.base import VIEW_SLOTS, Policy
-from ..processors.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY
 from .unitree_g1 import build_unitree_g1_policy
 
 __all__ = [
@@ -75,6 +83,7 @@ __all__ = [
     "ROBOT_ALIASES",
     "available_robots",
     "get_robot_preset",
+    "register_robot_preset",
     "build_robot_policy",
 ]
 
@@ -122,51 +131,6 @@ class Embodiment:
         rather than publishing the preset name unqualified.
         """
         return self.builder is not _build_generic
-
-
-@dataclass(frozen=True)
-class Convention:
-    """A dataset's recording convention: what the client calls things.
-
-    Everything here is a string on the network, plus the one routing decision
-    that follows from how the data was recorded. It survives a change of robot:
-    LIBERO's keys describe a Franka today and would describe any arm recorded the
-    same way. Nothing here knows an action width or a camera count.
-    """
-
-    #: Convention name (a dataset or an integrator's dialect).
-    name: str
-    #: Camera wire keys, in model view-slot order. Entry *i* fills slot *i*.
-    image_keys: Tuple[str, ...]
-    #: Wire key of the proprioceptive state vector.
-    state_key: str
-    #: Wire key of the task instruction.
-    prompt_key: str = "prompt"
-    #: Whether state is discretized into the prompt. Off means state is *dropped*.
-    discrete_state: bool = False
-
-    def __post_init__(self) -> None:
-        if not self.image_keys:
-            raise ValueError(f"Convention {self.name!r}: at least one camera key is required")
-        if len(self.image_keys) > len(VIEW_SLOTS):
-            raise ValueError(
-                f"Convention {self.name!r}: {len(self.image_keys)} camera keys exceeds "
-                f"pi05's {len(VIEW_SLOTS)} view slots {VIEW_SLOTS}"
-            )
-        if len(set(self.image_keys)) != len(self.image_keys):
-            raise ValueError(
-                f"Convention {self.name!r}: duplicate camera wire keys {list(self.image_keys)}"
-            )
-
-    @property
-    def num_cameras(self) -> int:
-        """Cameras this convention names — cross-checked against the body's."""
-        return len(self.image_keys)
-
-    @property
-    def slots(self) -> Tuple[Tuple[str, str], ...]:
-        """``(view slot, wire key)`` pairs — the pairing, for logs and review."""
-        return tuple(zip(VIEW_SLOTS, self.image_keys))
 
 
 @dataclass(frozen=True)
@@ -311,35 +275,13 @@ UNITREE_G1_BODY = Embodiment(
     builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
-#: --- key conventions ---------------------------------------------------------
-
-#: LIBERO's recording convention (the 7-DoF sim benchmark). Mirrors openpi
-#: ``LiberoInputs``: flat ``observation/...`` keys. State is dropped by default,
-#: matching the numerics of the existing serving link.
-LIBERO_KEYS = Convention(
-    name="libero",
-    image_keys=("observation/image", "observation/wrist_image"),
-    state_key="observation/state",
-    discrete_state=False,
-)
-
-#: The ``pi05_UnitreeG1`` fine-tune's convention, from its
-#: ``unitreeG1Inputs``/``Outputs``: cameras nested one level under ``images``,
-#: a flat ``state``, discretized into the prompt.
-UNITREE_G1_KEYS = Convention(
-    name="unitree_g1",
-    image_keys=tuple(G1_CAMERAS),
-    state_key=G1_STATE_KEY,
-    discrete_state=True,
-)
-
 #: --- deployable pairings -----------------------------------------------------
 
 #: Franka Panda under LIBERO's keys: 2 cameras, 7-dim action.
 FRANKA_LIBERO = RobotPreset(
     name="franka_libero",
     embodiment=FRANKA,
-    convention=LIBERO_KEYS,
+    convention=conventions.LIBERO,
     summary="Franka Panda, LIBERO keys: 2 cameras, 7-dim action (6 EEF deltas + gripper)",
 )
 
@@ -348,12 +290,14 @@ FRANKA_LIBERO = RobotPreset(
 UNITREE_G1 = RobotPreset(
     name="unitree_g1",
     embodiment=UNITREE_G1_BODY,
-    convention=UNITREE_G1_KEYS,
+    convention=conventions.UNITREE_G1,
     summary="Unitree G1: 3 cameras, 16-DoF state, delta joint actions, 32->16 encode",
 )
 
 #: Name -> preset. Add an embodiment here once its steps and factory exist; that
 #: is the whole registration step (openpi's ``training/config.py`` equivalent).
+#: A preset defined outside this package joins the same dict through
+#: :func:`register_robot_preset`.
 ROBOT_PRESETS: Dict[str, RobotPreset] = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1)}
 
 #: Accepted spellings that are not canonical names. ``libero`` names a benchmark
@@ -378,6 +322,56 @@ def get_robot_preset(name: str) -> RobotPreset:
             f"unknown robot preset {name!r}; known: {list(available_robots())}"
             f" (aliases: {list(ROBOT_ALIASES)})"
         ) from None
+
+
+def register_robot_preset(
+    preset: RobotPreset,
+    *,
+    aliases: Iterable[str] = (),
+    replace: bool = False,
+) -> RobotPreset:
+    """Add ``preset`` to the registry and return it, for use at module scope.
+
+    The registry above is this repository's table; a robot that lives in someone
+    else's package should not have to patch it to become ``--robot <name>``.
+    Importing that package is enough::
+
+        MY_ROBOT = register_robot_preset(
+            RobotPreset(name="myarm_mydataset", embodiment=MY_ARM, convention=MY_KEYS),
+            aliases=("myarm",),
+        )
+
+    Re-registering a name is an error unless ``replace=True``: a silent overwrite
+    would change what a launch command already in production resolves to, which
+    is the same class of invisible failure ``--robot`` exists to prevent. An alias
+    may never shadow a canonical name, for the same reason.
+
+    Registration is process-local and not persisted — ``--robot`` on the shipped
+    server only sees presets whose module was imported.
+    """
+    if not isinstance(preset, RobotPreset):
+        raise TypeError(f"expected a RobotPreset, got {type(preset).__name__}")
+    existing = ROBOT_PRESETS.get(preset.name)
+    if existing is not None and not replace:
+        raise ValueError(
+            f"robot preset {preset.name!r} is already registered ({existing.describe()}); "
+            "pass replace=True to override it"
+        )
+    for alias in aliases:
+        if alias in ROBOT_PRESETS:
+            raise ValueError(
+                f"alias {alias!r} for {preset.name!r} is already a canonical preset name; "
+                "an alias that shadows a real preset would silently redirect --robot"
+            )
+        target = ROBOT_ALIASES.get(alias)
+        if target is not None and target != preset.name and not replace:
+            raise ValueError(
+                f"alias {alias!r} already resolves to {target!r}; pass replace=True to move it"
+            )
+    ROBOT_PRESETS[preset.name] = preset
+    for alias in aliases:
+        ROBOT_ALIASES[alias] = preset.name
+    return preset
 
 
 def build_robot_policy(

--- a/python/apxinf/apxinf/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/robots/unitree_g1.py
@@ -8,6 +8,10 @@ no model class, no step inside the model's chain, and no checkpoint layout:
 holds, and :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter` wraps the
 G1 steps around that policy's own pre/post chain.
 
+It knows nothing about the *dataset* either: the wire keys arrive as required
+arguments from a :class:`~apxinf.conventions.Convention`, so the same body serves
+a re-recorded G1 without an edit here.
+
 The nesting is the entire coupling, and it is an ordering rule, not a naming one:
 
     decode G1 state  ->  [ whatever the model does ]  ->  delta->absolute -> 32->16
@@ -38,9 +42,7 @@ from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy, Policy
 from ..processors.base import StepSpec
 from ..processors.robots.unitree_g1 import (
-    G1_CAMERAS,
     G1_ROBOT_DIM,
-    G1_STATE_KEY,
     UnitreeG1AbsoluteActions,
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
@@ -52,10 +54,10 @@ __all__ = ["build_unitree_g1_policy"]
 def build_unitree_g1_policy(
     model_dir,
     *,
+    state_key: str,
+    image_keys: Sequence[str],
     use_delta_joint_actions: bool = True,
     adapt_to_pi: bool = True,
-    state_key: str = G1_STATE_KEY,
-    image_keys: Sequence[str] = G1_CAMERAS,
     discrete_state: bool = True,
     action_dim: Optional[int] = None,
     metadata: Optional[dict] = None,
@@ -89,11 +91,22 @@ def build_unitree_g1_policy(
     (``device`` / ``precision`` / ``checkpoint`` / ``model_type`` / a pre-built
     ``model=`` handle / an injected ``unnormalizer=``, ...).
 
-    Defaults match what an unmodified openpi G1 client sends: the nested
-    ``obs["images"][...]`` cameras, a flat ``"state"``, and state discretized into
-    the prompt. Serving with ``discrete_state=False`` silently drops state, which
-    also makes ``use_delta_joint_actions`` a no-op (a delta cannot be resolved
-    without the current joint positions).
+    ``state_key`` and ``image_keys`` are **required and have no defaults**. They
+    are a recording convention, not a fact about this body: the G1 client's
+    dialect lives in :data:`apxinf.conventions.UNITREE_G1`, and defaulting to it
+    here would rebuild the robot↔dataset coupling one layer up. Pass
+    ``**vars(...)`` of a convention, or let
+    :func:`~apxinf.robots.presets.build_robot_policy` do it from the preset
+    table::
+
+        from apxinf.conventions import UNITREE_G1 as G1_KEYS
+        policy = build_unitree_g1_policy(
+            ckpt, state_key=G1_KEYS.state_key, image_keys=G1_KEYS.image_keys
+        )
+
+    Serving with ``discrete_state=False`` silently drops state, which also makes
+    ``use_delta_joint_actions`` a no-op (a delta cannot be resolved without the
+    current joint positions).
     """
     base = AutoPolicy.from_pretrained(
         model_dir,

--- a/python/apxinf/apxinf/robots/unitree_g1.py
+++ b/python/apxinf/apxinf/robots/unitree_g1.py
@@ -1,15 +1,29 @@
-"""Unitree G1 adapter: wire the G1 steps onto a pi05 policy.
+"""Unitree G1 adapter: wrap the G1 steps around whatever policy the checkpoint is.
 
-Assembles the robot-specific steps in
-:mod:`apxinf.processors.robots.unitree_g1` with a generic
-:class:`~apxinf.policies.impls.pi05.Pi05Policy`. Only the primary serving path
-(3 cameras, ``adapt_to_pi=True``, no fixed-hand override) is wired — that is what
-the shipped ``pi05_UnitreeG1_groundwire`` config uses; the integrator's
-``_NoLeftCam`` / ``fixed_hand`` variants are training-data cleaning knobs, not
-serving paths, so they are intentionally omitted.
+This module is the *robot* half of the robot/model split. It knows the G1 body —
+16 DoF laid out ``[L-arm 7, L-gripper 1, R-arm 7, R-gripper 1]``, three cameras,
+delta joint actions — and it knows nothing about the model serving it. It names
+no model class, no step inside the model's chain, and no checkpoint layout:
+:class:`~apxinf.policies.auto.AutoPolicy` decides which policy the directory
+holds, and :meth:`~apxinf.policies.base.ComposablePolicy.with_adapter` wraps the
+G1 steps around that policy's own pre/post chain.
+
+The nesting is the entire coupling, and it is an ordering rule, not a naming one:
+
+    decode G1 state  ->  [ whatever the model does ]  ->  delta->absolute -> 32->16
+
+which is openpi's ``data_transforms`` sitting outside its ``model_transforms``.
+Everything else — how the model tokenizes, whether it discretizes state, what its
+steps are called — stays the model's business, so a G1 checkpoint of a different
+architecture serves through this same adapter unchanged.
+
+Only the primary serving path (3 cameras, ``adapt_to_pi=True``, no fixed-hand
+override) is wired — that is what the shipped ``pi05_UnitreeG1_groundwire`` config
+uses; the integrator's ``_NoLeftCam`` / ``fixed_hand`` variants are training-data
+cleaning knobs, not serving paths, so they are intentionally omitted.
 
 .. note::
-   With a stand-in pi05 checkpoint (no real G1 weights / norm_stats) this adapter
+   With a stand-in checkpoint (no real G1 weights / norm_stats) this adapter
    validates *plumbing and shape* (G1 obs -> ``[action_horizon, 16]``), not G1
    action values. Numeric parity needs the integrator's real gripper limits
    **and** the G1 checkpoint/norm_stats; the same adapter code then runs
@@ -18,10 +32,11 @@ serving paths, so they are intentionally omitted.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
-from ..policies.impls.pi05 import Pi05Policy
-from ..processors import Pipeline
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy, Policy
+from ..processors.base import StepSpec
 from ..processors.robots.unitree_g1 import (
     G1_CAMERAS,
     G1_ROBOT_DIM,
@@ -30,7 +45,6 @@ from ..processors.robots.unitree_g1 import (
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
 )
-from ..processors.transforms import Unnormalize
 
 __all__ = ["build_unitree_g1_policy"]
 
@@ -44,29 +58,36 @@ def build_unitree_g1_policy(
     image_keys: Sequence[str] = G1_CAMERAS,
     discrete_state: bool = True,
     action_dim: Optional[int] = None,
-    unnormalizer: Optional[Unnormalize] = None,
     metadata: Optional[dict] = None,
-    **from_pretrained_kwargs: Any,
-) -> Pi05Policy:
-    """Build a :class:`Pi05Policy` wired with the Unitree G1 pre/post adapter.
+    **load_kwargs: Any,
+) -> Policy:
+    """Load ``model_dir`` and wrap the Unitree G1 pre/post adapter around it.
 
-    Loads the checkpoint through the generic :meth:`Pi05Policy.from_pretrained`
-    (full model-width unnormalizer, so the delta->absolute step sees the whole
-    action before the 32->16 robot truncation), then swaps in the G1 pipelines:
+    The checkpoint is loaded through :class:`~apxinf.policies.auto.AutoPolicy`, so
+    the model type comes from ``config.json`` (or an explicit ``model_type=``)
+    rather than from this file. It is loaded at **full model width**
+    (``action_dim=None``) because the delta->absolute step must see the whole
+    action before ``UnitreeG1EncodeActions`` truncates it to 16. The model's own
+    unnormalizer therefore comes from the checkpoint's ``norm_stats["actions"]``
+    at its native width, so a real deployment needs G1 norm_stats at least ``16``
+    wide; pass ``unnormalizer=`` through to inject one instead (e.g. a full-width
+    identity for a shape/plumbing run on a stand-in checkpoint).
 
-    * **input**  — ``[image_stack, g1_decode_state?, tokenize]``; PI0.5 samples
-      its latent internally unless the caller supplies ``noise``
-    * **output** — ``[unnormalize, g1_absolute?, g1_encode]``
+    The resulting chain is the model's own, wrapped:
+
+    * **input**  — ``[g1_decode_state?, <the model's input steps>]``
+    * **output** — ``[<the model's output steps>, g1_absolute?, g1_encode?]``
 
     ``adapt_to_pi=False`` drops the decode/encode conventions (raw robot space);
     ``use_delta_joint_actions=False`` drops the delta->absolute step (the model
     already emits absolute actions). ``action_dim`` is the **deployable** width
-    reported to clients and defaults to :data:`G1_ROBOT_DIM` — the model always
-    runs at full width internally, and ``UnitreeG1EncodeActions`` performs the
-    truncation. By default the unnormalizer comes from the checkpoint's
-    ``norm_stats["actions"]``, so a real deployment needs G1 norm_stats at least
-    ``16`` wide; pass ``unnormalizer=`` to inject one (e.g. a full-width identity
-    for a shape/plumbing test on a stand-in checkpoint).
+    reported to clients: it defaults to :data:`G1_ROBOT_DIM` when ``adapt_to_pi``
+    wires the truncating encode step, and otherwise to whatever the model's own
+    chain emits — a policy must not advertise a width no step produces.
+
+    Extra ``load_kwargs`` reach the concrete policy's ``from_pretrained``
+    (``device`` / ``precision`` / ``checkpoint`` / ``model_type`` / a pre-built
+    ``model=`` handle / an injected ``unnormalizer=``, ...).
 
     Defaults match what an unmodified openpi G1 client sends: the nested
     ``obs["images"][...]`` cameras, a flat ``"state"``, and state discretized into
@@ -74,36 +95,44 @@ def build_unitree_g1_policy(
     also makes ``use_delta_joint_actions`` a no-op (a delta cannot be resolved
     without the current joint positions).
     """
-    base = Pi05Policy.from_pretrained(
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,  # keep full model width; the g1_encode step truncates to 16
         state_key=state_key,
         discrete_state=discrete_state,
-        **from_pretrained_kwargs,
+        **load_kwargs,
     )
-    if unnormalizer is None:
-        unnormalizer = base.output_pipeline["unnormalize"]
-
-    input_pipeline = base.input_pipeline
-    if adapt_to_pi:
-        input_pipeline = input_pipeline.insert_before(
-            "tokenize", ("g1_decode_state", UnitreeG1DecodeState(state_key))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(
+            f"the Unitree G1 adapter has to run its steps around the model's, which "
+            f"{type(base).__name__} (loaded from {model_dir}) does not allow: it has no "
+            "with_adapter(). Give that policy class a ComposablePolicy.with_adapter "
+            "rather than teaching this adapter about its internals."
         )
 
-    output_steps = [("unnormalize", unnormalizer)]
-    if use_delta_joint_actions:
-        output_steps.append(("g1_absolute", UnitreeG1AbsoluteActions(state_key)))
+    before: List[StepSpec] = []
     if adapt_to_pi:
-        output_steps.append(("g1_encode", UnitreeG1EncodeActions()))
-    output_pipeline = Pipeline(output_steps)
+        # Ahead of the model's own steps, so both the (optional) state
+        # discretization and the delta->absolute output step read decoded state.
+        before.append(("g1_decode_state", UnitreeG1DecodeState(state_key)))
 
-    return Pi05Policy(
-        base.model,
-        input_pipeline=input_pipeline,
-        output_pipeline=output_pipeline,
-        image_keys=tuple(image_keys),
-        state_key=state_key,
-        action_dim=G1_ROBOT_DIM if action_dim is None else int(action_dim),
+    after: List[StepSpec] = []
+    if use_delta_joint_actions:
+        after.append(("g1_absolute", UnitreeG1AbsoluteActions(state_key)))
+    if adapt_to_pi:
+        after.append(("g1_encode", UnitreeG1EncodeActions()))
+
+    if action_dim is not None:
+        width: Optional[int] = int(action_dim)
+    elif adapt_to_pi:
+        width = G1_ROBOT_DIM  # g1_encode does the truncation
+    else:
+        width = None  # no truncating step is wired; keep the model chain's width
+
+    return base.with_adapter(
+        before=before,
+        after=after,
+        action_dim=width,
         metadata={"robot": "unitree_g1", **(metadata or {})},
     )

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -325,29 +325,46 @@ wrong is silent. Add one entry to
 contract becomes `--robot <name>`:
 
 ```python
+MY_ROBOT_BODY = Embodiment(                       # the hardware: survives a re-record
+    name="my_robot",
+    num_cameras=2,
+    action_dim=None,                              # None: the encode step trims
+    builder=build_my_robot_policy,
+    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
+)
+
+MY_ROBOT_KEYS = Convention(                       # the dataset dialect: survives a re-body
+    name="my_dataset",
+    image_keys=("images/cam_high", "images/cam_left_wrist"),  # in model view-slot order
+    state_key="state",
+    discrete_state=True,                          # False *drops* state entirely
+)
+
 MY_ROBOT = RobotPreset(
     name="my_robot",                              # <arm>_<key convention> if the arm is shared
-    slots=(                                       # (model view slot, wire key), in slot order
-        ("base_0_rgb",        "images/cam_high"),
-        ("left_wrist_0_rgb",  "images/cam_left_wrist"),
-    ),
-    state_key="state",
-    action_dim=None,                              # None: the encode step trims
-    discrete_state=True,                          # False *drops* state entirely
-    builder=build_my_robot_policy,
+    embodiment=MY_ROBOT_BODY,
+    convention=MY_ROBOT_KEYS,
     summary="My robot: 2 cameras, 14-DoF state, delta joint actions",
-    builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
 ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 ```
 
-Naming each wire key with the **model view slot** it fills is the point: the
-tuple is order-significant (entry *i* becomes model view slot *i*), and a wrong
-order still stacks, still has the right shape, and silently feeds the wrong
-camera to each slot. The pairing is validated — slots must be a prefix of
-`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb` in order, with no duplicate
-wire keys.
+The two halves are separate because they vary independently: the same arm
+recorded under a second key convention is a new `Convention`, not a new body, and
+re-recording changes no `Embodiment` field. Only the *pairing* is deployable, and
+`--robot` stays one flag over the pairings — separate `--robot`/`--convention`
+flags would let an operator spell a combination nobody ever recorded, which is
+the silent mismatch the flag exists to prevent.
+
+`image_keys` is order-significant: entry *i* becomes model view slot *i*
+(`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb`), and a wrong order still
+stacks, still has the right shape, and silently feeds the wrong camera to each
+slot. `preset.slots` renders the pairing for logs and review; because the slot
+names are *derived* from the list rather than written by hand, a wrong slot order
+is not expressible at all. What is still checked: no duplicate wire keys, no more
+keys than there are view slots, and — on the pairing — the convention's camera
+count against the body's.
 
 Wire keys may be written **flat** (`"observation/image"` — the slash is part of
 the name, as LIBERO and DROID send it) or as a **nested path**

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -247,14 +247,24 @@ Port **placeholder calibration** faithfully as a hook (in G1 the flip mask is al
 Default pi05 pipelines: input `[image_stack, tokenize]`, output
 `[trim, unnormalize]`. Noise is generated inside the runtime unless the caller
 passes it explicitly; a custom host sampler can still be inserted as a pipeline
-step. `Pipeline` offers
-`insert_before/insert_after/replace/override/remove/reorder` (each returns a new
-pipeline). The factory does three things: load full-width → insert decode on the
-input → rewrite the output pipeline:
+step.
+
+`Pipeline` has two families of editing verbs, and picking the wrong one is what
+couples a robot to a model. `insert_before/insert_after/replace/override/remove/
+reorder` address a step **by name**, so they are for a caller who owns that
+chain. A robot adapter does not: its requirement is only "run outside the model's
+steps, in both directions". That is `prepend`/`append`, the two verbs that name
+nothing inside — and a policy exposes them as
+[`ComposablePolicy.with_adapter`](../policies/base.py). Every verb returns a new
+pipeline; none mutate.
+
+So the factory does two things: load full-width through `AutoPolicy`, then wrap.
+It names no model class, so a G1 checkpoint of a different architecture serves
+through the same file unchanged:
 
 ```python
-from ..policies.impls.pi05 import Pi05Policy
-from ..processors import Pipeline
+from ..policies.auto import AutoPolicy
+from ..policies.base import ComposablePolicy
 from ..processors.robots.my_robot import (
     MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions,
     ROBOT_CAMERAS, ROBOT_DIM,
@@ -262,31 +272,29 @@ from ..processors.robots.my_robot import (
 
 def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_pi=True,
                           state_key="observation/state", image_keys=ROBOT_CAMERAS, **kw):
-    base = Pi05Policy.from_pretrained(
+    base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
         action_dim=None,        # keep full 32 dims; the encode step trims to ROBOT_DIM
         state_key=state_key,
         **kw,
     )
-    input_pipeline = base.input_pipeline
-    if adapt_to_pi:
-        input_pipeline = input_pipeline.insert_before(
-            "tokenize", ("decode_state", MyRobotDecodeState(state_key)))
+    if not isinstance(base, ComposablePolicy):
+        raise TypeError(f"{type(base).__name__} has no with_adapter(); ...")
 
-    output_steps = [("unnormalize", base.output_pipeline["unnormalize"])]   # full width
+    before = [("decode_state", MyRobotDecodeState(state_key))] if adapt_to_pi else []
+    after = []
     if use_delta_joint_actions:
-        output_steps.append(("absolute", MyRobotAbsoluteActions(state_key)))
+        after.append(("absolute", MyRobotAbsoluteActions(state_key)))
     if adapt_to_pi:
-        output_steps.append(("encode", MyRobotEncodeActions()))
+        after.append(("encode", MyRobotEncodeActions()))
 
-    return Pi05Policy(
-        base.model,
-        input_pipeline=input_pipeline,
-        output_pipeline=Pipeline(output_steps),
-        image_keys=tuple(image_keys),
-        state_key=state_key,
-        action_dim=ROBOT_DIM,
+    return base.with_adapter(
+        before=before,
+        after=after,
+        # Only the width a step you appended actually produces. Without `encode`
+        # there is nothing to claim: inherit the model's own width (None).
+        action_dim=ROBOT_DIM if adapt_to_pi else None,
         metadata={"robot": "my_robot"},
     )
 ```
@@ -294,9 +302,12 @@ def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_p
 Resulting pipelines:
 
 ```
-input : [image_stack, decode_state, tokenize]
-output: [unnormalize, absolute, encode]   # normalized[H,32] -> actions[H,ROBOT_DIM]
+input : [decode_state, image_stack, tokenize]
+output: [trim, unnormalize, absolute, encode]   # normalized[H,32] -> actions[H,ROBOT_DIM]
 ```
+
+`trim` is the model's own step at full width (a no-op when `norm_stats` is as
+wide as the model), so `absolute` still sees the whole action.
 
 ### 5.5 One general framework hook (built in, nothing to change)
 

--- a/python/apxinf/apxinf/serving/README.md
+++ b/python/apxinf/apxinf/serving/README.md
@@ -103,8 +103,10 @@ result["policy_timing"]   # {'infer_ms': bare model, 'policy_ms': full policy}
 The metadata **is** the wire contract — assert against `meta["image_keys"]` /
 `meta["state_key"]` instead of hardcoding keys, so a server/client mismatch shows
 up as a failed assertion at startup rather than as degraded accuracy in the
-field. Sending a key the server does not serve raises a `KeyError` naming both
-sides; sending an *extra* key is silently ignored (matching openpi).
+field. A `state_key` of `null` is not a gap: it says the served policy drops
+state, so there is no key to send one under. Sending a key the server does not
+serve raises a `KeyError` naming both sides; sending an *extra* key is silently
+ignored (matching openpi).
 
 **Images are RGB.** Neither this server nor openpi converts colour: an `H×W×3`
 uint8 array is taken as RGB as-is. A client reading frames with OpenCV must
@@ -194,6 +196,7 @@ A working G1 example ships in-tree — copy and adapt it:
 ```
 python/apxinf/apxinf/processors/robots/unitree_g1.py   # robot-specific ProcessorSteps
 python/apxinf/apxinf/robots/unitree_g1.py              # build_unitree_g1_policy factory
+python/apxinf/apxinf/conventions.py                    # the G1 client's wire keys
 ```
 
 ### 5.1 Two landing spots
@@ -202,6 +205,7 @@ python/apxinf/apxinf/robots/unitree_g1.py              # build_unitree_g1_policy
 |---|---|---|
 | **robot-specific step** (pure numpy, per-embodiment, model-agnostic) | `python/apxinf/apxinf/processors/robots/<robot>.py` | `ProcessorStep` subclasses: decode-state / delta→absolute / encode-actions |
 | **assembly factory** (wires the steps onto `Pi05Policy`) | `python/apxinf/apxinf/robots/<robot>.py` | a `build_<robot>_policy(...)` that rewrites the pre/post pipelines after `from_pretrained` |
+| **recording convention** (the wire keys your client sends) | `python/apxinf/apxinf/conventions.py` | a `Convention`; it belongs to the *dataset*, so no step and no factory may hardcode it |
 
 ### 5.2 OpenPI transform → apxinf equivalent (G1 as the sample)
 
@@ -266,12 +270,16 @@ through the same file unchanged:
 from ..policies.auto import AutoPolicy
 from ..policies.base import ComposablePolicy
 from ..processors.robots.my_robot import (
-    MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions,
-    ROBOT_CAMERAS, ROBOT_DIM,
+    MyRobotDecodeState, MyRobotAbsoluteActions, MyRobotEncodeActions, ROBOT_DIM,
 )
 
-def build_my_robot_policy(model_dir, *, use_delta_joint_actions=True, adapt_to_pi=True,
-                          state_key="observation/state", image_keys=ROBOT_CAMERAS, **kw):
+# state_key / image_keys are **required and have no defaults**: they are a
+# recording convention, not a fact about this body. Defaulting them here would
+# rebuild the robot<->dataset coupling one layer up — the same arm re-recorded
+# under new keys would silently keep serving the old ones. They come from a
+# `Convention` (§5.6), which `build_robot_policy` reads off the preset for you.
+def build_my_robot_policy(model_dir, *, state_key, image_keys,
+                          use_delta_joint_actions=True, adapt_to_pi=True, **kw):
     base = AutoPolicy.from_pretrained(
         model_dir,
         image_keys=tuple(image_keys),
@@ -333,7 +341,8 @@ MY_ROBOT_BODY = Embodiment(                       # the hardware: survives a re-
     builder_kwargs={"use_delta_joint_actions": True, "adapt_to_pi": True},
 )
 
-MY_ROBOT_KEYS = Convention(                       # the dataset dialect: survives a re-body
+# In apxinf/conventions.py — the dataset dialect: survives a re-body.
+MY_ROBOT_KEYS = Convention(
     name="my_dataset",
     image_keys=("images/cam_high", "images/cam_left_wrist"),  # in model view-slot order
     state_key="state",
@@ -352,10 +361,32 @@ ROBOT_PRESETS = {p.name: p for p in (FRANKA_LIBERO, UNITREE_G1, MY_ROBOT)}
 
 The two halves are separate because they vary independently: the same arm
 recorded under a second key convention is a new `Convention`, not a new body, and
-re-recording changes no `Embodiment` field. Only the *pairing* is deployable, and
-`--robot` stays one flag over the pairings — separate `--robot`/`--convention`
-flags would let an operator spell a combination nobody ever recorded, which is
-the silent mismatch the flag exists to prevent.
+re-recording changes no `Embodiment` field. That is also why they live in
+different modules — a `Convention` goes in
+[`apxinf/conventions.py`](../conventions.py), which imports no body and no policy
+implementation, so a dialect is never anyone's property. Only the *pairing* is
+deployable, and `--robot` stays one flag over the pairings — separate
+`--robot`/`--convention` flags would let an operator spell a combination nobody
+ever recorded, which is the silent mismatch the flag exists to prevent.
+
+**From outside this repository.** A robot that lives in your own package does not
+have to patch either file. Importing your module is enough:
+
+```python
+from apxinf import Convention, Embodiment, RobotPreset
+from apxinf import register_convention, register_robot_preset
+
+MY_KEYS = register_convention(Convention(name="my_dataset", ...))
+MY_ROBOT = register_robot_preset(
+    RobotPreset(name="myarm_my_dataset", embodiment=MY_ARM, convention=MY_KEYS),
+    aliases=("myarm",),
+)
+```
+
+Re-registering a name needs an explicit `replace=True`, and an alias may never
+shadow a canonical preset name: a silent overwrite would change what a launch
+command already in production resolves to. Registration is process-local, so
+`--robot` only sees presets whose module the server imported.
 
 `image_keys` is order-significant: entry *i* becomes model view slot *i*
 (`base_0_rgb, left_wrist_0_rgb, right_wrist_0_rgb`), and a wrong order still
@@ -379,8 +410,23 @@ startup, so a client can assert it.
 
 ```python
 from apxinf import build_unitree_g1_policy          # shipped G1 example
-policy = build_unitree_g1_policy("<g1-ckpt>", use_delta_joint_actions=True, adapt_to_pi=True)
+from apxinf.conventions import UNITREE_G1 as G1_KEYS
+
+policy = build_unitree_g1_policy(
+    "<g1-ckpt>",
+    state_key=G1_KEYS.state_key,                    # required: a dataset fact, not a body's
+    image_keys=G1_KEYS.image_keys,
+    use_delta_joint_actions=True,
+    adapt_to_pi=True,
+)
 actions = policy.infer(obs)["actions"]               # [H, 16]
+```
+
+Or let the preset table supply both, which is what the server does:
+
+```python
+from apxinf import build_robot_policy
+policy = build_robot_policy("unitree_g1", "<g1-ckpt>")
 ```
 
 Served the same way, once §5.6 is done:

--- a/python/apxinf/examples/_common.py
+++ b/python/apxinf/examples/_common.py
@@ -24,7 +24,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 
 def synthetic_observation(
     *,
-    image_keys: Sequence[str] = ("observation/image", "observation/wrist_image"),
+    image_keys: Sequence[str],
+    state_key: str = "observation/state",
     height: int = 256,
     width: int = 256,
     state_dim: int = 8,
@@ -36,12 +37,17 @@ def synthetic_observation(
     Random ``uint8`` camera frames (raw ``HWC``; the policy's own resize step
     handles them) plus a float32 state vector and a text prompt. This is only to
     exercise the interface end-to-end — the actions it yields are meaningless.
+
+    ``image_keys`` has no default on purpose: camera wire keys are a dataset's
+    convention, and every caller here can read the real ones off the policy
+    (``policy.image_keys`` / ``policy.state_key``). A helper that guessed them
+    would drift from whatever the policy is actually serving.
     """
     rng = np.random.default_rng(seed)
     observation: Dict[str, Any] = {
         key: rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
         for key in image_keys
     }
-    observation["observation/state"] = rng.standard_normal(state_dim).astype(np.float32)
+    observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
     observation["prompt"] = prompt
     return observation

--- a/python/apxinf/examples/_common.py
+++ b/python/apxinf/examples/_common.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
@@ -25,7 +25,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 def synthetic_observation(
     *,
     image_keys: Sequence[str],
-    state_key: str = "observation/state",
+    state_key: Optional[str] = None,
+    prompt_key: str = "prompt",
     height: int = 256,
     width: int = 256,
     state_dim: int = 8,
@@ -42,12 +43,17 @@ def synthetic_observation(
     convention, and every caller here can read the real ones off the policy
     (``policy.image_keys`` / ``policy.state_key``). A helper that guessed them
     would drift from whatever the policy is actually serving.
+
+    ``state_key`` is ``None`` by default for the same reason, and ``None`` is
+    also what a policy that *drops* state publishes — so no state is put in the
+    dict, which is exactly what such a policy reads.
     """
     rng = np.random.default_rng(seed)
     observation: Dict[str, Any] = {
         key: rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
         for key in image_keys
     }
-    observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
-    observation["prompt"] = prompt
+    if state_key is not None:
+        observation[state_key] = rng.standard_normal(state_dim).astype(np.float32)
+    observation[prompt_key] = prompt
     return observation

--- a/python/apxinf/examples/autopolicy_infer.py
+++ b/python/apxinf/examples/autopolicy_infer.py
@@ -44,7 +44,7 @@ def main() -> None:
     try:
         print("dispatched model_type:", policy.metadata.get("model_type"))
 
-        observation = synthetic_observation(image_keys=policy.image_keys)
+        observation = synthetic_observation(image_keys=policy.image_keys, state_key=policy.state_key)
         result = policy.infer(observation)
 
         actions = result["actions"]

--- a/python/apxinf/examples/openpi_client.py
+++ b/python/apxinf/examples/openpi_client.py
@@ -52,9 +52,11 @@ def main() -> None:
 
     observation = synthetic_observation(
         # The wire contract comes from the server, not from a constant here —
-        # hardcoding keys is the mismatch that shows up as "bad accuracy".
+        # hardcoding keys is the mismatch that shows up as "bad accuracy". A
+        # null state_key means the server drops state, so none is sent.
         image_keys=metadata["image_keys"],
         state_key=metadata["state_key"],
+        prompt_key=metadata.get("prompt_key", "prompt"),
         prompt=args.prompt,
     )
     response = client.infer(observation)

--- a/python/apxinf/examples/openpi_client.py
+++ b/python/apxinf/examples/openpi_client.py
@@ -50,7 +50,13 @@ def main() -> None:
     metadata = client.get_server_metadata()
     print("server metadata:", metadata)
 
-    observation = synthetic_observation(prompt=args.prompt)
+    observation = synthetic_observation(
+        # The wire contract comes from the server, not from a constant here —
+        # hardcoding keys is the mismatch that shows up as "bad accuracy".
+        image_keys=metadata["image_keys"],
+        state_key=metadata["state_key"],
+        prompt=args.prompt,
+    )
     response = client.infer(observation)
 
     actions = np.asarray(response["actions"], dtype=np.float32)

--- a/python/apxinf/examples/openpi_server.py
+++ b/python/apxinf/examples/openpi_server.py
@@ -31,6 +31,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--precision", choices=("auto", "fp8", "bf16", "int8"), default="bf16")
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--action-dim", type=int, default=7, help="0 keeps the full vector")
+    parser.add_argument(
+        "--image-keys",
+        default=None,
+        help=(
+            "comma-separated camera wire keys, in model view-slot order. Omitted, "
+            "the policy names them after its own view slots (base_0_rgb, ...) — a "
+            "real deployment states its robot's keys, or uses --robot on "
+            "scripts/pi05_openpi_websocket_server.py, which has the preset table."
+        ),
+    )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     return parser.parse_args()
@@ -45,6 +55,11 @@ def main() -> None:
         device=args.device,
         precision=args.precision,
         action_dim=(args.action_dim or None),
+        image_keys=(
+            tuple(key.strip() for key in args.image_keys.split(",") if key.strip())
+            if args.image_keys
+            else None
+        ),
         # Extra metadata is sent to the client on connect (get_server_metadata).
         metadata={"protocol": "openpi.websocket_policy", "precision": args.precision},
     )

--- a/python/apxinf/examples/pi05policy_infer.py
+++ b/python/apxinf/examples/pi05policy_infer.py
@@ -49,7 +49,7 @@ def main() -> None:
     try:
         print("metadata:", policy.metadata)
 
-        observation = synthetic_observation(image_keys=policy.image_keys)
+        observation = synthetic_observation(image_keys=policy.image_keys, state_key=policy.state_key)
         result = policy.infer(observation)
 
         actions = result["actions"]

--- a/python/apxinf/pyproject.toml
+++ b/python/apxinf/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
 
 [project.optional-dependencies]
 # The prompt tokenizer needs sentencepiece; the golden/layering tests want it too.
-tokenizer = ["sentencepiece>=0.1.99"]
+tokenizer = ["sentencepiece>=0.1.99", "tokenizers>=0.20"]
+groot = ["tokenizers>=0.20", "opencv-python-headless>=4.8"]
 # A live Pi05Policy binds the PyO3 model handle (Phase 1).
 policy = ["apxinf-py>=0.1.0"]
 # The OpenPI-compatible websocket server (apxinf.serving) needs the transport deps.

--- a/python/apxinf/tests/test_checkpoint_layout.py
+++ b/python/apxinf/tests/test_checkpoint_layout.py
@@ -1,0 +1,401 @@
+"""Checkpoint layout detection: which format, and which files it implies.
+
+Offline and dependency-free — no torch, no CUDA, no real checkpoint. The
+``metadata.pt`` fixtures are built by hand because that is precisely the claim
+under test: ``torch.save``'s modern format is a zip whose ``<archive>/data.pkl``
+member is an ordinary pickle, so the standard library can read one. If that ever
+stops being true these tests fail rather than the field.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pickle
+import zipfile
+from collections import Counter, OrderedDict
+from pathlib import Path
+
+import pytest
+
+from apxinf.checkpoints import (
+    LEROBOT,
+    OPENPI_PYTORCH,
+    CheckpointError,
+    MetadataError,
+    detect_checkpoint,
+    read_metadata_pt,
+    require_norm_stats,
+    resolve_tokenizer,
+    train_config_facts,
+)
+
+STATS = {"actions": {"q01": [-1.0] * 16, "q99": [1.0] * 16}, "state": {"q01": [0.0] * 16, "q99": [1.0] * 16}}
+
+
+def write_metadata_pt(path: Path, payload) -> Path:
+    """Write ``payload`` the way ``torch.save`` does: a zip around one pickle."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("metadata/data.pkl", pickle.dumps(payload, protocol=2))
+        archive.writestr("metadata/version", "3\n")
+    return path
+
+
+def openpi_payload(
+    *,
+    asset_id="groundwire",
+    repo_id=None,
+    images=("cam_high", "cam_left_wrist", "cam_right_wrist"),
+    **model_overrides,
+):
+    """A payload shaped like a real openpi ``TrainConfig`` dump."""
+    model = {
+        "action_dim": 32,
+        "action_horizon": 50,
+        "max_token_len": 200,
+        "discrete_state_input": True,
+        "pi05": True,
+        "paligemma_variant": "gemma_2b",
+        "action_expert_variant": "gemma_300m",
+    }
+    model.update(model_overrides)
+    return {
+        "global_step": 14002,
+        "timestamp": "2025-07-27T17:01:00",
+        "config": {
+            "exp_name": "pi05_UnitreeG1_groundwire",
+            "model": model,
+            "data": {
+                "repo_id": repo_id,
+                "assets": {"assets_dir": "/mnt/a/yehua/yangqi/UnitreeG1/", "asset_id": asset_id},
+                "adapt_to_pi": True,
+                "use_delta_joint_actions": True,
+                "default_prompt": "",
+                "repack_transforms": {
+                    "inputs": [
+                        {
+                            "structure": {
+                                "images": {key: f"observation.images.{key}" for key in images},
+                                "state": "observation.state",
+                            }
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+
+def openpi_dir(root: Path, *, stats_at=None, **kwargs) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model.safetensors").write_bytes(b"")
+    write_metadata_pt(root / "metadata.pt", openpi_payload(**kwargs))
+    if stats_at is not None:
+        target = root / stats_at
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(STATS))
+    return root
+
+
+def lerobot_dir(root: Path, *, stats=True) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model.safetensors").write_bytes(b"")
+    (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 50}))
+    if stats:
+        (root / "norm_stats.json").write_text(json.dumps(STATS))
+    return root
+
+
+# --- the torch-free metadata.pt reader -------------------------------------
+
+
+def test_reads_a_torch_style_zip_without_torch(tmp_path):
+    path = write_metadata_pt(tmp_path / "metadata.pt", openpi_payload())
+    payload = read_metadata_pt(path)
+    assert payload["global_step"] == 14002
+    assert payload["config"]["model"]["action_horizon"] == 50
+
+
+def test_ordered_dict_survives_but_other_classes_are_stubbed(tmp_path):
+    """Container types on the allowlist are real; everything else is inert."""
+    path = write_metadata_pt(
+        tmp_path / "metadata.pt", {"ordered": OrderedDict(a=1), "counter": Counter("aab")}
+    )
+    payload = read_metadata_pt(path)
+    assert payload["ordered"] == OrderedDict(a=1)
+    assert not isinstance(payload["counter"], Counter)
+
+
+def test_builtins_are_not_blanket_allowed():
+    """``builtins.eval`` must not resolve: this parses untrusted checkpoints.
+
+    The allowlist is ``(module, name)`` pairs rather than module names for
+    exactly this reason — ``collections`` and ``builtins`` both contain harmless
+    container types *and* a route to arbitrary execution.
+    """
+    import io
+
+    from apxinf.checkpoints.metadata import _RestrictedUnpickler
+
+    unpickler = _RestrictedUnpickler(io.BytesIO(b""))
+    for module, name in (("builtins", "eval"), ("builtins", "exec"), ("os", "system")):
+        resolved = unpickler.find_class(module, name)
+        assert resolved is not eval and callable(resolved)
+        assert resolved().__class__.__name__ == name  # an inert stub instance
+
+    # The container types that *are* allowed still come back for real.
+    assert unpickler.find_class("collections", "OrderedDict") is OrderedDict
+
+
+def test_non_zip_file_is_reported_not_crashed(tmp_path):
+    path = tmp_path / "metadata.pt"
+    path.write_bytes(b"not a zip at all")
+    with pytest.raises(MetadataError, match="not a zip-format torch archive"):
+        read_metadata_pt(path)
+
+
+def test_missing_config_key_is_reported(tmp_path):
+    path = write_metadata_pt(tmp_path / "metadata.pt", {"global_step": 1})
+    with pytest.raises(MetadataError, match="no 'config' dict"):
+        train_config_facts(read_metadata_pt(path))
+
+
+# --- fact extraction --------------------------------------------------------
+
+
+def test_architecture_is_extracted_in_config_json_vocabulary(tmp_path):
+    facts = train_config_facts(openpi_payload())
+    assert facts["arch"] == {
+        "action_dim": 32,
+        "action_horizon": 50,
+        "max_token_len": 200,
+        "num_views": 3,  # counted from the repack image structure
+        "discrete_state_input": True,
+    }
+    # Upstream openpi does not serialize num_steps, and asserting a value the
+    # checkpoint never stated would present the loader's default as a fact.
+    assert "num_flow_steps" not in facts["arch"]
+
+
+def test_unnamed_cameras_leave_num_views_to_the_loader():
+    """RLinf's shape: a TrainConfig with no repack image structure at all."""
+    facts = train_config_facts(openpi_payload(images=()))
+    assert facts["image_keys"] == ()
+    assert "num_views" not in facts["arch"]
+
+
+def test_fork_specific_num_steps_wins_over_the_default():
+    facts = train_config_facts(openpi_payload(num_steps=5, action_horizon=5))
+    assert facts["arch"]["num_flow_steps"] == 5
+    assert facts["arch"]["action_horizon"] == 5
+
+
+def test_asset_id_comes_from_assets_then_repo_id():
+    explicit = train_config_facts(openpi_payload(asset_id="groundwire", repo_id="x/y"))
+    assert (explicit["asset_id"], explicit["asset_id_source"]) == (
+        "groundwire",
+        "data.assets.asset_id",
+    )
+
+    # openpi: `asset_id = data.assets.asset_id or data.repo_id`.
+    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="RLinf/pick_red"))
+    assert (fallback["asset_id"], fallback["asset_id_source"]) == (
+        "RLinf/pick_red",
+        "data.repo_id",
+    )
+
+
+def test_deployment_facts_are_carried_through():
+    facts = train_config_facts(openpi_payload())
+    assert facts["image_keys"] == ("cam_high", "cam_left_wrist", "cam_right_wrist")
+    assert facts["state_key"] == "observation.state"
+    assert facts["adapt_to_pi"] is True
+    assert facts["use_delta_joint_actions"] is True
+    assert facts["exp_name"] == "pi05_UnitreeG1_groundwire"
+    assert facts["global_step"] == 14002
+
+
+def test_a_pi0_checkpoint_is_refused():
+    with pytest.raises(MetadataError, match="pi05=False"):
+        train_config_facts(openpi_payload(pi05=False))
+
+
+def test_an_unsupported_backbone_is_refused():
+    with pytest.raises(MetadataError, match="paligemma_variant"):
+        train_config_facts(openpi_payload(paligemma_variant="gemma_2b_lora"))
+
+
+# --- format detection -------------------------------------------------------
+
+
+def test_openpi_export_is_detected_from_metadata_pt(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    layout = detect_checkpoint(root)
+    assert layout.format == OPENPI_PYTORCH
+    assert layout.asset_id == "groundwire"
+    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+    assert json.loads(layout.config_json_text())["num_views"] == 3
+
+
+def test_lerobot_directory_is_detected_from_config_json(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt")
+    layout = detect_checkpoint(root)
+    assert layout.format == LEROBOT
+    assert layout.norm_stats == root / "norm_stats.json"
+    # No architecture override: the Rust loader reads config.json itself, which
+    # is what LeRobot checkpoints already did.
+    assert layout.config_json_text() is None
+
+
+def test_metadata_pt_outranks_a_stale_config_json(tmp_path):
+    """The customer's directory shape: real metadata.pt, hand-added config.json."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 10}))
+
+    layout = detect_checkpoint(root)
+    assert layout.format == OPENPI_PYTORCH
+    assert json.loads(layout.config_json_text())["action_horizon"] == 50
+    assert any("config.json is ignored" in note for note in layout.notes)
+
+
+def test_neither_layout_names_both_requirements(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    with pytest.raises(CheckpointError) as excinfo:
+        detect_checkpoint(root)
+    message = str(excinfo.value)
+    assert "metadata.pt" in message and "config.json" in message
+
+
+def test_pinned_format_does_not_fall_back_to_sniffing(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt")
+    with pytest.raises(CheckpointError, match="metadata.pt does not"):
+        detect_checkpoint(root, checkpoint_format=OPENPI_PYTORCH)
+
+
+# --- norm_stats resolution --------------------------------------------------
+
+
+def test_slashed_asset_id_becomes_nested_directories(tmp_path):
+    """RLinf's shape: no asset_id, so openpi falls back to repo_id 'org/name'."""
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        asset_id=None,
+        repo_id="RLinf/pick_red",
+        stats_at="assets/RLinf/pick_red/norm_stats.json",
+    )
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats == root / "assets/RLinf/pick_red/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+
+
+def test_asset_path_without_the_assets_prefix_is_accepted(tmp_path):
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        asset_id=None,
+        repo_id="RLinf/pick_red",
+        stats_at="RLinf/pick_red/norm_stats.json",
+    )
+    assert detect_checkpoint(root).norm_stats == root / "RLinf/pick_red/norm_stats.json"
+
+
+def test_root_fallback_is_used_and_logged(tmp_path, caplog):
+    """The decision: keep reading the root file, but never do it silently."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="norm_stats.json")
+    with caplog.at_level(logging.WARNING, logger="apxinf.checkpoints"):
+        layout = detect_checkpoint(root)
+
+    assert layout.norm_stats == root / "norm_stats.json"
+    assert layout.norm_stats_is_fallback is True
+    message = caplog.text
+    assert "assets/groundwire/norm_stats.json" in message  # the path that missed
+    assert str(root / "norm_stats.json") in message  # the one actually used
+    assert "groundwire" in message  # the asset_id, so the ask is actionable
+
+
+def test_the_asset_path_wins_over_a_root_file(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    (root / "norm_stats.json").write_text(json.dumps(STATS))
+
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats_is_fallback is False
+    assert any("is ignored" in note for note in layout.notes)
+
+
+def test_explicit_path_outranks_every_convention(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    elsewhere = tmp_path / "elsewhere" / "norm_stats.json"
+    elsewhere.parent.mkdir()
+    elsewhere.write_text(json.dumps(STATS))
+
+    assert detect_checkpoint(root, norm_stats=elsewhere).norm_stats == elsewhere
+
+
+def test_explicit_asset_id_overrides_metadata(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/other/norm_stats.json")
+    layout = detect_checkpoint(root, asset_id="other")
+    assert layout.norm_stats == root / "assets/other/norm_stats.json"
+    assert layout.asset_id_source == "explicit override"
+
+
+def test_a_traversing_asset_id_is_refused(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt", asset_id="../../etc")
+    with pytest.raises(CheckpointError, match="not a usable relative path"):
+        detect_checkpoint(root)
+
+
+def test_missing_stats_is_deferred_not_raised_by_detection(tmp_path):
+    """preflight reports all findings at once, so detection must not crash."""
+    root = openpi_dir(tmp_path / "ckpt")
+    layout = detect_checkpoint(root)
+    assert layout.norm_stats is None
+    assert len(layout.norm_stats_tried) == 3
+
+
+def test_require_norm_stats_names_every_path_and_the_asset_id(tmp_path):
+    root = openpi_dir(tmp_path / "ckpt")
+    with pytest.raises(CheckpointError) as excinfo:
+        require_norm_stats(detect_checkpoint(root))
+    message = str(excinfo.value)
+    for candidate in ("assets/groundwire/norm_stats.json", "groundwire/norm_stats.json"):
+        assert str(root / candidate) in message
+    assert "train_pytorch.py" in message  # where the file comes from
+
+
+def test_lerobot_error_explains_where_lerobot_keeps_statistics(tmp_path):
+    root = lerobot_dir(tmp_path / "ckpt", stats=False)
+    with pytest.raises(CheckpointError) as excinfo:
+        require_norm_stats(detect_checkpoint(root))
+    message = str(excinfo.value)
+    assert "normalizer_processor.safetensors" in message
+    assert "meta/stats.json" in message
+
+
+# --- tokenizer --------------------------------------------------------------
+
+
+def test_tokenizer_resolution_order(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    (root / "paligemma_tokenizer.model").write_bytes(b"sp")
+    elsewhere = tmp_path / "shared.model"
+    elsewhere.write_bytes(b"sp")
+
+    assert resolve_tokenizer(root, elsewhere) == elsewhere
+    assert resolve_tokenizer(root, env={"APXINF_TOKENIZER": str(elsewhere)}) == elsewhere
+    assert resolve_tokenizer(root, env={}) == root / "paligemma_tokenizer.model"
+
+
+def test_tokenizer_error_says_where_to_get_the_file(tmp_path):
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    with pytest.raises(CheckpointError) as excinfo:
+        resolve_tokenizer(root, env={})
+    message = str(excinfo.value)
+    assert "gs://big_vision/paligemma_tokenizer.model" in message
+    assert "APXINF_TOKENIZER" in message
+    assert str(root / "paligemma_tokenizer.model") in message

--- a/python/apxinf/tests/test_checkpoint_layout.py
+++ b/python/apxinf/tests/test_checkpoint_layout.py
@@ -44,7 +44,7 @@ def write_metadata_pt(path: Path, payload) -> Path:
 
 def openpi_payload(
     *,
-    asset_id="groundwire",
+    asset_id="example-asset",
     repo_id=None,
     images=("cam_high", "cam_left_wrist", "cam_right_wrist"),
     **model_overrides,
@@ -64,11 +64,11 @@ def openpi_payload(
         "global_step": 14002,
         "timestamp": "2025-07-27T17:01:00",
         "config": {
-            "exp_name": "pi05_UnitreeG1_groundwire",
+            "exp_name": "pi05_unitree_g1_example",
             "model": model,
             "data": {
                 "repo_id": repo_id,
-                "assets": {"assets_dir": "/mnt/a/yehua/yangqi/UnitreeG1/", "asset_id": asset_id},
+                "assets": {"assets_dir": "/data/train-assets/", "asset_id": asset_id},
                 "adapt_to_pi": True,
                 "use_delta_joint_actions": True,
                 "default_prompt": "",
@@ -179,7 +179,7 @@ def test_architecture_is_extracted_in_config_json_vocabulary(tmp_path):
 
 
 def test_unnamed_cameras_leave_num_views_to_the_loader():
-    """RLinf's shape: a TrainConfig with no repack image structure at all."""
+    """A TrainConfig whose repack transform names no cameras at all."""
     facts = train_config_facts(openpi_payload(images=()))
     assert facts["image_keys"] == ()
     assert "num_views" not in facts["arch"]
@@ -192,16 +192,16 @@ def test_fork_specific_num_steps_wins_over_the_default():
 
 
 def test_asset_id_comes_from_assets_then_repo_id():
-    explicit = train_config_facts(openpi_payload(asset_id="groundwire", repo_id="x/y"))
+    explicit = train_config_facts(openpi_payload(asset_id="example-asset", repo_id="x/y"))
     assert (explicit["asset_id"], explicit["asset_id_source"]) == (
-        "groundwire",
+        "example-asset",
         "data.assets.asset_id",
     )
 
     # openpi: `asset_id = data.assets.asset_id or data.repo_id`.
-    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="RLinf/pick_red"))
+    fallback = train_config_facts(openpi_payload(asset_id=None, repo_id="some-org/some-task"))
     assert (fallback["asset_id"], fallback["asset_id_source"]) == (
-        "RLinf/pick_red",
+        "some-org/some-task",
         "data.repo_id",
     )
 
@@ -212,7 +212,7 @@ def test_deployment_facts_are_carried_through():
     assert facts["state_key"] == "observation.state"
     assert facts["adapt_to_pi"] is True
     assert facts["use_delta_joint_actions"] is True
-    assert facts["exp_name"] == "pi05_UnitreeG1_groundwire"
+    assert facts["exp_name"] == "pi05_unitree_g1_example"
     assert facts["global_step"] == 14002
 
 
@@ -230,11 +230,11 @@ def test_an_unsupported_backbone_is_refused():
 
 
 def test_openpi_export_is_detected_from_metadata_pt(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     layout = detect_checkpoint(root)
     assert layout.format == OPENPI_PYTORCH
-    assert layout.asset_id == "groundwire"
-    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.asset_id == "example-asset"
+    assert layout.norm_stats == root / "assets/example-asset/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
     assert json.loads(layout.config_json_text())["num_views"] == 3
 
@@ -250,8 +250,8 @@ def test_lerobot_directory_is_detected_from_config_json(tmp_path):
 
 
 def test_metadata_pt_outranks_a_stale_config_json(tmp_path):
-    """The customer's directory shape: real metadata.pt, hand-added config.json."""
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    """A shipped directory shape: real metadata.pt, hand-added config.json."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     (root / "config.json").write_text(json.dumps({"type": "pi05", "chunk_size": 10}))
 
     layout = detect_checkpoint(root)
@@ -280,15 +280,15 @@ def test_pinned_format_does_not_fall_back_to_sniffing(tmp_path):
 
 
 def test_slashed_asset_id_becomes_nested_directories(tmp_path):
-    """RLinf's shape: no asset_id, so openpi falls back to repo_id 'org/name'."""
+    """No asset_id, so openpi falls back to repo_id, which is 'org/name'."""
     root = openpi_dir(
         tmp_path / "ckpt",
         asset_id=None,
-        repo_id="RLinf/pick_red",
-        stats_at="assets/RLinf/pick_red/norm_stats.json",
+        repo_id="some-org/some-task",
+        stats_at="assets/some-org/some-task/norm_stats.json",
     )
     layout = detect_checkpoint(root)
-    assert layout.norm_stats == root / "assets/RLinf/pick_red/norm_stats.json"
+    assert layout.norm_stats == root / "assets/some-org/some-task/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
 
 
@@ -296,10 +296,10 @@ def test_asset_path_without_the_assets_prefix_is_accepted(tmp_path):
     root = openpi_dir(
         tmp_path / "ckpt",
         asset_id=None,
-        repo_id="RLinf/pick_red",
-        stats_at="RLinf/pick_red/norm_stats.json",
+        repo_id="some-org/some-task",
+        stats_at="some-org/some-task/norm_stats.json",
     )
-    assert detect_checkpoint(root).norm_stats == root / "RLinf/pick_red/norm_stats.json"
+    assert detect_checkpoint(root).norm_stats == root / "some-org/some-task/norm_stats.json"
 
 
 def test_root_fallback_is_used_and_logged(tmp_path, caplog):
@@ -311,23 +311,23 @@ def test_root_fallback_is_used_and_logged(tmp_path, caplog):
     assert layout.norm_stats == root / "norm_stats.json"
     assert layout.norm_stats_is_fallback is True
     message = caplog.text
-    assert "assets/groundwire/norm_stats.json" in message  # the path that missed
+    assert "assets/example-asset/norm_stats.json" in message  # the path that missed
     assert str(root / "norm_stats.json") in message  # the one actually used
-    assert "groundwire" in message  # the asset_id, so the ask is actionable
+    assert "example-asset" in message  # the asset_id, so the ask is actionable
 
 
 def test_the_asset_path_wins_over_a_root_file(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     (root / "norm_stats.json").write_text(json.dumps(STATS))
 
     layout = detect_checkpoint(root)
-    assert layout.norm_stats == root / "assets/groundwire/norm_stats.json"
+    assert layout.norm_stats == root / "assets/example-asset/norm_stats.json"
     assert layout.norm_stats_is_fallback is False
     assert any("is ignored" in note for note in layout.notes)
 
 
 def test_explicit_path_outranks_every_convention(tmp_path):
-    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/groundwire/norm_stats.json")
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
     elsewhere = tmp_path / "elsewhere" / "norm_stats.json"
     elsewhere.parent.mkdir()
     elsewhere.write_text(json.dumps(STATS))
@@ -361,7 +361,7 @@ def test_require_norm_stats_names_every_path_and_the_asset_id(tmp_path):
     with pytest.raises(CheckpointError) as excinfo:
         require_norm_stats(detect_checkpoint(root))
     message = str(excinfo.value)
-    for candidate in ("assets/groundwire/norm_stats.json", "groundwire/norm_stats.json"):
+    for candidate in ("assets/example-asset/norm_stats.json", "example-asset/norm_stats.json"):
         assert str(root / candidate) in message
     assert "train_pytorch.py" in message  # where the file comes from
 
@@ -399,3 +399,148 @@ def test_tokenizer_error_says_where_to_get_the_file(tmp_path):
     assert "gs://big_vision/paligemma_tokenizer.model" in message
     assert "APXINF_TOKENIZER" in message
     assert str(root / "paligemma_tokenizer.model") in message
+
+
+# --- the wiring into Pi05Policy.from_pretrained -----------------------------
+#
+# Detection is only worth anything if what it resolves reaches the loader. An
+# openpi export has no config.json, so before this the Rust side fell back to
+# Pi05Config::default() without a word — a checkpoint with a 50-step horizon
+# would have been served at whatever the default happened to be.
+
+
+class _FakeModel:
+    action_horizon = 50
+    action_dim = 32
+    num_views = 3
+    image_size = 224
+    max_token_len = 200
+
+    def reset_sampling(self, seed=None):
+        pass
+
+
+def _load_with_fake_binding(monkeypatch, model_dir, **kwargs):
+    """Run ``from_pretrained`` against a stub binding; return the load kwargs."""
+    import sys
+    import types
+
+    from apxinf.policies.impls import pi05
+
+    captured = {}
+
+    class FakeBindingModel:
+        @staticmethod
+        def load(*args, **load_kwargs):
+            captured.update(load_kwargs)
+            captured["positional"] = args
+            return _FakeModel()
+
+    class FakePipeline:
+        names = []
+
+        def __getitem__(self, name):
+            raise KeyError(name)
+
+    monkeypatch.setitem(sys.modules, "apxinf_py", types.SimpleNamespace(Model=FakeBindingModel))
+    monkeypatch.setattr(pi05, "resolve_pi05_tactics", lambda *a, **k: None)
+    monkeypatch.setattr(pi05, "PromptTokenizer", lambda *a, **k: object())
+    monkeypatch.setattr(
+        pi05.Pi05Policy, "default_pipelines", classmethod(
+            lambda cls, *a, **k: (FakePipeline(), FakePipeline())
+        )
+    )
+    (Path(model_dir) / "paligemma_tokenizer.model").write_bytes(b"sp")
+    pi05.Pi05Policy.from_pretrained(model_dir, device="cuda:0", precision="bf16", **kwargs)
+    return captured
+
+
+def test_metadata_pt_architecture_reaches_the_rust_loader(tmp_path, monkeypatch):
+    root = openpi_dir(
+        tmp_path / "ckpt",
+        stats_at="assets/example-asset/norm_stats.json",
+        action_horizon=50,
+    )
+
+    captured = _load_with_fake_binding(monkeypatch, root, action_dim=16, discrete_state=False)
+
+    config = json.loads(captured["config_json"])
+    assert config["action_horizon"] == 50
+    assert config["action_dim"] == 32
+    assert config["num_views"] == 3
+
+
+def test_a_lerobot_directory_still_lets_the_loader_read_config_json(tmp_path, monkeypatch):
+    """No ``config_json=``: the Rust loader reads config.json itself, as before."""
+    root = lerobot_dir(tmp_path / "ckpt")
+
+    captured = _load_with_fake_binding(monkeypatch, root, action_dim=16, discrete_state=False)
+
+    assert "config_json" not in captured
+
+
+def test_the_asset_path_statistics_are_the_ones_loaded(tmp_path, monkeypatch):
+    """A wrong root file next to correct asset statistics — the delivered shape."""
+    root = openpi_dir(tmp_path / "ckpt", stats_at="assets/example-asset/norm_stats.json")
+    (root / "norm_stats.json").write_text(
+        json.dumps({"actions": {"q01": [-1.0] * 7, "q99": [1.0] * 7}})
+    )
+
+    from apxinf.policies.impls import pi05
+
+    seen = {}
+    original = pi05.Unnormalizer.from_norm_stats
+
+    def spy(*args, **kwargs):
+        seen.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(pi05.Unnormalizer, "from_norm_stats", spy)
+    _load_with_fake_binding(monkeypatch, root, discrete_state=False)
+
+    assert seen["path"] == root / "assets" / "example-asset" / "norm_stats.json"
+
+
+def test_a_flat_directory_loads_with_no_layout_at_all(tmp_path, monkeypatch):
+    """The hand-assembled layout that predates this module must keep working."""
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    (root / "norm_stats.json").write_text(json.dumps(STATS))
+
+    captured = _load_with_fake_binding(monkeypatch, root, discrete_state=False)
+
+    assert "config_json" not in captured
+
+
+def test_explicit_norm_stats_needs_no_layout(tmp_path, monkeypatch):
+    """``--norm-stats`` names one file; it does not assert a directory shape."""
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+    elsewhere = tmp_path / "stats.json"
+    elsewhere.write_text(json.dumps(STATS))
+
+    from apxinf.policies.impls import pi05
+
+    seen = {}
+    original = pi05.Unnormalizer.from_norm_stats
+    monkeypatch.setattr(
+        pi05.Unnormalizer,
+        "from_norm_stats",
+        lambda *a, **k: (seen.update(k), original(*a, **k))[1],
+    )
+    _load_with_fake_binding(monkeypatch, root, discrete_state=False, norm_stats=elsewhere)
+
+    assert seen["path"] == elsewhere
+
+
+def test_a_missing_explicit_norm_stats_path_is_refused(tmp_path, monkeypatch):
+    root = tmp_path / "flat"
+    root.mkdir()
+    (root / "model.safetensors").write_bytes(b"")
+
+    with pytest.raises(CheckpointError, match="does not exist"):
+        _load_with_fake_binding(
+            monkeypatch, root, discrete_state=False, norm_stats=tmp_path / "nope.json"
+        )

--- a/python/apxinf/tests/test_lerobot_adapter.py
+++ b/python/apxinf/tests/test_lerobot_adapter.py
@@ -23,7 +23,12 @@ from apxinf.adapters.lerobot import (
     IdentityProcessor,
     observation_to_apxinf,
 )
-from apxinf.processors import ProcessorStep, PromptTokenizer, Unnormalizer
+from apxinf.processors import (
+    GaussianNoise,
+    ProcessorStep,
+    PromptTokenizer,
+    Unnormalizer,
+)
 
 HORIZON = 10
 MODEL_DIM = 32
@@ -78,6 +83,12 @@ def build_policy() -> Pi05Policy:
         unnormalizer=Unnormalizer(
             q01=[-1.0] * LIBERO_DIM, q99=[1.0] * LIBERO_DIM, dims=LIBERO_DIM, eps=0.0
         ),
+        # Host-side noise, which the mock echoes back as the chunk. The queueing
+        # tests below need two things this gives them: rows that differ from each
+        # other (so "did the queue advance?" is answerable) and an RNG that moves
+        # per call (so "was it re-inferred?" is answerable). Without it the mock
+        # returns a constant chunk and those assertions cannot fail.
+        noise=GaussianNoise(HORIZON, MODEL_DIM, seed=0),
         image_keys=APXINF_KEYS,
     )
     return Pi05Policy(

--- a/python/apxinf/tests/test_normalize_golden.py
+++ b/python/apxinf/tests/test_normalize_golden.py
@@ -19,9 +19,12 @@ def ref_unnormalize(normalized: np.ndarray, q01: np.ndarray, q99: np.ndarray) ->
 
 
 def ref_digitize(state: np.ndarray) -> np.ndarray:
-    # NumPy digitize(state, linspace(-1, 1, 257)[:-1]) - 1, with saturation.
+    # Verbatim from openpi models/tokenizer.py. Note there is NO lower clamp:
+    # digitize returns 0 for v < -1, so the bin is -1 and openpi puts that
+    # straight into the prompt. An earlier version of this helper clipped to
+    # [0, 255], which made the test agree with a wrong implementation.
     edges = np.linspace(-1.0, 1.0, 257)[:-1]
-    return np.clip(np.digitize(state, edges) - 1, 0, 255).astype(np.uint8)
+    return (np.digitize(state, edges) - 1).astype(np.int16)
 
 
 @pytest.fixture
@@ -71,8 +74,36 @@ def test_mean_std_roundtrip():
 
 def test_wrong_last_dim_raises(quantiles):
     q01, q99 = quantiles
+    # Narrower than the stats is a genuine mismatch on both steps...
     with pytest.raises(ValueError):
-        Unnormalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM + 1), dtype=np.float32))
+        Unnormalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM - 1), dtype=np.float32))
+    with pytest.raises(ValueError):
+        Normalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM - 1), dtype=np.float32))
+    # ...and so is a *wider* array on the input side, where openpi's Normalize
+    # would broadcast-fail too. Only Unnormalizer widens; see below.
+    with pytest.raises(ValueError):
+        Normalizer(q01=q01, q99=q99)(np.zeros((4, LIBERO_DIM + 1), dtype=np.float32))
+
+
+def test_unnormalize_passes_a_wider_array_s_tail_through(quantiles):
+    """openpi ``Unnormalize._unnormalize_quantile``'s narrow-stats branch.
+
+    A checkpoint's ``norm_stats`` is the robot's width (16 for a Unitree G1)
+    while the model emits its padded width (32), so without this the G1 path
+    cannot serve a real ``norm_stats.json`` at all.
+    """
+    q01, q99 = quantiles
+    pad = 4
+    rng = np.random.default_rng(5)
+    wide = rng.uniform(-1.0, 1.0, size=(3, LIBERO_DIM + pad)).astype(np.float32)
+
+    got = Unnormalizer(q01=q01, q99=q99)(wide)
+
+    assert got.shape == wide.shape
+    # The head is unnormalized exactly as if the tail were not there...
+    np.testing.assert_array_equal(got[:, :LIBERO_DIM], Unnormalizer(q01=q01, q99=q99)(wide[:, :LIBERO_DIM]))
+    # ...and the tail is copied verbatim, not scaled by some implied identity.
+    np.testing.assert_array_equal(got[:, LIBERO_DIM:], wide[:, LIBERO_DIM:])
 
 
 def test_discretize_matches_numpy_digitize():
@@ -81,8 +112,36 @@ def test_discretize_matches_numpy_digitize():
     np.testing.assert_array_equal(discretize_state(state), ref_digitize(state))
 
 
-def test_discretize_saturates_out_of_range():
-    state = np.array([-5.0, -1.0, 0.0, 0.99999, 1.0, 5.0], dtype=np.float32)
+def test_discretize_underflows_signed_and_saturates_high():
+    # Under -1 openpi emits -1, not 0: that token is in the training distribution.
+    state = np.array([-5.0, -1.0000001, -1.0, 0.0, 0.99999, 1.0, 5.0], dtype=np.float64)
     out = discretize_state(state)
-    assert out[0] == 0 and out[-1] == 255
-    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out, ref_digitize(state))
+    np.testing.assert_array_equal(out, [-1, -1, 0, 128, 255, 255, 255])
+    assert out.dtype == np.int16
+
+
+def test_discretize_matches_digitize_on_bin_edges():
+    edges = np.linspace(-1.0, 1.0, 257)[:-1]
+    for probe in (edges, edges - 1e-9, edges + 1e-9):
+        np.testing.assert_array_equal(discretize_state(probe), ref_digitize(probe))
+
+
+def test_discretize_matches_digitize_one_ulp_from_every_edge():
+    """The ±1e-9 probe above is ~10 million ulps wide and misses the real trap.
+
+    ``floor((v + 1.0) * 128.0)`` -- the obvious way to write this -- is not equal
+    to ``digitize``. For a value one ulp below an edge in ``[-1, -0.5)``, adding
+    ``1.0`` moves it into a binade with twice the ulp, the sum rounds *up* onto
+    the edge, and the index comes out one bin high. One bin is a different prompt
+    string, hence different token ids, hence a different rollout.
+    """
+    edges = np.linspace(-1.0, 1.0, 257)[:-1]
+    for probe in (np.nextafter(edges, -np.inf), np.nextafter(edges, np.inf)):
+        np.testing.assert_array_equal(discretize_state(probe), ref_digitize(probe))
+
+    # The one f64 value that the arithmetic form gets wrong, pinned by name.
+    trap = np.nextafter(-0.4921875, -np.inf)
+    assert np.floor((trap + 1.0) * 128.0) == 65, "the trap this test guards"
+    assert discretize_state([trap])[0] == 64
+    np.testing.assert_array_equal(discretize_state([trap]), ref_digitize(np.array([trap])))

--- a/python/apxinf/tests/test_policy_layering.py
+++ b/python/apxinf/tests/test_policy_layering.py
@@ -270,7 +270,9 @@ def test_reorder_independent_pre_steps_is_identical():
 
     model, in_pipe, out_pipe = make_parts()
     reordered = in_pipe.reorder(["tokenize", "image_stack"])
-    policy = Pi05Policy(model, input_pipeline=reordered, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=reordered, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     np.testing.assert_array_equal(policy.infer(obs)["actions"], baseline)
 
 
@@ -286,7 +288,9 @@ def test_insert_passthrough_step_does_not_change_result():
 
     model, in_pipe, out_pipe = make_parts()
     injected = in_pipe.insert_after("image_stack", ("noop", Passthrough()))
-    policy = Pi05Policy(model, input_pipeline=injected, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=injected, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     assert policy.metadata["input_pipeline"] == ["image_stack", "noop", "tokenize"]
     np.testing.assert_array_equal(policy.infer(obs)["actions"], baseline)
 
@@ -298,8 +302,11 @@ def test_explicit_host_sampler_remains_pluggable():
         tokenizer=ConstTokenizer(),
         unnormalizer=make_quantile_unnormalizer(),
         noise=GaussianNoise(HORIZON, MODEL_DIM, seed=7),
+        image_keys=DEFAULT_KEYS,
     )
-    policy = Pi05Policy(model, input_pipeline=in_pipe, output_pipeline=out_pipe)
+    policy = Pi05Policy(
+        model, input_pipeline=in_pipe, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    )
     assert policy.metadata["input_pipeline"] == ["image_stack", "tokenize", "sample_noise"]
     result = policy.infer(make_obs())
     assert result["noise"] is not None
@@ -312,7 +319,9 @@ def test_default_vs_explicitly_built_pipeline_are_bit_identical():
     default = build_policy().infer(obs)
 
     model, in_pipe, out_pipe = make_parts()
-    explicit = Pi05Policy(model, input_pipeline=in_pipe, output_pipeline=out_pipe).infer(obs)
+    explicit = Pi05Policy(
+        model, input_pipeline=in_pipe, output_pipeline=out_pipe, image_keys=DEFAULT_KEYS
+    ).infer(obs)
     np.testing.assert_array_equal(default["actions"], explicit["actions"])
     np.testing.assert_array_equal(default["normalized_actions"], explicit["normalized_actions"])
     np.testing.assert_array_equal(default["token_ids"], explicit["token_ids"])

--- a/python/apxinf/tests/test_tactics.py
+++ b/python/apxinf/tests/test_tactics.py
@@ -94,11 +94,16 @@ class Pi05TacticSelectionTest(unittest.TestCase):
             "default_pipelines",
             return_value=(FakePipeline(), FakePipeline()),
         ):
+            # A real (empty) file: the tokenizer path is checked for existence
+            # now, so a typo'd --tokenizer fails at load instead of inside
+            # SentencePiece. PromptTokenizer itself is mocked out here.
+            tokenizer_path = pathlib.Path(model_dir) / "paligemma_tokenizer.model"
+            tokenizer_path.write_bytes(b"")
             pi05.Pi05Policy.from_pretrained(
                 model_dir,
                 device="cuda:0",
                 precision="bf16",
-                tokenizer_path="unused-tokenizer.model",
+                tokenizer_path=str(tokenizer_path),
             )
 
         resolve.assert_called_once_with(

--- a/scripts/eval_libero.py
+++ b/scripts/eval_libero.py
@@ -52,6 +52,13 @@ from PIL import Image
 
 # --- rollout protocol constants (OpenPI's public PI0.5 LIBERO configuration) ---
 LIBERO_ACTION_DIM = 7
+
+#: LIBERO's camera wire keys, in model view-slot order. Stated here because the
+#: policy layer no longer defaults to them: these are a *dataset* convention, and
+#: a default in the model layer silently applied them to every checkpoint. The
+#: same pair is what the ``franka_libero`` preset serves.
+LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+LIBERO_STATE_KEY = "observation/state"
 MAX_STEPS = 520
 WAIT_STEPS = 10
 REPLAN_STEPS = 5
@@ -289,9 +296,9 @@ def _observation(base, wrist, state, prompt) -> dict:
     """The OpenPI LIBERO observation both backends consume, identical on the wire
     and in-process."""
     return {
-        "observation/image": base,
-        "observation/wrist_image": wrist,
-        "observation/state": state,
+        LIBERO_IMAGE_KEYS[0]: base,
+        LIBERO_IMAGE_KEYS[1]: wrist,
+        LIBERO_STATE_KEY: state,
         "prompt": prompt,
     }
 
@@ -377,6 +384,10 @@ class InProcessBackend:
             action_horizon=args.action_horizon,
             seed=args.seed,
             discrete_state=args.discrete_state,
+            # LIBERO's wire keys, stated rather than inherited: the policy layer
+            # holds no dataset's convention as a default.
+            image_keys=LIBERO_IMAGE_KEYS,
+            state_key=LIBERO_STATE_KEY,
             metadata={"precision": args.precision, "policy": "libero"},
         )
         self.metadata = dict(getattr(self._policy, "metadata", {}))

--- a/scripts/eval_libero.py
+++ b/scripts/eval_libero.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import functools
 import json
 import math
 import os
@@ -53,12 +54,10 @@ from PIL import Image
 # --- rollout protocol constants (OpenPI's public PI0.5 LIBERO configuration) ---
 LIBERO_ACTION_DIM = 7
 
-#: LIBERO's camera wire keys, in model view-slot order. Stated here because the
-#: policy layer no longer defaults to them: these are a *dataset* convention, and
-#: a default in the model layer silently applied them to every checkpoint. The
-#: same pair is what the ``franka_libero`` preset serves.
-LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
-LIBERO_STATE_KEY = "observation/state"
+#: The preset whose wire contract this evaluator drives. The keys themselves are
+#: *not* restated here: they are read from the table below, so the evaluator and
+#: the server cannot drift into two different dialects of "LIBERO".
+LIBERO_PRESET = "franka_libero"
 MAX_STEPS = 520
 WAIT_STEPS = 10
 REPLAN_STEPS = 5
@@ -74,6 +73,28 @@ ALL_SUITES = (
 )
 
 LedgerKey = Tuple[str, int, int]  # (suite, task_id, trial_id)
+
+
+def _add_apxinf_to_path() -> None:
+    """Make ``import apxinf`` work from a source checkout, idempotently."""
+    package_dir = pathlib.Path(__file__).resolve().parents[1] / "python" / "apxinf"
+    if package_dir.is_dir() and str(package_dir) not in sys.path:
+        sys.path.insert(0, str(package_dir))
+
+
+@functools.lru_cache(maxsize=1)
+def libero_convention():
+    """LIBERO's wire dialect, read from the preset table rather than restated.
+
+    Both backends send the same observation, so both resolve it here: the keys
+    the evaluator writes are by construction the keys ``--robot franka_libero``
+    serves. Importing ``apxinf`` costs no CUDA (the binding is loaded lazily by
+    ``from_pretrained``), so the websocket backend pays nothing for this.
+    """
+    _add_apxinf_to_path()
+    from apxinf import get_robot_preset
+
+    return get_robot_preset(LIBERO_PRESET).convention
 
 
 # --- LIBERO harness (inlined; was scripts/libero_harness.py) ------------------
@@ -294,12 +315,13 @@ class Backend(Protocol):
 
 def _observation(base, wrist, state, prompt) -> dict:
     """The OpenPI LIBERO observation both backends consume, identical on the wire
-    and in-process."""
+    and in-process. Keys come from the preset table, not from constants here."""
+    convention = libero_convention()
     return {
-        LIBERO_IMAGE_KEYS[0]: base,
-        LIBERO_IMAGE_KEYS[1]: wrist,
-        LIBERO_STATE_KEY: state,
-        "prompt": prompt,
+        convention.image_keys[0]: base,
+        convention.image_keys[1]: wrist,
+        convention.state_key: state,
+        convention.prompt_key: prompt,
     }
 
 
@@ -362,14 +384,12 @@ class InProcessBackend:
     """
 
     def __init__(self, args: argparse.Namespace) -> None:
-        # Lazy: importing apxinf pulls in the CUDA binding; websocket-only users
+        # Lazy: importing apxinf pulls in the policy stack; websocket-only users
         # never pay for it. Make ``import apxinf`` work from a source checkout.
-        repo_root = pathlib.Path(__file__).resolve().parents[1]
-        package_dir = repo_root / "python" / "apxinf"
-        if package_dir.is_dir() and str(package_dir) not in sys.path:
-            sys.path.insert(0, str(package_dir))
+        _add_apxinf_to_path()
         from apxinf import AutoPolicy
 
+        convention = libero_convention()
         self._policy = AutoPolicy.from_pretrained(
             args.model_dir,
             model_type=args.model_type,
@@ -384,10 +404,13 @@ class InProcessBackend:
             action_horizon=args.action_horizon,
             seed=args.seed,
             discrete_state=args.discrete_state,
-            # LIBERO's wire keys, stated rather than inherited: the policy layer
-            # holds no dataset's convention as a default.
-            image_keys=LIBERO_IMAGE_KEYS,
-            state_key=LIBERO_STATE_KEY,
+            # LIBERO's wire keys, read from the ``franka_libero`` preset rather
+            # than restated: the policy layer holds no dataset's convention as a
+            # default, and this evaluator should not become a second source of
+            # truth for what "LIBERO keys" means.
+            image_keys=convention.image_keys,
+            state_key=convention.state_key,
+            prompt_key=convention.prompt_key,
             metadata={"precision": args.precision, "policy": "libero"},
         )
         self.metadata = dict(getattr(self._policy, "metadata", {}))

--- a/scripts/g1_adapter_smoke.py
+++ b/scripts/g1_adapter_smoke.py
@@ -30,7 +30,6 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
 
 from apxinf import build_unitree_g1_policy  # noqa: E402
 from apxinf.processors import Unnormalizer  # noqa: E402
-from apxinf.processors.transforms import Unnormalize  # noqa: E402
 from apxinf.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY  # noqa: E402
 
 
@@ -47,20 +46,17 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Full-model-width identity unnormalizer: [50,32] passes through unchanged so
-    # the 32->16 robot truncation and delta->absolute run on the raw model output.
-    identity = None  # built after we know the model width
-
-    # Build once to learn the model width, then rebuild with a matching identity.
-    # (Cheap: model load dominates; we load a single time by peeking metadata.)
+    # Load the handle first so the identity unnormalizer can be built at the
+    # model's own width: [50,32] then passes through unchanged, so delta->absolute
+    # and the 32->16 robot truncation run on the raw model output.
     import apxinf_py
 
     model = apxinf_py.Model.load(
         "pi05", str(args.model_dir / "model.safetensors"), device=args.device, precision=args.precision
     )
     width = model.action_dim
-    identity = Unnormalize(
-        Unnormalizer(mean=np.zeros(width, np.float32), std=np.ones(width, np.float32), mode="mean_std")
+    identity = Unnormalizer(
+        mean=np.zeros(width, np.float32), std=np.ones(width, np.float32), mode="mean_std"
     )
 
     policy = build_unitree_g1_policy(
@@ -69,7 +65,7 @@ def main():
         use_delta_joint_actions=True,
         adapt_to_pi=True,
         state_key=G1_STATE_KEY,
-        unnormalizer=identity,
+        unnormalizer=identity,  # injected into the model's own unnormalize step
         precision=args.precision,
         device=args.device,
         metadata={"config": "pi05_UnitreeG1_groundwire", "note": "stand-in ckpt, shape-only"},

--- a/scripts/g1_adapter_smoke.py
+++ b/scripts/g1_adapter_smoke.py
@@ -29,8 +29,8 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import build_unitree_g1_policy  # noqa: E402
+from apxinf.conventions import UNITREE_G1 as G1_KEYS  # noqa: E402
 from apxinf.processors import Unnormalizer  # noqa: E402
-from apxinf.robots.unitree_g1 import G1_CAMERAS, G1_STATE_KEY  # noqa: E402
 
 
 def parse_args():
@@ -64,7 +64,8 @@ def main():
         model=model,  # reuse the already-loaded handle
         use_delta_joint_actions=True,
         adapt_to_pi=True,
-        state_key=G1_STATE_KEY,
+        state_key=G1_KEYS.state_key,
+        image_keys=G1_KEYS.image_keys,
         unnormalizer=identity,  # injected into the model's own unnormalize step
         precision=args.precision,
         device=args.device,
@@ -86,13 +87,13 @@ def main():
     # level under "images", state flat. The policy's image_keys are the paths
     # ("images/cam_high"), which lookup_key walks into this dict.
     groups: dict = {}
-    for key in G1_CAMERAS:
+    for key in G1_KEYS.image_keys:
         group, _, camera = key.partition("/")
         assert camera, f"expected a nested camera path, got {key!r}"
         groups.setdefault(group, {})[camera] = cam()
     observation = dict(groups)
-    observation[G1_STATE_KEY] = rng.standard_normal(16).astype(np.float32)
-    observation["prompt"] = args.prompt
+    observation[G1_KEYS.state_key] = rng.standard_normal(16).astype(np.float32)
+    observation[G1_KEYS.prompt_key] = args.prompt
 
     out = policy.infer(observation)
     actions = np.asarray(out["actions"])

--- a/scripts/openpi_metadata_to_apxinf.py
+++ b/scripts/openpi_metadata_to_apxinf.py
@@ -2,7 +2,7 @@
 """Read an openpi checkpoint's own ``metadata.pt`` and say what apxinf must run.
 
 openpi keeps the serving contract in a Python registry: ``serve_policy.py
---policy.config pi05_UnitreeG1_groundwire`` selects a ``TrainConfig``, and that
+--policy.config <TrainConfig name>`` selects a ``TrainConfig``, and that
 object decides the wire keys, the delta convention, the state handling and the
 action width. When a checkpoint is exported, openpi serializes that
 ``TrainConfig`` into ``metadata.pt`` — so the checkpoint carries its own answer to
@@ -28,11 +28,12 @@ checkpoint. The value here is the assertion, not the transcription.
 
 Usage::
 
-    python scripts/openpi_metadata_to_apxinf.py --model-dir ~/airs/airs-model --robot unitree_g1
+    python scripts/openpi_metadata_to_apxinf.py --model-dir CKPT_DIR --robot unitree_g1
 
 Exit status is 1 when any check is fatal, so it can gate a deployment.
-``metadata.pt`` is optional: without it (or without torch) the checkpoint-
-directory checks still run and the openpi cross-check is reported as skipped.
+``metadata.pt`` is optional: without it the checkpoint-directory checks still run
+and the openpi cross-check is reported as skipped. Nothing here needs torch, CUDA
+or a loaded weight -- it is a seconds-long, laptop-runnable check.
 """
 
 from __future__ import annotations
@@ -47,6 +48,12 @@ _APXINF_PKG = _REPO_ROOT / "python" / "apxinf"
 if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
+from apxinf.checkpoints import (  # noqa: E402
+    FORMATS as CHECKPOINT_FORMATS,
+    MetadataError,
+    read_metadata_pt,
+    repack_structure,
+)
 from apxinf.robots.preflight import (  # noqa: E402
     FAIL,
     INFO,
@@ -65,42 +72,25 @@ from apxinf.robots.presets import (  # noqa: E402
 def load_train_config(model_dir: pathlib.Path):
     """Return openpi's serialized ``TrainConfig`` dict, or ``(None, reason)``.
 
-    ``metadata.pt`` is a torch pickle of nested plain dicts plus a couple of
-    openpi/flax sentinel objects, so unpickling needs those packages importable.
-    Both failure modes -- no file, no torch -- are expected in the field and are
-    reported rather than raised: the directory checks are still worth running.
+    Read through :func:`apxinf.checkpoints.read_metadata_pt`, which parses the
+    torch archive with the standard library alone. That matters here: this script
+    is meant to run on a laptop, before anything heavy is installed, and
+    ``metadata.pt`` is 30 kB of nested dicts — needing torch to see them made the
+    check skippable exactly when it was most useful. A missing or unparseable
+    file is still reported rather than raised, because the directory checks are
+    worth running either way.
     """
     path = model_dir / "metadata.pt"
     if not path.exists():
         return None, f"{path} not present (apxinf does not require it)"
     try:
-        import torch
-    except ImportError:
-        return None, "torch is not installed, so metadata.pt cannot be unpickled"
-    try:
-        # weights_only=False: this is a config object graph, not tensors.
-        payload = torch.load(path, map_location="cpu", weights_only=False)
-    except Exception as exc:  # noqa: BLE001 - any unpickle failure is the same story
-        return None, f"{type(exc).__name__}: {exc} (openpi may need to be importable)"
-    config = payload.get("config") if isinstance(payload, dict) else None
+        payload = read_metadata_pt(path)
+    except MetadataError as exc:
+        return None, str(exc)
+    config = payload.get("config")
     if not isinstance(config, dict):
         return None, f"metadata.pt has no 'config' dict (keys: {sorted(payload)})"
     return config, ""
-
-
-def _repack_structure(data: dict) -> dict:
-    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
-
-    openpi's repack transform is written *inbound*: ``{wire_key: dataset_column}``.
-    Its keys are therefore exactly what the client puts on the network, which is
-    what an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
-    """
-    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
-    for entry in inputs:
-        structure = entry.get("structure") if isinstance(entry, dict) else None
-        if isinstance(structure, dict):
-            return structure
-    return {}
 
 
 def compare_to_preset(config: dict, robot: str) -> list:
@@ -108,7 +98,7 @@ def compare_to_preset(config: dict, robot: str) -> list:
     preset = get_robot_preset(robot)
     model = config.get("model") or {}
     data = config.get("data") or {}
-    structure = _repack_structure(data)
+    structure = repack_structure(data)
     out = []
 
     exp = config.get("exp_name") or config.get("name")
@@ -174,8 +164,9 @@ def compare_to_preset(config: dict, robot: str) -> list:
                     WARN,
                     label,
                     f"metadata.pt says {value}, apxinf's pi05 path assumes {ours}",
-                    "apxinf reads the real value from config.json at load time; this "
-                    "only flags that the assumption baked into the preset is stale",
+                    "apxinf reads the real value from the checkpoint at load time "
+                    "(config.json, or metadata.pt for an openpi export); this only "
+                    "flags that the assumption baked into the preset is stale",
                 )
             )
         else:
@@ -219,7 +210,7 @@ def compare_to_preset(config: dict, robot: str) -> list:
     if prompt is not None:
         out.append(Finding(INFO, "default_prompt", repr(prompt)))
 
-    # --- where the *real* norm_stats live, which is the A1 question.
+    # --- where the *real* norm_stats live, which is the whole question.
     assets = data.get("assets") or {}
     asset_id, assets_dir = assets.get("asset_id"), assets.get("assets_dir")
     if asset_id or assets_dir:
@@ -266,17 +257,28 @@ def describe_launch(config: dict, robot: str, model_dir: pathlib.Path) -> str:
     return " \\\n".join(flags) + "\n\n" + note
 
 
-def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
+def _check_lerobot_config(model_dir: pathlib.Path, robot: str, *, authoritative: bool) -> list:
     """Flag a ``config.json`` that describes a different robot than the weights.
 
-    apxinf loads the model shape from this file, so a stale one is not inert: its
-    ``input_features`` decide ``num_views``. Its ``observation.state`` /
-    ``action`` shapes are not read by apxinf at all, which is exactly why a wrong
-    one survives -- but they are the loudest available signal that the file was
-    copied from a different training run.
+    ``authoritative`` says whether apxinf will actually load the model shape from
+    this file. For a LeRobot directory it will, so a stale ``input_features``
+    silently decides ``num_views``. For an openpi export ``metadata.pt`` wins and
+    the file is inert — but a config.json describing a *different* robot sitting
+    next to the weights is still the loudest available signal that the directory
+    was assembled from more than one training run, which is exactly how a wrong
+    ``norm_stats.json`` gets in.
     """
     path = model_dir / "config.json"
     if not path.exists():
+        if not authoritative:
+            return [
+                Finding(
+                    INFO,
+                    "config.json",
+                    "absent, as an openpi PyTorch export always is; the architecture "
+                    "comes from metadata.pt",
+                )
+            ]
         return [Finding(WARN, "config.json", f"missing from {model_dir}")]
     try:
         config = json.loads(path.read_text())
@@ -290,11 +292,15 @@ def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
     if views and views != preset.num_views:
         out.append(
             Finding(
-                FAIL,
+                FAIL if authoritative else WARN,
                 "config.json num_views",
                 f"{views} VISUAL features, preset {robot!r} sends {preset.num_views}",
                 "apxinf reads the view count from this file, so it decides how many "
-                "camera slots the model has. Pass --num-views to serve fewer.",
+                "camera slots the model has. Pass --num-views to serve fewer."
+                if authoritative
+                else "metadata.pt outranks this file for an openpi export, so this "
+                "does not decide the view count -- but it says the file came from "
+                "another run, so treat everything else in the directory the same way.",
             )
         )
     else:
@@ -342,6 +348,14 @@ def main() -> int:
     )
     parser.add_argument("--norm-key", default="actions")
     parser.add_argument("--tokenizer", type=pathlib.Path, default=None)
+    parser.add_argument(
+        "--ckpt-format",
+        choices=CHECKPOINT_FORMATS,
+        default="auto",
+        help="how to read the directory; must match what the server will be given",
+    )
+    parser.add_argument("--asset-id", default=None)
+    parser.add_argument("--norm-stats", type=pathlib.Path, default=None)
     parser.add_argument("--action-dim", type=int, default=None)
     parser.add_argument(
         "--discrete-state", dest="discrete_state", action="store_true", default=None
@@ -362,9 +376,18 @@ def main() -> int:
             discrete_state=args.discrete_state,
             action_dim=args.action_dim,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
         )
     )
-    findings += _check_lerobot_config(model_dir, args.robot)
+    findings += _check_lerobot_config(
+        model_dir,
+        args.robot,
+        # metadata.pt outranks config.json, so the file only decides the
+        # architecture when there is no metadata.pt to outrank it.
+        authoritative=not (model_dir / "metadata.pt").is_file(),
+    )
 
     config, reason = load_train_config(model_dir)
     if config is None:

--- a/scripts/openpi_metadata_to_apxinf.py
+++ b/scripts/openpi_metadata_to_apxinf.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Read an openpi checkpoint's own ``metadata.pt`` and say what apxinf must run.
+
+openpi keeps the serving contract in a Python registry: ``serve_policy.py
+--policy.config pi05_UnitreeG1_groundwire`` selects a ``TrainConfig``, and that
+object decides the wire keys, the delta convention, the state handling and the
+action width. When a checkpoint is exported, openpi serializes that
+``TrainConfig`` into ``metadata.pt`` — so the checkpoint carries its own answer to
+"how must this be served", and nothing reads it.
+
+apxinf's equivalent is a ``--robot`` preset, which is a *hand* transcription of
+the same facts. This script closes the loop: it reads ``metadata.pt``, prints the
+apxinf launch command it implies, and diffs every field against the preset the
+operator named. Then it runs the checkpoint-directory checks from
+:mod:`apxinf.robots.preflight` (norm_stats widths, tokenizer) on top.
+
+Why this exists: the delivered configuration was a Unitree G1 checkpoint served
+with LIBERO norm_stats and ``--action-dim 7``. Nothing errored. The weights
+loaded, the tokenizer ran, the unnormalizer found quantiles of *some* width, and
+the robot got seven plausible floats per step that meant nothing. Every one of
+those facts contradicts ``metadata.pt``, which says 16-dim G1, three cameras,
+delta joint actions, discretized state. This script prints that contradiction in
+one screen.
+
+It does *not* generate a config file. apxinf's counterpart to ``TrainConfig`` is
+``robots/presets.py`` plus a builder — code, reviewed once, not generated per
+checkpoint. The value here is the assertion, not the transcription.
+
+Usage::
+
+    python scripts/openpi_metadata_to_apxinf.py --model-dir ~/airs/airs-model --robot unitree_g1
+
+Exit status is 1 when any check is fatal, so it can gate a deployment.
+``metadata.pt`` is optional: without it (or without torch) the checkpoint-
+directory checks still run and the openpi cross-check is reported as skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_APXINF_PKG = _REPO_ROOT / "python" / "apxinf"
+if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
+    sys.path.insert(0, str(_APXINF_PKG))
+
+from apxinf.robots.preflight import (  # noqa: E402
+    FAIL,
+    INFO,
+    WARN,
+    Finding,
+    check_checkpoint,
+    format_findings,
+)
+from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_PRESETS,
+    available_robots,
+    get_robot_preset,
+)
+
+
+def load_train_config(model_dir: pathlib.Path):
+    """Return openpi's serialized ``TrainConfig`` dict, or ``(None, reason)``.
+
+    ``metadata.pt`` is a torch pickle of nested plain dicts plus a couple of
+    openpi/flax sentinel objects, so unpickling needs those packages importable.
+    Both failure modes -- no file, no torch -- are expected in the field and are
+    reported rather than raised: the directory checks are still worth running.
+    """
+    path = model_dir / "metadata.pt"
+    if not path.exists():
+        return None, f"{path} not present (apxinf does not require it)"
+    try:
+        import torch
+    except ImportError:
+        return None, "torch is not installed, so metadata.pt cannot be unpickled"
+    try:
+        # weights_only=False: this is a config object graph, not tensors.
+        payload = torch.load(path, map_location="cpu", weights_only=False)
+    except Exception as exc:  # noqa: BLE001 - any unpickle failure is the same story
+        return None, f"{type(exc).__name__}: {exc} (openpi may need to be importable)"
+    config = payload.get("config") if isinstance(payload, dict) else None
+    if not isinstance(config, dict):
+        return None, f"metadata.pt has no 'config' dict (keys: {sorted(payload)})"
+    return config, ""
+
+
+def _repack_structure(data: dict) -> dict:
+    """The wire keys openpi's client sends, from ``repack_transforms.inputs``.
+
+    openpi's repack transform is written *inbound*: ``{wire_key: dataset_column}``.
+    Its keys are therefore exactly what the client puts on the network, which is
+    what an apxinf preset's ``slots`` and ``state_key`` have to reproduce.
+    """
+    inputs = (data.get("repack_transforms") or {}).get("inputs") or ()
+    for entry in inputs:
+        structure = entry.get("structure") if isinstance(entry, dict) else None
+        if isinstance(structure, dict):
+            return structure
+    return {}
+
+
+def compare_to_preset(config: dict, robot: str) -> list:
+    """Diff openpi's own TrainConfig against the named apxinf preset."""
+    preset = get_robot_preset(robot)
+    model = config.get("model") or {}
+    data = config.get("data") or {}
+    structure = _repack_structure(data)
+    out = []
+
+    exp = config.get("exp_name") or config.get("name")
+    if exp:
+        out.append(Finding(INFO, "metadata.pt", f"exp_name={exp!r}, serving as --robot {robot}"))
+
+    # --- cameras: count and, where openpi names them, the keys themselves.
+    images = structure.get("images")
+    if isinstance(images, dict):
+        openpi_keys = tuple(images)
+        preset_keys = tuple(key.split("/")[-1] for key in preset.image_keys)
+        if openpi_keys == preset_keys:
+            out.append(
+                Finding(INFO, "cameras", f"{len(openpi_keys)} views {list(openpi_keys)}, match")
+            )
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    "cameras",
+                    f"openpi sends {list(openpi_keys)}, preset {robot!r} expects "
+                    f"{list(preset_keys)}",
+                    "camera keys are order-significant -- entry i fills model view "
+                    "slot i. A mismatch either drops a camera or feeds the wrong one "
+                    "to a slot, and neither raises. Fix the preset's slots.",
+                )
+            )
+    else:
+        out.append(Finding(WARN, "cameras", "metadata.pt has no repack image structure"))
+
+    # --- state: is it sent at all, and does apxinf discretize it the same way?
+    discrete = model.get("discrete_state_input")
+    if discrete is not None:
+        if bool(discrete) == preset.discrete_state:
+            out.append(Finding(INFO, "discrete_state", f"{bool(discrete)}, match"))
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    "discrete_state",
+                    f"checkpoint trained with discrete_state_input={bool(discrete)}, "
+                    f"preset {robot!r} serves {preset.discrete_state}",
+                    "with it off the model receives no proprioception at all (state is "
+                    "dropped, not merely left continuous) and any delta->absolute "
+                    "output step silently becomes a no-op",
+                )
+            )
+
+    # --- widths. action_dim here is the *model's* padded width (32); the robot's
+    #     physical width is not in metadata.pt -- it is in the norm_stats, which
+    #     the directory check covers.
+    for field, ours, label in (
+        ("action_dim", 32, "model action width"),
+        ("action_horizon", None, "action horizon"),
+        ("max_token_len", 200, "max token len"),
+    ):
+        value = model.get(field)
+        if value is None:
+            continue
+        if ours is not None and value != ours:
+            out.append(
+                Finding(
+                    WARN,
+                    label,
+                    f"metadata.pt says {value}, apxinf's pi05 path assumes {ours}",
+                    "apxinf reads the real value from config.json at load time; this "
+                    "only flags that the assumption baked into the preset is stale",
+                )
+            )
+        else:
+            out.append(Finding(INFO, label, str(value)))
+
+    # --- the two robot conventions the G1 output chain implements.
+    for field, label, why in (
+        (
+            "adapt_to_pi",
+            "adapt_to_pi",
+            "the joint-flip / gripper decode+encode steps; off means raw robot space",
+        ),
+        (
+            "use_delta_joint_actions",
+            "use_delta_joint_actions",
+            "whether the model emits joint deltas that must have the current state "
+            "added back. Getting this wrong is not subtle in the logs and is "
+            "catastrophic on the robot: absolute targets treated as deltas double "
+            "every joint command.",
+        ),
+    ):
+        value = data.get(field)
+        if value is None:
+            continue
+        wanted = preset.builder_kwargs.get(field)
+        if wanted is None:
+            out.append(Finding(INFO, label, f"metadata.pt={value}; preset does not set it"))
+        elif bool(value) == bool(wanted):
+            out.append(Finding(INFO, label, f"{bool(value)}, match"))
+        else:
+            out.append(
+                Finding(
+                    FAIL,
+                    label,
+                    f"checkpoint trained with {bool(value)}, preset serves {bool(wanted)}",
+                    why,
+                )
+            )
+
+    prompt = data.get("default_prompt")
+    if prompt is not None:
+        out.append(Finding(INFO, "default_prompt", repr(prompt)))
+
+    # --- where the *real* norm_stats live, which is the A1 question.
+    assets = data.get("assets") or {}
+    asset_id, assets_dir = assets.get("asset_id"), assets.get("assets_dir")
+    if asset_id or assets_dir:
+        out.append(
+            Finding(
+                INFO,
+                "norm_stats source",
+                f"openpi computed them under {assets_dir}{asset_id}/norm_stats.json",
+                "",
+            )
+        )
+
+    # openpi derives the normalization mode from the model type, not from a file:
+    # `use_quantile_norm = model_config.model_type != ModelType.PI0`. pi05 is
+    # therefore always quantile, whatever a LeRobot-style config.json says.
+    if model.get("pi05"):
+        out.append(
+            Finding(INFO, "normalization", "pi05 -> quantile (q01/q99), per openpi's model-type rule")
+        )
+    return out
+
+
+def describe_launch(config: dict, robot: str, model_dir: pathlib.Path) -> str:
+    """The apxinf launch line this checkpoint's own metadata implies."""
+    preset = get_robot_preset(robot)
+    data = config.get("data") or {}
+    model = config.get("model") or {}
+    flags = [
+        "python scripts/pi05_openpi_websocket_server.py",
+        f"  --model-dir {model_dir}",
+        f"  --robot {preset.name}",
+        # bf16 explicitly: --precision auto resolves to int8 on SM87 (Jetson
+        # Orin), which is a different numeric contract than openpi's.
+        "  --precision bf16",
+    ]
+    if model.get("discrete_state_input") and not preset.discrete_state:
+        flags.append("  --discrete-state")
+    note = (
+        f"# metadata.pt: action_horizon={model.get('action_horizon')} "
+        f"adapt_to_pi={data.get('adapt_to_pi')} "
+        f"delta_joints={data.get('use_delta_joint_actions')} "
+        f"discrete_state={model.get('discrete_state_input')}"
+    )
+    return " \\\n".join(flags) + "\n\n" + note
+
+
+def _check_lerobot_config(model_dir: pathlib.Path, robot: str) -> list:
+    """Flag a ``config.json`` that describes a different robot than the weights.
+
+    apxinf loads the model shape from this file, so a stale one is not inert: its
+    ``input_features`` decide ``num_views``. Its ``observation.state`` /
+    ``action`` shapes are not read by apxinf at all, which is exactly why a wrong
+    one survives -- but they are the loudest available signal that the file was
+    copied from a different training run.
+    """
+    path = model_dir / "config.json"
+    if not path.exists():
+        return [Finding(WARN, "config.json", f"missing from {model_dir}")]
+    try:
+        config = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        return [Finding(FAIL, "config.json", f"unreadable: {exc}", "fix or re-export")]
+
+    preset = get_robot_preset(robot)
+    out = []
+    features = config.get("input_features") or {}
+    views = sum(1 for f in features.values() if isinstance(f, dict) and f.get("type") == "VISUAL")
+    if views and views != preset.num_views:
+        out.append(
+            Finding(
+                FAIL,
+                "config.json num_views",
+                f"{views} VISUAL features, preset {robot!r} sends {preset.num_views}",
+                "apxinf reads the view count from this file, so it decides how many "
+                "camera slots the model has. Pass --num-views to serve fewer.",
+            )
+        )
+    else:
+        out.append(Finding(INFO, "config.json num_views", str(views)))
+
+    state = (features.get("observation.state") or {}).get("shape")
+    action = ((config.get("output_features") or {}).get("action") or {}).get("shape")
+    for label, shape, expected in (
+        ("observation.state", state, preset.state_dim),
+        ("action", action, preset.action_width),
+    ):
+        if not shape or expected is None:
+            continue
+        got = shape[-1]
+        if got != expected:
+            out.append(
+                Finding(
+                    WARN,
+                    f"config.json {label}",
+                    f"{got}-dim, but preset {robot!r} is a {expected}-dim robot "
+                    f"(repo_id={config.get('repo_id')!r})",
+                    "apxinf does not read these fields, so this cannot break serving "
+                    "on its own -- but a config.json describing a different robot "
+                    "than the weights means the file was copied from another run, "
+                    "and whatever else came with it (norm_stats.json above) is "
+                    "suspect for the same reason",
+                )
+            )
+    return out
+
+
+def main() -> int:
+    robot_help = "\n".join(f"  {p.describe()}" for p in ROBOT_PRESETS.values())
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=f"robot presets (--robot):\n{robot_help}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model-dir", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--robot",
+        default="unitree_g1",
+        choices=available_robots(include_aliases=True),
+        help="the preset the checkpoint would be served under",
+    )
+    parser.add_argument("--norm-key", default="actions")
+    parser.add_argument("--tokenizer", type=pathlib.Path, default=None)
+    parser.add_argument("--action-dim", type=int, default=None)
+    parser.add_argument(
+        "--discrete-state", dest="discrete_state", action="store_true", default=None
+    )
+    parser.add_argument("--no-discrete-state", dest="discrete_state", action="store_false")
+    parser.add_argument("--quiet", action="store_true", help="show only WARN and FAIL")
+    args = parser.parse_args()
+
+    model_dir = args.model_dir
+    if not model_dir.is_dir():
+        parser.error(f"--model-dir {model_dir} is not a directory")
+
+    findings = list(
+        check_checkpoint(
+            model_dir,
+            args.robot,
+            norm_key=args.norm_key,
+            discrete_state=args.discrete_state,
+            action_dim=args.action_dim,
+            tokenizer_path=args.tokenizer,
+        )
+    )
+    findings += _check_lerobot_config(model_dir, args.robot)
+
+    config, reason = load_train_config(model_dir)
+    if config is None:
+        findings.append(
+            Finding(
+                WARN,
+                "metadata.pt",
+                reason,
+                "without it the openpi-side contract (cameras, delta convention, "
+                "discrete state) cannot be cross-checked and has to be trusted",
+            )
+        )
+    else:
+        findings += compare_to_preset(config, args.robot)
+
+    print(f"checkpoint: {model_dir}")
+    print(f"preset:     {get_robot_preset(args.robot).describe()}\n")
+    # Re-sort: check_checkpoint returns sorted, but the metadata.pt and
+    # config.json findings are appended after it. Severity order across the whole
+    # report is what makes it readable at a glance.
+    order = {FAIL: 0, WARN: 1, INFO: 2}
+    findings.sort(key=lambda f: order.get(f.level, 3))
+    print(format_findings(findings, include_info=not args.quiet))
+
+    if config is not None:
+        print("\nimplied launch:\n")
+        print(describe_launch(config, args.robot, model_dir))
+
+    fatal = sum(1 for f in findings if f.level == FAIL)
+    warned = sum(1 for f in findings if f.level == WARN)
+    print(f"\n{fatal} fatal, {warned} warning(s)")
+    return 1 if fatal else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -318,7 +318,10 @@ def main() -> None:
             metadata=metadata,
         )
     # Clients read the served wire contract off this metadata rather than assuming
-    # one: a key mismatch is silent on the wire but visible here.
+    # one: a key mismatch is silent on the wire but visible here. A null state_key
+    # is not a gap — it says this policy drops state, so there is no key to send
+    # one under; rendered as "(dropped)" so the log line cannot read as an omission.
+    served_state_key = policy.metadata["state_key"]
     logging.info(
         "serving robot=%s robot_steps=%s H=%d x D=%d image_keys=%s state=%s "
         "discrete_state=%s",
@@ -327,7 +330,7 @@ def main() -> None:
         policy.metadata["action_horizon"],
         policy.metadata["action_dim"],
         policy.metadata["image_keys"],
-        policy.metadata["state_key"],
+        served_state_key if served_state_key is not None else "(dropped)",
         policy.metadata["discrete_state"],
     )
     server = WebsocketPolicyServer(policy, args.host, args.port)

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -103,7 +103,9 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="serve a checkpoint-free engine with deterministic random weights and "
         "synthetic processors (latency-only; actions are numerically meaningless). "
-        "No --model-dir needed.",
+        "Reproduces --robot's wire keys and view count but not its robot pre/post "
+        "steps, which need a checkpoint; the served metadata says robot_steps=false "
+        "and startup warns per gap. No --model-dir needed.",
     )
     parser.add_argument(
         "--checkpoint",
@@ -234,18 +236,28 @@ def main() -> None:
         # The preset's cameras define the synthetic view count unless --num-views is
         # given explicitly, so --robot alone yields a servable synthetic engine.
         num_views = args.num_views if args.num_views is not None else len(image_keys)
-        # The synthetic tokenizer emits a fixed token stream and never reads state,
-        # so this server cannot reproduce a discrete-state preset. Say so: the
-        # published metadata is the wire contract, and silently serving
-        # discrete_state=False for a preset that declares True is precisely the
-        # mismatch --robot exists to prevent.
-        if discrete_state:
+        # A checkpoint-free engine still serves the preset's *deployable* width, so a
+        # client previews the action shape it will get in production. --action-dim
+        # outranks it (and also sets the synthetic model's own width).
+        model_dim = args.action_dim or 32
+        trim_dim = args.action_dim if args.action_dim is not None else preset.action_dim
+        served_dim = trim_dim or model_dim
+        # The synthetic path reproduces the preset's wire keys and view count and
+        # nothing else: the tokenizer emits a fixed token stream and never reads
+        # state, and preset.builder never runs. The published metadata is the wire
+        # contract, so name every gap and mark robot_steps=False below — silently
+        # serving half an embodiment under its own name is precisely the mismatch
+        # --robot exists to prevent.
+        gaps = preset.synthetic_gaps(
+            discrete_state=discrete_state, served_action_dim=served_dim
+        )
+        if gaps:
             logging.warning(
-                "--random-weights cannot honour %s's discrete_state=True: the "
-                "synthetic tokenizer ignores state, so the served metadata will "
-                "say discrete_state=False. Use a checkpoint to preview the real "
-                "contract.",
+                "--random-weights cannot honour %s: %s. The wire keys and view count "
+                "are real; the action semantics are not. Use a checkpoint to preview "
+                "the full contract.",
                 preset.name,
+                "; ".join(gaps),
             )
         logging.info(
             "serving checkpoint-free %s random-weights engine (views=%d, H=%d, T=%d) "
@@ -262,7 +274,7 @@ def main() -> None:
             num_views=num_views,
             image_size=args.image_size,
             action_horizon=action_horizon,
-            action_dim=(args.action_dim or 32),
+            action_dim=model_dim,
             num_flow_steps=args.num_flow_steps,
             max_token_len=args.max_token_len,
             calibration=calibration,
@@ -272,11 +284,11 @@ def main() -> None:
         policy = Pi05Policy.from_random(
             handle,
             token_count=args.token_count,
-            action_dim=(args.action_dim or None),
+            action_dim=(trim_dim or None),
             seed=args.seed,
             image_keys=image_keys[:num_views],
             state_key=state_key,
-            metadata={**metadata, "robot": preset.name},
+            metadata={**metadata, "robot": preset.name, "robot_steps": False},
         )
     else:
         logging.info(
@@ -308,8 +320,10 @@ def main() -> None:
     # Clients read the served wire contract off this metadata rather than assuming
     # one: a key mismatch is silent on the wire but visible here.
     logging.info(
-        "serving robot=%s H=%d x D=%d image_keys=%s state=%s discrete_state=%s",
+        "serving robot=%s robot_steps=%s H=%d x D=%d image_keys=%s state=%s "
+        "discrete_state=%s",
         policy.metadata.get("robot", preset.name),
+        policy.metadata.get("robot_steps"),
         policy.metadata["action_horizon"],
         policy.metadata["action_dim"],
         policy.metadata["image_keys"],

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -47,6 +47,7 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import Pi05Policy  # noqa: E402
+from apxinf.robots.preflight import FAIL, WARN, check_checkpoint, format_findings  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     available_robots,
@@ -187,6 +188,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--log-level", default="INFO")
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="start even if the checkpoint contradicts the --robot preset. The "
+        "preflight compares norm_stats widths and the tokenizer against the "
+        "preset; every mismatch it reports is one that produces confidently "
+        "wrong actions instead of an error. Use only to reproduce a known-bad "
+        "deployment on purpose.",
+    )
     return parser.parse_args()
 
 
@@ -291,6 +301,34 @@ def main() -> None:
             metadata={**metadata, "robot": preset.name, "robot_steps": False},
         )
     else:
+        # Refuse a checkpoint that contradicts the preset *before* spending a
+        # minute loading 7 GB of weights. A G1 checkpoint served with LIBERO
+        # norm_stats runs to completion and emits actions of the right shape in
+        # the right numeric range that mean nothing -- the only symptom is
+        # "accuracy regressed", which is indistinguishable from a model problem
+        # until someone diffs the two pipelines by hand.
+        findings = check_checkpoint(
+            args.model_dir,
+            preset.name,
+            norm_key=args.norm_key,
+            discrete_state=discrete_state,
+            image_keys=image_keys,
+            action_dim=args.action_dim,
+            tokenizer_path=args.tokenizer,
+        )
+        fatal = [f for f in findings if f.level == FAIL]
+        if fatal and not args.skip_preflight:
+            raise SystemExit(
+                f"preflight: {args.model_dir} does not match --robot {preset.name}\n"
+                + format_findings(findings, include_info=False)
+                + "\n\nPass --skip-preflight to serve it anyway (the actions will be wrong)."
+            )
+        for finding in findings:
+            level = logging.ERROR if finding.level == FAIL else (
+                logging.WARNING if finding.level == WARN else logging.INFO
+            )
+            logging.log(level, "preflight %s", finding)
+
         logging.info(
             "loading %s policy in-process from %s as robot=%s",
             args.precision,

--- a/scripts/pi05_openpi_websocket_server.py
+++ b/scripts/pi05_openpi_websocket_server.py
@@ -47,6 +47,7 @@ if _APXINF_PKG.is_dir() and str(_APXINF_PKG) not in sys.path:
     sys.path.insert(0, str(_APXINF_PKG))
 
 from apxinf import Pi05Policy  # noqa: E402
+from apxinf.checkpoints import FORMATS as CHECKPOINT_FORMATS  # noqa: E402
 from apxinf.robots.preflight import FAIL, WARN, check_checkpoint, format_findings  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
@@ -115,12 +116,34 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model-type",
-        help="policy model_type; default reads MODEL_DIR/config.json (e.g. pi05)",
+        help="policy model_type; default reads MODEL_DIR/config.json, or metadata.pt "
+        "for an openpi export, which has no config.json (e.g. pi05)",
     )
     parser.add_argument(
         "--tokenizer",
         type=pathlib.Path,
-        help="SentencePiece model (auto-detected under MODEL_DIR by default)",
+        help="SentencePiece model (auto-detected under MODEL_DIR, or APXINF_TOKENIZER)",
+    )
+    parser.add_argument(
+        "--ckpt-format",
+        choices=CHECKPOINT_FORMATS,
+        default="auto",
+        help="how to read MODEL_DIR. 'auto' (default) picks openpi_pytorch when a "
+        "metadata.pt is present and lerobot when a config.json is. Pin it when a "
+        "directory carries both and the wrong one wins.",
+    )
+    parser.add_argument(
+        "--asset-id",
+        default=None,
+        help="override the asset_id the checkpoint names, which is what selects "
+        "assets/<asset_id>/norm_stats.json. For assets reorganized after export.",
+    )
+    parser.add_argument(
+        "--norm-stats",
+        type=pathlib.Path,
+        default=None,
+        help="explicit norm_stats.json, outranking every path convention. Required "
+        "for a LeRobot checkpoint, which ships no such file of its own.",
     )
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument(
@@ -148,8 +171,9 @@ def parse_args() -> argparse.Namespace:
         "--action-horizon",
         type=int,
         default=None,
-        help="chunk length to serve. Default: the checkpoint's config.json value, "
-        "or 50 with --random-weights. An explicit value outranks the checkpoint "
+        help="chunk length to serve. Default: the checkpoint's own value (config.json, "
+        "or metadata.pt for an openpi export), or 50 with --random-weights. An "
+        "explicit value outranks the checkpoint "
         "(the horizon is a sequence length, not a weight dimension).",
     )
     parser.add_argument(
@@ -315,6 +339,9 @@ def main() -> None:
             image_keys=image_keys,
             action_dim=args.action_dim,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
         )
         fatal = [f for f in findings if f.level == FAIL]
         if fatal and not args.skip_preflight:
@@ -350,6 +377,9 @@ def main() -> None:
             calibration=args.calibration,
             tactics=args.tactics,
             tokenizer_path=args.tokenizer,
+            checkpoint_format=args.ckpt_format,
+            asset_id=args.asset_id,
+            norm_stats=args.norm_stats,
             norm_key=args.norm_key,
             action_horizon=args.action_horizon,
             seed=args.seed,

--- a/tests/test_pi05_openpi_websocket.py
+++ b/tests/test_pi05_openpi_websocket.py
@@ -27,6 +27,9 @@ from apxinf.serving.websocket import health_check  # noqa: E402
 HORIZON = 10
 MODEL_DIM = 32
 LIBERO_DIM = 7
+# The wire keys a LIBERO client puts on the socket. The model layer no longer
+# guesses them, so the test has to name them the way a real deployment does.
+LIBERO_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
 IMAGE_SIZE = 224
 NUM_VIEWS = 2
 
@@ -79,12 +82,16 @@ def build_policy() -> Pi05Policy:
     q99 = q01 + 2
     model = MockModel()
     input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
-        model, tokenizer=ConstTokenizer(), unnormalizer=Unnormalizer(q01=q01, q99=q99)
+        model,
+        tokenizer=ConstTokenizer(),
+        unnormalizer=Unnormalizer(q01=q01, q99=q99),
+        image_keys=LIBERO_IMAGE_KEYS,
     )
     return Pi05Policy(
         model,
         input_pipeline=input_pipeline,
         output_pipeline=output_pipeline,
+        image_keys=LIBERO_IMAGE_KEYS,
         metadata={"precision": "int8", "protocol": "openpi.websocket_policy"},
     )
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import json
 import pathlib
+import pickle
 import sys
 import tempfile
 import unittest
+import zipfile
 
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPOSITORY_ROOT / "python" / "apxinf"))
@@ -63,6 +65,43 @@ class CheckpointFixture:
 
     def write_tokenizer(self, name: str = "paligemma_tokenizer.model") -> "CheckpointFixture":
         (self.path / name).write_bytes(b"not a real sentencepiece model")
+        return self
+
+    def write_weights(self) -> "CheckpointFixture":
+        """An empty ``model.safetensors``; nothing here reads a weight."""
+        (self.path / "model.safetensors").write_bytes(b"")
+        return self
+
+    def write_metadata_pt(self, *, asset_id: str = "example-asset") -> "CheckpointFixture":
+        """Write an openpi-shaped ``metadata.pt`` the way ``torch.save`` does.
+
+        A zip whose ``<archive>/data.pkl`` member is an ordinary pickle — built
+        by hand so these tests need neither torch nor a real checkpoint.
+        """
+        payload = {
+            "global_step": 1,
+            "config": {
+                "exp_name": "pi05_example",
+                "model": {
+                    "action_dim": 32,
+                    "action_horizon": 50,
+                    "max_token_len": 200,
+                    "discrete_state_input": True,
+                    "pi05": True,
+                },
+                "data": {"assets": {"asset_id": asset_id}},
+            },
+        }
+        with zipfile.ZipFile(self.path / "metadata.pt", "w") as archive:
+            archive.writestr("metadata/data.pkl", pickle.dumps(payload, protocol=2))
+            archive.writestr("metadata/version", "3\n")
+        return self
+
+    def write_asset_stats(self, asset_id: str, **entries) -> "CheckpointFixture":
+        """Statistics where openpi actually writes them: ``assets/<asset_id>/``."""
+        target = self.path / "assets" / asset_id / "norm_stats.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({"norm_stats": entries}))
         return self
 
 
@@ -252,6 +291,105 @@ class ReportTest(unittest.TestCase):
 
         self.assertNotIn("[INFO", quiet)
         self.assertIn("[FAIL", quiet)
+
+
+class CheckpointLayoutTest(unittest.TestCase):
+    """An openpi export keeps its statistics under ``assets/<asset_id>/``.
+
+    Reading ``<model_dir>/norm_stats.json`` unconditionally is how a file left
+    behind by an unrelated run got both checked and served. These pin that the
+    preflight now checks the file the loader will actually open.
+    """
+
+    def test_the_asset_path_is_checked_not_the_root_file(self) -> None:
+        # The failure shape: correct statistics where openpi puts them, a
+        # leftover 7-dim LIBERO file in the root. Reading the root one produces
+        # a spurious FAIL here and wrong actions on the robot.
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+        ckpt.write_asset_stats(
+            "example-asset", actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        )
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats["))
+        chosen = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in chosen], [INFO])
+        self.assertIn("assets/example-asset/norm_stats.json", chosen[0].detail)
+
+    def test_the_root_fallback_is_a_warning_not_a_silent_success(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        warned = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in warned], [WARN])
+        # Both paths, so the operator can see what to go and fetch.
+        self.assertIn("assets/example-asset/norm_stats.json", warned[0].detail)
+        self.assertIn(str(ckpt.path / "norm_stats.json"), warned[0].detail)
+
+    def test_absent_statistics_name_every_path_tried(self) -> None:
+        ckpt = CheckpointFixture(self)
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        fatal = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertEqual([f.level for f in fatal], [FAIL])
+        self.assertIn("assets/example-asset/norm_stats.json", fatal[0].detail)
+
+    def test_the_layout_and_asset_id_are_reported(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        ckpt.write_weights().write_metadata_pt(asset_id="example-asset")
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        reported = {f.check: f.detail for f in findings}
+        layout = [f.detail for f in findings if f.check == "checkpoint layout"]
+        self.assertIn("openpi_pytorch", layout[0])
+        self.assertIn("example-asset", reported["asset_id"])
+        # The architecture comes out of metadata.pt, which is the only place an
+        # openpi export states it: no config.json exists to read it from.
+        self.assertIn("action_horizon=50", reported["architecture"])
+
+    def test_a_flat_directory_is_still_checked_the_old_way(self) -> None:
+        """No metadata.pt, no config.json: the hand-assembled layout still loads."""
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats"))
+        self.assertNotIn("checkpoint layout", {f.check for f in findings})
+
+    def test_an_explicit_norm_stats_path_works_without_any_layout(self) -> None:
+        """A flat directory plus --norm-stats: no metadata.pt, no config.json.
+
+        The statistics for a hand-assembled directory often live outside it, so
+        naming the file must not require the directory to declare a layout — and
+        the root file it does have must then be ignored, not checked.
+        """
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+        elsewhere = ckpt.path / "elsewhere.json"
+        elsewhere.write_text(
+            json.dumps({"norm_stats": {"actions": _stats(G1_DIM), "state": _stats(G1_DIM)}})
+        )
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1", norm_stats=elsewhere)
+
+        self.assertNotIn(FAIL, _levels(findings, "norm_stats"))
+        chosen = [f for f in findings if f.check == "norm_stats.json"]
+        self.assertIn(str(elsewhere), chosen[0].detail)
+
+    def test_a_missing_explicit_norm_stats_path_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(
+            ckpt.path, "unitree_g1", norm_stats=ckpt.path / "nope.json"
+        )
+
+        self.assertEqual(_levels(findings, "norm_stats.json"), [FAIL])
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,258 @@
+"""Startup preflight: does the checkpoint on disk match the preset serving it?
+
+The delivered configuration that motivated :mod:`apxinf.robots.preflight` was a
+Unitree G1 checkpoint (16-DoF, three cameras, delta joint actions) served with a
+LIBERO ``norm_stats.json`` (8-dim state, 7-dim action) and ``--action-dim 7``.
+Every layer accepted it. These tests pin the checks that refuse it, and — just as
+importantly — pin that a *correct* checkpoint produces no fatal finding, so the
+preflight cannot become a thing operators route around with
+``--skip-preflight``.
+
+Runs offline against synthesised checkpoint directories; no CUDA, no weights.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / "python" / "apxinf"))
+
+from apxinf.robots.preflight import (  # noqa: E402
+    FAIL,
+    INFO,
+    WARN,
+    check_checkpoint,
+    format_findings,
+)
+from apxinf.robots.presets import get_robot_preset  # noqa: E402
+
+G1_DIM = 16
+
+
+def _stats(width: int, *, quantiles: bool = True) -> dict:
+    entry = {"mean": [0.0] * width, "std": [1.0] * width}
+    if quantiles:
+        entry["q01"] = [-1.0] * width
+        entry["q99"] = [1.0] * width
+    return entry
+
+
+class CheckpointFixture:
+    """A checkpoint directory with exactly the files the preflight reads."""
+
+    def __init__(self, case: unittest.TestCase, **norm_stats) -> None:
+        self.path = pathlib.Path(tempfile.mkdtemp())
+        case.addCleanup(self._cleanup)
+        if norm_stats:
+            self.write_norm_stats(**norm_stats)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.path, ignore_errors=True)
+
+    def write_norm_stats(self, *, nested: bool = True, **entries) -> "CheckpointFixture":
+        document = {"norm_stats": entries} if nested else entries
+        (self.path / "norm_stats.json").write_text(json.dumps(document))
+        return self
+
+    def write_tokenizer(self, name: str = "paligemma_tokenizer.model") -> "CheckpointFixture":
+        (self.path / name).write_bytes(b"not a real sentencepiece model")
+        return self
+
+
+def _levels(findings, check_prefix: str) -> list:
+    return [f.level for f in findings if f.check.startswith(check_prefix)]
+
+
+class NormStatsWidthTest(unittest.TestCase):
+    """A1: the shipped statistics have to be *this robot's* statistics."""
+
+    def test_libero_stats_under_the_g1_preset_are_fatal(self) -> None:
+        """The exact delivered combination: G1 preset, LIBERO norm_stats."""
+        ckpt = CheckpointFixture(
+            self, actions=_stats(7), state=_stats(8)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        fatal = [f for f in findings if f.level == FAIL]
+        self.assertEqual(len(fatal), 2, format_findings(findings))
+        widths = {f.check for f in fatal}
+        self.assertEqual(
+            widths, {"norm_stats['actions'] width", "norm_stats['state'] width"}
+        )
+        # The remedy has to name the number the operator should be looking for;
+        # "width mismatch" alone sends them to the wrong file.
+        self.assertIn("16", fatal[0].detail + fatal[0].remedy)
+
+    def test_matching_widths_pass(self) -> None:
+        ckpt = CheckpointFixture(
+            self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual([f for f in findings if f.level == FAIL], [], format_findings(findings))
+        self.assertEqual([f for f in findings if f.level == WARN], [])
+
+    def test_libero_preset_checks_its_own_asymmetric_widths(self) -> None:
+        """LIBERO is 8-dim state / 7-dim action; the two are checked separately.
+
+        A single "robot width" field would have to pick one and skip the other,
+        so this pins that the preset carries both.
+        """
+        preset = get_robot_preset("franka_libero")
+        self.assertEqual((preset.state_dim, preset.action_width), (8, 7))
+
+        # LIBERO's default is discrete_state=False, so only "actions" is checked;
+        # turn state injection on and the 8-dim entry has to be there and correct.
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(16)).write_tokenizer()
+        off = check_checkpoint(ckpt.path, "franka_libero")
+        self.assertEqual([f for f in off if f.level == FAIL], [], format_findings(off))
+
+        on = check_checkpoint(ckpt.path, "franka_libero", discrete_state=True)
+        self.assertEqual(_levels(on, "norm_stats['state'] width"), [FAIL])
+
+    def test_flat_norm_stats_layout_is_read_too(self) -> None:
+        """openpi writes ``{"norm_stats": {...}}``; some exports are flat."""
+        ckpt = CheckpointFixture(self)
+        ckpt.write_norm_stats(
+            nested=False, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual([f for f in findings if f.level == FAIL], [], format_findings(findings))
+
+    def test_missing_quantiles_are_fatal_for_pi05(self) -> None:
+        """pi05 always unnormalizes with q01/q99 regardless of any config field."""
+        ckpt = CheckpointFixture(
+            self,
+            actions=_stats(G1_DIM, quantiles=False),
+            state=_stats(G1_DIM),
+        ).write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "norm_stats['actions'] quantiles"), [FAIL])
+
+    def test_missing_state_entry_is_fatal_only_when_state_is_used(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM)).write_tokenizer()
+
+        used = check_checkpoint(ckpt.path, "unitree_g1")
+        self.assertEqual(_levels(used, "norm_stats['state']"), [FAIL])
+
+        dropped = check_checkpoint(ckpt.path, "unitree_g1", discrete_state=False)
+        self.assertEqual(_levels(dropped, "norm_stats['state']"), [])
+
+    def test_missing_file_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self)
+        ckpt.write_tokenizer()
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "norm_stats.json"), [FAIL])
+
+
+class TokenizerTest(unittest.TestCase):
+    """A14: openpi downloads its tokenizer at runtime, so exports lack one."""
+
+    def test_absent_tokenizer_is_fatal(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+
+        self.assertEqual(_levels(findings, "tokenizer"), [FAIL])
+
+    def test_either_accepted_filename_satisfies_the_check(self) -> None:
+        for name in ("tokenizer.model", "paligemma_tokenizer.model"):
+            with self.subTest(name=name):
+                ckpt = CheckpointFixture(
+                    self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+                ).write_tokenizer(name)
+                findings = check_checkpoint(ckpt.path, "unitree_g1")
+                self.assertEqual(_levels(findings, "tokenizer"), [INFO])
+
+    def test_explicit_path_outranks_the_checkpoint_and_is_itself_checked(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(G1_DIM), state=_stats(G1_DIM))
+        elsewhere = ckpt.path / "elsewhere.model"
+
+        missing = check_checkpoint(ckpt.path, "unitree_g1", tokenizer_path=elsewhere)
+        self.assertEqual(_levels(missing, "tokenizer"), [FAIL])
+
+        elsewhere.write_bytes(b"x")
+        present = check_checkpoint(ckpt.path, "unitree_g1", tokenizer_path=elsewhere)
+        self.assertEqual(_levels(present, "tokenizer"), [INFO])
+
+
+class OverrideTest(unittest.TestCase):
+    """The flags that turn a correct checkpoint into a wrong deployment."""
+
+    def setUp(self) -> None:
+        self.ckpt = CheckpointFixture(
+            self, actions=_stats(G1_DIM), state=_stats(G1_DIM)
+        ).write_tokenizer()
+
+    def test_action_dim_override_that_contradicts_the_robot_warns(self) -> None:
+        """``--action-dim 7`` on a 16-DoF robot: the other half of the delivery."""
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", action_dim=7)
+
+        self.assertEqual(_levels(findings, "action_dim"), [WARN])
+
+    def test_action_dim_matching_the_robot_is_silent(self) -> None:
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", action_dim=G1_DIM)
+
+        self.assertEqual(_levels(findings, "action_dim"), [])
+
+    def test_turning_state_off_on_a_joint_space_robot_warns(self) -> None:
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", discrete_state=False)
+
+        warned = [f for f in findings if f.check == "discrete_state"]
+        self.assertEqual([f.level for f in warned], [WARN])
+        # State is *dropped*, not left continuous — the remedy has to say so,
+        # because "no discrete state" reads like a precision choice.
+        self.assertIn("dropped", warned[0].remedy)
+
+    def test_reordered_camera_keys_warn_even_at_the_right_count(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+        swapped = (preset.image_keys[1], preset.image_keys[0], preset.image_keys[2])
+
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", image_keys=swapped)
+
+        self.assertEqual(_levels(findings, "cameras"), [WARN])
+
+    def test_fewer_cameras_than_the_preset_warns(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+
+        findings = check_checkpoint(self.ckpt.path, "unitree_g1", image_keys=preset.image_keys[:2])
+
+        self.assertEqual(_levels(findings, "cameras"), [WARN])
+
+
+class ReportTest(unittest.TestCase):
+    def test_findings_are_sorted_most_severe_first(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(8))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1", action_dim=7)
+
+        levels = [f.level for f in findings]
+        self.assertEqual(levels, sorted(levels, key={FAIL: 0, WARN: 1, INFO: 2}.get))
+
+    def test_quiet_rendering_drops_info_but_keeps_problems(self) -> None:
+        ckpt = CheckpointFixture(self, actions=_stats(7), state=_stats(G1_DIM))
+
+        findings = check_checkpoint(ckpt.path, "unitree_g1")
+        quiet = format_findings(findings, include_info=False)
+
+        self.assertNotIn("[INFO", quiet)
+        self.assertIn("[FAIL", quiet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -9,7 +9,10 @@ Three groups:
 * :class:`KeyResolutionTest` — ``lookup_key`` / ``has_key`` / ``set_key``, the
   flat-vs-nested wire layouts (``"observation/image"`` vs
   ``obs["images"]["cam_high"]``).
-* :class:`RobotPresetTest` — the preset table's invariants and overrides.
+* :class:`RobotPresetTest` / :class:`SyntheticContractTest` /
+  :class:`BuildRobotPolicyTest` — the preset table's invariants, its overrides,
+  and the contract it publishes (including what a checkpoint-free server must
+  admit it cannot honour).
 * :class:`UnitreeG1ServingTest` — an **unmodified openpi G1 observation** driven
   through the real websocket transport into a G1-wired policy, asserting camera
   →slot binding, state routing, and the delta→absolute / 32→16 output chain.
@@ -56,6 +59,7 @@ from apxinf.robots.presets import (  # noqa: E402
     VIEW_SLOTS,
     RobotPreset,
     available_robots,
+    build_robot_policy,
     get_robot_preset,
 )
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
@@ -169,6 +173,122 @@ class RobotPresetTest(unittest.TestCase):
             get_robot_preset("g1")
         for name in available_robots(include_aliases=True):
             self.assertIn(name, str(caught.exception))
+
+
+class SyntheticContractTest(unittest.TestCase):
+    """A checkpoint-free server may serve a preset's keys, not its arithmetic.
+
+    ``--random-weights --robot unitree_g1`` runs ``Pi05Policy.from_random``, which
+    never calls ``preset.builder``: the wire keys and view count are real, the
+    action semantics are absent. Publishing the preset name unqualified would be
+    the silent embodiment mismatch ``--robot`` exists to prevent, so every gap is
+    named at startup and ``robot_steps`` goes on the wire.
+    """
+
+    def test_only_a_builder_preset_reports_robot_steps(self) -> None:
+        self.assertFalse(get_robot_preset("franka_libero").has_robot_steps)
+        self.assertTrue(get_robot_preset("unitree_g1").has_robot_steps)
+
+    def test_a_generic_preset_that_drops_state_has_nothing_to_report(self) -> None:
+        preset = get_robot_preset("franka_libero")
+        self.assertEqual(
+            preset.synthetic_gaps(discrete_state=False, served_action_dim=7), ()
+        )
+
+    def test_dropped_state_is_reported_even_for_a_generic_preset(self) -> None:
+        # --discrete-state on franka_libero: the synthetic tokenizer ignores it.
+        preset = get_robot_preset("franka_libero")
+        gaps = preset.synthetic_gaps(discrete_state=True, served_action_dim=7)
+        self.assertEqual(len(gaps), 1)
+        self.assertIn("discrete_state", gaps[0])
+
+    def test_g1_reports_both_its_state_and_its_skipped_steps(self) -> None:
+        preset = get_robot_preset("unitree_g1")
+        gaps = preset.synthetic_gaps(discrete_state=True, served_action_dim=MODEL_DIM)
+        self.assertEqual(len(gaps), 2)
+        joined = " ".join(gaps)
+        self.assertIn("discrete_state", joined)
+        # The gap must name the factory that was skipped and the concrete symptom:
+        # a 32-wide action where the real server truncates to 16.
+        self.assertIn("build_unitree_g1_policy", joined)
+        self.assertIn(str(MODEL_DIM), joined)
+
+    def test_a_preset_whose_builder_owns_no_truncation_omits_the_width_gap(self) -> None:
+        # action_dim set means the width is the preset's, not a skipped step's, so
+        # the synthetic server serves the right one and must not claim otherwise.
+        preset = RobotPreset(
+            name="stub",
+            slots=(("base_0_rgb", "cam"),),
+            state_key="state",
+            action_dim=7,
+            builder=lambda model_dir, **kwargs: None,
+        )
+        gaps = preset.synthetic_gaps(discrete_state=False, served_action_dim=7)
+        self.assertEqual(len(gaps), 1)
+        self.assertNotIn("action_dim", gaps[0])
+
+
+class BuildRobotPolicyTest(unittest.TestCase):
+    """``build_robot_policy`` resolves overrides and publishes the contract."""
+
+    def _register(self, preset: RobotPreset) -> None:
+        ROBOT_PRESETS[preset.name] = preset
+        self.addCleanup(ROBOT_PRESETS.pop, preset.name, None)
+
+    def test_preset_defaults_and_builder_kwargs_reach_the_builder(self) -> None:
+        seen: dict = {}
+        preset = RobotPreset(
+            name="stub_robot",
+            slots=(("base_0_rgb", "cam/high"), ("left_wrist_0_rgb", "cam/wrist")),
+            state_key="joints",
+            action_dim=None,
+            discrete_state=True,
+            builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
+            builder_kwargs={"use_delta_joint_actions": True},
+        )
+        self._register(preset)
+
+        build_robot_policy("stub_robot", "/nowhere", metadata={"precision": "bf16"})
+
+        self.assertEqual(seen["model_dir"], "/nowhere")
+        self.assertEqual(seen["image_keys"], ("cam/high", "cam/wrist"))
+        self.assertEqual(seen["state_key"], "joints")
+        self.assertIsNone(seen["action_dim"])
+        self.assertTrue(seen["discrete_state"])
+        self.assertTrue(seen["use_delta_joint_actions"])
+
+        published = seen["metadata"]
+        self.assertEqual(published["robot"], "stub_robot")
+        # A robot-step preset loaded from a checkpoint gets its arithmetic, so the
+        # flag the synthetic path clears is set here.
+        self.assertTrue(published["robot_steps"])
+        self.assertEqual(
+            published["robot_slots"],
+            [["base_0_rgb", "cam/high"], ["left_wrist_0_rgb", "cam/wrist"]],
+        )
+        self.assertEqual(published["precision"], "bf16")
+
+    def test_overrides_replace_only_the_named_fields(self) -> None:
+        seen: dict = {}
+        preset = RobotPreset(
+            name="stub_generic",
+            slots=(("base_0_rgb", "observation/image"),),
+            state_key="observation/state",
+            action_dim=7,
+            builder=lambda model_dir, **kwargs: seen.update(kwargs),
+        )
+        self._register(preset)
+
+        build_robot_policy(
+            "stub_generic", "/nowhere", image_keys=["rgb/front"], state_key="q"
+        )
+
+        self.assertEqual(seen["image_keys"], ("rgb/front",))
+        self.assertEqual(seen["state_key"], "q")
+        self.assertEqual(seen["action_dim"], 7)
+        # robot_slots reports the *served* keys against the slots they fill, so an
+        # override stays reviewable instead of hiding behind the preset name.
+        self.assertEqual(seen["metadata"]["robot_slots"], [["base_0_rgb", "rgb/front"]])
 
 
 class MockModel:

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -27,9 +27,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import pathlib
 import sys
+import tempfile
 import threading
 import types
 import unittest
@@ -46,7 +48,13 @@ os.environ["no_proxy"] = "127.0.0.1,localhost"
 
 from apxinf import Pi05Policy  # noqa: E402
 from apxinf.policies.base import ComposablePolicy  # noqa: E402
-from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf.processors import (  # noqa: E402
+    Normalizer,
+    Pipeline,
+    ProcessorStep,
+    PromptTokenizer,
+    Unnormalizer,
+)
 from apxinf import conventions as conventions_module  # noqa: E402
 from apxinf.conventions import (  # noqa: E402
     CONVENTIONS,
@@ -1186,6 +1194,157 @@ class StateKeyIsRequiredWhenItIsReadTest(unittest.TestCase):
         )
         self.assertIsNone(stateless.metadata["state_key"])
         self.assertFalse(stateless.metadata["discrete_state"])
+
+
+class NormalizationDtypeTest(unittest.TestCase):
+    """A G1 checkpoint has to be normalized in float64, the way openpi does it.
+
+    openpi parses ``norm_stats.json`` with the stdlib JSON decoder and keeps the
+    result in float64. Subtracting a float64 ``q01`` from a robot's float32 state
+    promotes, so openpi's whole G1 chain -- normalize the state, discretize it
+    into the prompt, unnormalize the action -- runs in float64 whatever the robot
+    sent. Ours follows the input dtype unless told otherwise.
+
+    The gap is ~3e-7. On the output side that is nothing: a joint angle nobody
+    can measure. On the *input* side the very next operation compares the
+    normalized state against bin edges 1/128 apart, so an element sitting near
+    one lands in a different bin, writes a different number into the prompt
+    string, produces different token ids, and sends the rollout somewhere else.
+
+    Under the robot/model split the pin is not something the adapter reaches in
+    and applies -- it is a load flag the body declares (``norm_dtype`` in
+    :attr:`Embodiment.builder_kwargs`) and the model's loader honours. These
+    tests cover that as two links plus the reason it is load-bearing:
+    the preset asks for it, ``from_pretrained`` applies it, and float32 really
+    does cross a bin edge.
+    """
+
+    # --- link 1: the body declares it, and the loader accepts the keyword -----
+
+    def test_the_g1_preset_asks_the_loader_for_float64(self) -> None:
+        captured: dict = {}
+
+        def load(model_dir, *, model_type=None, **kwargs):
+            # Bind against the real signature, as UnitreeG1AdapterTest does: a
+            # flag the preset spells but ``from_pretrained`` does not accept is a
+            # TypeError the first time anyone serves a G1 checkpoint, and a
+            # kwargs-swallowing mock would never show it.
+            inspect.signature(Pi05Policy.from_pretrained).bind(model_dir, **kwargs)
+            captured.update(kwargs)
+            return _StubComposable()
+
+        with mock.patch.object(
+            robot_adapter, "AutoPolicy", types.SimpleNamespace(from_pretrained=load)
+        ):
+            build_robot_policy("unitree_g1", "/nowhere")
+
+        self.assertEqual(captured.get("norm_dtype"), "float64")
+
+    def test_libero_does_not_ask_for_it(self) -> None:
+        # The pin is scoped to the body that needs it. LIBERO's numbers are
+        # unchanged by this work, and a global default would have moved them.
+        self.assertNotIn("norm_dtype", get_robot_preset("franka_libero").builder_kwargs)
+
+    # --- link 2: the loader turns the flag into pinned normalizers ------------
+
+    def _checkpoint(self) -> pathlib.Path:
+        path = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(path, ignore_errors=True))
+        (path / "norm_stats.json").write_text(
+            json.dumps(
+                {
+                    "norm_stats": {
+                        "actions": {
+                            "q01": [-1.0] * MODEL_DIM,
+                            "q99": [1.0] * MODEL_DIM,
+                            "mean": [0.0] * MODEL_DIM,
+                            "std": [1.0] * MODEL_DIM,
+                        },
+                        "state": {
+                            "q01": [-1.0] * G1_ROBOT_DIM,
+                            "q99": [1.0] * G1_ROBOT_DIM,
+                            "mean": [0.0] * G1_ROBOT_DIM,
+                            "std": [1.0] * G1_ROBOT_DIM,
+                        },
+                    }
+                }
+            )
+        )
+        (path / "tokenizer.model").write_bytes(b"not a real sentencepiece model")
+        return path
+
+    def _load(self, **kwargs) -> Pi05Policy:
+        """Run the real ``from_pretrained``, stubbing only the tokenizer.
+
+        Everything the pin touches -- reading norm_stats, building both
+        normalizers, assembling the pipelines -- is the shipped code path. Only
+        SentencePiece is replaced, because it is the one step that needs a real
+        binary model file and it has nothing to do with dtypes.
+        """
+        with mock.patch.object(pi05_module, "PromptTokenizer", lambda *a, **k: RecordingTokenizer()):
+            return Pi05Policy.from_pretrained(
+                self._checkpoint(),
+                model=MockModel(num_views=len(G1_CAMERAS)),
+                discrete_state=True,
+                state_key=G1_STATE_KEY,
+                image_keys=G1_CAMERAS,
+                **kwargs,
+            )
+
+    def test_norm_dtype_pins_both_normalizers(self) -> None:
+        policy = self._load(norm_dtype="float64")
+        self.assertEqual(
+            policy.input_pipeline["tokenize"].state_normalizer.dtype, np.dtype("float64")
+        )
+        self.assertEqual(
+            policy.output_pipeline["unnormalize"].unnormalizer.dtype, np.dtype("float64")
+        )
+
+    def test_the_default_still_follows_the_input(self) -> None:
+        # Without the flag nothing is pinned, so this work changes no numbers for
+        # any checkpoint that does not ask -- which is what keeps LIBERO's
+        # float32 results bit-identical.
+        policy = self._load()
+        self.assertIsNone(policy.input_pipeline["tokenize"].state_normalizer.dtype)
+        self.assertIsNone(policy.output_pipeline["unnormalize"].unnormalizer.dtype)
+
+    # --- why it is load-bearing ----------------------------------------------
+
+    def test_float32_normalization_lands_in_a_different_bin(self) -> None:
+        """The reason for the pin, stated as a number rather than an assertion of faith."""
+        from apxinf.processors import discretize_state
+
+        rng = np.random.default_rng(11)
+        q01 = rng.uniform(-2.6, -0.4, G1_ROBOT_DIM)
+        q99 = q01 + rng.uniform(0.7, 4.1, G1_ROBOT_DIM)
+
+        # States that normalize *onto the bin edges*, by inverting openpi's
+        # normalize. Uniformly sampled states would not show anything: a 3e-7
+        # shift only changes a bin for an element already within 3e-7 of an edge
+        # 1/128 apart, which is a ~4e-5 chance each. That rarity is not safety --
+        # a G1 has 16 joints polled at 30 Hz, so "one in 25000 elements" is a
+        # corrupted prompt every minute or so, on a random joint, with no symptom
+        # other than the rollout going somewhere else.
+        edges = np.linspace(-1.0, 1.0, 257)[:-1]
+        targets = np.resize(edges, (edges.size // G1_ROBOT_DIM, G1_ROBOT_DIM))
+        states = (q01 + (targets + 1.0) / 2.0 * (q99 - q01 + 1e-6)).astype(np.float32)
+
+        pinned = Normalizer(q01=q01, q99=q99, dims=G1_ROBOT_DIM, dtype="float64")
+        loose = Normalizer(q01=q01, q99=q99, dims=G1_ROBOT_DIM)
+
+        wide = np.stack([pinned(s) for s in states])
+        narrow = np.stack([loose(s) for s in states])
+        self.assertEqual(wide.dtype, np.float64)
+        self.assertEqual(narrow.dtype, np.float32, "the unpinned default follows the input")
+
+        # openpi's own arithmetic, for the record: float64 stats promote the state.
+        reference = (states - q01) / (q99 - q01 + 1e-6) * 2.0 - 1.0
+        np.testing.assert_array_equal(wide, reference)
+
+        moved = int((discretize_state(wide) != discretize_state(narrow)).sum())
+        self.assertGreater(
+            moved, 0, "if float32 never crossed a bin edge the pin would be cosmetic"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -65,6 +65,8 @@ from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     VIEW_SLOTS,
+    Convention,
+    Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
@@ -158,24 +160,56 @@ class RobotPresetTest(unittest.TestCase):
         # Full model width; UnitreeG1EncodeActions does the 32->16 truncation.
         self.assertIsNone(preset.action_dim)
 
-    def test_slots_must_be_a_prefix_of_the_model_view_slots(self) -> None:
-        # A checkpoint fills view slots from 0 up, so declaring "base + right
-        # wrist" is not expressible and must be rejected at table-definition
-        # time rather than mis-binding a camera at inference time.
-        with self.assertRaises(ValueError):
-            RobotPreset(
-                name="bad",
-                slots=(("base_0_rgb", "a"), ("right_wrist_0_rgb", "b")),
-                state_key="state",
-            )
+    def test_slots_are_derived_in_view_slot_order(self) -> None:
+        # A checkpoint fills view slots from 0 up, so "base + right wrist" is not
+        # expressible. The old table let you *write* the pairs and validated the
+        # order; deriving them removes the failure mode instead of checking it.
+        convention = Convention(
+            name="two_cam", image_keys=("a", "b"), state_key="state"
+        )
+        self.assertEqual(convention.slots, (("base_0_rgb", "a"), ("left_wrist_0_rgb", "b")))
 
     def test_duplicate_camera_keys_are_rejected(self) -> None:
         with self.assertRaises(ValueError):
-            RobotPreset(
+            Convention(name="bad", image_keys=("a", "a"), state_key="state")
+
+    def test_more_cameras_than_view_slots_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            Convention(
                 name="bad",
-                slots=(("base_0_rgb", "a"), ("left_wrist_0_rgb", "a")),
+                image_keys=tuple(f"cam{i}" for i in range(len(VIEW_SLOTS) + 1)),
                 state_key="state",
             )
+
+    def test_a_convention_cannot_be_paired_with_the_wrong_body(self) -> None:
+        # The one check only the pairing can make: a 3-camera dialect against a
+        # 2-camera body would stack the wrong number of views, and nothing
+        # downstream distinguishes that from a checkpoint mismatch.
+        with self.assertRaises(ValueError) as caught:
+            RobotPreset(
+                name="mismatched",
+                embodiment=Embodiment(name="two_cam_body", num_cameras=2),
+                convention=Convention(
+                    name="three_cam", image_keys=("a", "b", "c"), state_key="state"
+                ),
+            )
+        message = str(caught.exception)
+        self.assertIn("three_cam", message)
+        self.assertIn("two_cam_body", message)
+
+    def test_the_two_halves_vary_independently(self) -> None:
+        # The reason for the split: a second key convention on the same body is a
+        # new Convention, not a new body. Re-pairing must need no builder edit.
+        franka = get_robot_preset("franka_libero").embodiment
+        droid_like = Convention(
+            name="droid_like",
+            image_keys=("observation/exterior_image_1_left", "observation/wrist_image_left"),
+            state_key="observation/joint_position",
+        )
+        repaired = RobotPreset(name="franka_droid_like", embodiment=franka, convention=droid_like)
+        self.assertEqual(repaired.image_keys, droid_like.image_keys)
+        self.assertEqual(repaired.action_dim, 7)
+        self.assertIs(repaired.builder, get_robot_preset("franka_libero").builder)
 
     def test_unknown_robot_names_the_known_ones(self) -> None:
         with self.assertRaises(KeyError) as caught:
@@ -227,10 +261,13 @@ class SyntheticContractTest(unittest.TestCase):
         # the synthetic server serves the right one and must not claim otherwise.
         preset = RobotPreset(
             name="stub",
-            slots=(("base_0_rgb", "cam"),),
-            state_key="state",
-            action_dim=7,
-            builder=lambda model_dir, **kwargs: None,
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=1,
+                action_dim=7,
+                builder=lambda model_dir, **kwargs: None,
+            ),
+            convention=Convention(name="stub_keys", image_keys=("cam",), state_key="state"),
         )
         gaps = preset.synthetic_gaps(discrete_state=False, served_action_dim=7)
         self.assertEqual(len(gaps), 1)
@@ -248,12 +285,19 @@ class BuildRobotPolicyTest(unittest.TestCase):
         seen: dict = {}
         preset = RobotPreset(
             name="stub_robot",
-            slots=(("base_0_rgb", "cam/high"), ("left_wrist_0_rgb", "cam/wrist")),
-            state_key="joints",
-            action_dim=None,
-            discrete_state=True,
-            builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
-            builder_kwargs={"use_delta_joint_actions": True},
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=2,
+                action_dim=None,
+                builder=lambda model_dir, **kwargs: seen.update(kwargs, model_dir=model_dir),
+                builder_kwargs={"use_delta_joint_actions": True},
+            ),
+            convention=Convention(
+                name="stub_keys",
+                image_keys=("cam/high", "cam/wrist"),
+                state_key="joints",
+                discrete_state=True,
+            ),
         )
         self._register(preset)
 
@@ -281,10 +325,17 @@ class BuildRobotPolicyTest(unittest.TestCase):
         seen: dict = {}
         preset = RobotPreset(
             name="stub_generic",
-            slots=(("base_0_rgb", "observation/image"),),
-            state_key="observation/state",
-            action_dim=7,
-            builder=lambda model_dir, **kwargs: seen.update(kwargs),
+            embodiment=Embodiment(
+                name="stub_body",
+                num_cameras=1,
+                action_dim=7,
+                builder=lambda model_dir, **kwargs: seen.update(kwargs),
+            ),
+            convention=Convention(
+                name="stub_keys",
+                image_keys=("observation/image",),
+                state_key="observation/state",
+            ),
         )
         self._register(preset)
 

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -47,15 +47,29 @@ os.environ["no_proxy"] = "127.0.0.1,localhost"
 from apxinf import Pi05Policy  # noqa: E402
 from apxinf.policies.base import ComposablePolicy  # noqa: E402
 from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf import conventions as conventions_module  # noqa: E402
+from apxinf.conventions import (  # noqa: E402
+    CONVENTIONS,
+    LIBERO as LIBERO_CONVENTION,
+    UNITREE_G1 as G1_CONVENTION,
+    Convention,
+    available_conventions,
+    get_convention,
+    register_convention,
+)
 from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
-    G1_CAMERAS,
     G1_ROBOT_DIM,
-    G1_STATE_KEY,
     UnitreeG1AbsoluteActions,
     UnitreeG1DecodeState,
     UnitreeG1EncodeActions,
 )
+
+# The G1 client's wire keys are a recording convention, not a fact about the
+# body, so the tests read them from the convention the preset pairs with.
+G1_CAMERAS = G1_CONVENTION.image_keys
+G1_STATE_KEY = G1_CONVENTION.state_key
 from apxinf.processors.transforms import (  # noqa: E402
+    Tokenize,
     has_key,
     lookup_key,
     set_key,
@@ -63,14 +77,15 @@ from apxinf.processors.transforms import (  # noqa: E402
 from apxinf.policies.impls import pi05 as pi05_module  # noqa: E402
 from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
+    ROBOT_ALIASES,
     ROBOT_PRESETS,
     VIEW_SLOTS,
-    Convention,
     Embodiment,
     RobotPreset,
     available_robots,
     build_robot_policy,
     get_robot_preset,
+    register_robot_preset,
 )
 from apxinf.robots.unitree_g1 import build_unitree_g1_policy  # noqa: E402
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
@@ -628,10 +643,25 @@ class UnitreeG1AdapterTest(unittest.TestCase):
         # Advertising 16 regardless would publish a width no step produces.
         stub = _StubComposable()
         with self._patched_loader({}, stub):
-            build_unitree_g1_policy("/nowhere", adapt_to_pi=False)
+            build_unitree_g1_policy(
+                "/nowhere",
+                state_key=G1_STATE_KEY,
+                image_keys=G1_CAMERAS,
+                adapt_to_pi=False,
+            )
         self.assertEqual(stub.wrapped["before"], [])
         self.assertEqual(stub.wrapped["after"], ["g1_absolute"])
         self.assertIsNone(stub.wrapped["action_dim"])
+
+    def test_the_wire_keys_are_required_arguments(self) -> None:
+        # They are a recording convention, not a fact about this body. A default
+        # here would rebuild the robot<->dataset coupling one layer up: the same
+        # G1 re-recorded under different keys would silently serve the old ones.
+        with self._patched_loader({}, _StubComposable()):
+            with self.assertRaises(TypeError):
+                build_unitree_g1_policy("/nowhere", image_keys=G1_CAMERAS)
+            with self.assertRaises(TypeError):
+                build_unitree_g1_policy("/nowhere", state_key=G1_STATE_KEY)
 
     def test_a_policy_that_cannot_be_wrapped_is_named_in_the_error(self) -> None:
         class Unwrappable:
@@ -639,7 +669,9 @@ class UnitreeG1AdapterTest(unittest.TestCase):
 
         with self._patched_loader({}, Unwrappable()):
             with self.assertRaises(TypeError) as caught:
-                build_unitree_g1_policy("/nowhere")
+                build_unitree_g1_policy(
+                    "/nowhere", state_key=G1_STATE_KEY, image_keys=G1_CAMERAS
+                )
         message = str(caught.exception)
         self.assertIn("Unwrappable", message)
         self.assertIn("with_adapter", message)
@@ -663,13 +695,20 @@ class ModelLayerHoldsNoWireKeysTest(unittest.TestCase):
 
     def _policy(self, num_views: int) -> Pi05Policy:
         model = MockModel(num_views=num_views)
+        # A state key has to be named because RecordingTokenizer discretizes
+        # state; these tests are about the *camera* fallback, so it is a neutral
+        # spelling rather than any dataset's.
         input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
             model,
             tokenizer=RecordingTokenizer(),
             unnormalizer=_identity_unnormalizer(),
+            state_key="state",
         )
         return Pi05Policy(
-            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+            model,
+            input_pipeline=input_pipeline,
+            output_pipeline=output_pipeline,
+            state_key="state",
         )
 
     def test_unnamed_cameras_fall_back_to_the_models_own_slots(self) -> None:
@@ -917,6 +956,236 @@ class ImageSlotOrderTest(unittest.TestCase):
                 "/nonexistent", model=MockModel(num_views=3), num_views=2
             )
         self.assertIn("pass num_views to the load call", str(caught.exception))
+
+
+class ConventionsAreTheirOwnLayerTest(unittest.TestCase):
+    """A recording dialect is not a robot's property, so it has its own module.
+
+    The G1's wire keys used to live in ``processors/robots/unitree_g1.py`` — a
+    *dataset* fact defined inside a *body*'s processing steps, so re-recording the
+    same robot meant editing its steps. They now live in :mod:`apxinf.conventions`,
+    which depends on neither a body nor a policy implementation.
+    """
+
+    def test_the_shipped_conventions_are_registered_under_their_names(self) -> None:
+        self.assertIs(get_convention("libero"), LIBERO_CONVENTION)
+        self.assertIs(get_convention("unitree_g1"), G1_CONVENTION)
+        for name in ("libero", "unitree_g1"):
+            self.assertIn(name, available_conventions())
+
+    def test_a_preset_reuses_the_convention_object_rather_than_restating_it(self) -> None:
+        # If a preset copied the keys instead, the two could drift and only a
+        # client would notice — on the wire, silently.
+        self.assertIs(get_robot_preset("unitree_g1").convention, G1_CONVENTION)
+        self.assertIs(get_robot_preset("franka_libero").convention, LIBERO_CONVENTION)
+
+    def test_the_g1_steps_no_longer_hold_the_g1s_wire_keys(self) -> None:
+        # The regression to catch: a body's processing steps naming a dataset's
+        # keys again. Checked on the module's exports, not by grepping prose.
+        from apxinf.processors.robots import unitree_g1 as g1_steps
+
+        self.assertFalse(hasattr(g1_steps, "G1_CAMERAS"))
+        self.assertFalse(hasattr(g1_steps, "G1_STATE_KEY"))
+        for step in (UnitreeG1DecodeState, UnitreeG1AbsoluteActions):
+            with self.subTest(step=step.__name__):
+                default = inspect.signature(step).parameters["state_key"].default
+                self.assertIs(default, inspect.Parameter.empty)
+
+    def test_conventions_import_no_body_and_no_policy_implementation(self) -> None:
+        # The layering rule: a dialect may read the model's VIEW_SLOTS vocabulary
+        # and nothing else. Anything more and the third axis is coupled again.
+        source = pathlib.Path(conventions_module.__file__).read_text()
+        for forbidden in ("Embodiment", "RobotPreset", "Pi05Policy", "AutoPolicy"):
+            with self.subTest(name=forbidden):
+                self.assertNotIn(f"import {forbidden}", source)
+                self.assertNotIn(f"{forbidden}(", source)
+
+
+class RegistrationFromOutsideTest(unittest.TestCase):
+    """A third-party robot or dialect must not have to patch our files.
+
+    Both registries are process-local dicts, so each test restores them; the
+    point under test is the guard rails, not the mutation.
+    """
+
+    def setUp(self) -> None:
+        self._presets = dict(ROBOT_PRESETS)
+        self._aliases = dict(ROBOT_ALIASES)
+        self._conventions = dict(CONVENTIONS)
+
+    def tearDown(self) -> None:
+        ROBOT_PRESETS.clear()
+        ROBOT_PRESETS.update(self._presets)
+        ROBOT_ALIASES.clear()
+        ROBOT_ALIASES.update(self._aliases)
+        CONVENTIONS.clear()
+        CONVENTIONS.update(self._conventions)
+
+    def _preset(self, name: str = "myarm_mydataset") -> RobotPreset:
+        return RobotPreset(
+            name=name,
+            embodiment=Embodiment(name="myarm", num_cameras=1, action_dim=6),
+            convention=Convention(name="mydataset", image_keys=("rgb",), state_key="q"),
+        )
+
+    def test_a_registered_preset_is_reachable_as_a_robot_flag(self) -> None:
+        preset = register_robot_preset(self._preset(), aliases=("myarm",))
+        self.assertIs(get_robot_preset("myarm_mydataset"), preset)
+        self.assertIs(get_robot_preset("myarm"), preset)
+        self.assertIn("myarm_mydataset", available_robots())
+        self.assertIn("myarm", available_robots(include_aliases=True))
+
+    def test_re_registering_a_name_needs_an_explicit_replace(self) -> None:
+        # A silent overwrite would change what a launch command already in
+        # production resolves to — the invisible failure --robot exists to prevent.
+        register_robot_preset(self._preset())
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset())
+        self.assertIn("replace=True", str(caught.exception))
+        replacement = self._preset()
+        self.assertIs(
+            register_robot_preset(replacement, replace=True),
+            get_robot_preset("myarm_mydataset"),
+        )
+
+    def test_an_alias_may_never_shadow_a_canonical_preset(self) -> None:
+        # Even with replace=True: an alias winning over a real preset would
+        # silently redirect a --robot spelling that already names something.
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset(), aliases=("unitree_g1",), replace=True)
+        self.assertIn("unitree_g1", str(caught.exception))
+        self.assertIs(get_robot_preset("unitree_g1").embodiment.builder, build_unitree_g1_policy)
+
+    def test_moving_an_existing_alias_needs_an_explicit_replace(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            register_robot_preset(self._preset(), aliases=("libero",))
+        self.assertIn("franka_libero", str(caught.exception))
+        self.assertIs(get_robot_preset("libero"), get_robot_preset("franka_libero"))
+        register_robot_preset(self._preset(), aliases=("libero",), replace=True)
+        self.assertEqual(get_robot_preset("libero").name, "myarm_mydataset")
+
+    def test_a_failed_registration_leaves_both_tables_untouched(self) -> None:
+        # The alias check runs before either dict is written, so a rejected call
+        # cannot half-register a preset under its canonical name.
+        with self.assertRaises(ValueError):
+            register_robot_preset(self._preset(), aliases=("unitree_g1",))
+        self.assertNotIn("myarm_mydataset", ROBOT_PRESETS)
+
+    def test_registering_something_that_is_not_a_preset_is_a_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            register_robot_preset(Convention(name="x", image_keys=("a",), state_key="q"))
+
+    def test_a_registered_convention_pairs_with_a_shipped_body(self) -> None:
+        droid_like = register_convention(
+            Convention(
+                name="franka_droid_like",
+                image_keys=("observation/exterior_image_1_left", "observation/wrist_image_left"),
+                state_key="observation/joint_position",
+            )
+        )
+        self.assertIs(get_convention("franka_droid_like"), droid_like)
+        # The payoff of the split: a new dialect on an existing body needs no
+        # new Embodiment, no builder, and no edit to either shipped module.
+        preset = RobotPreset(
+            name="franka_droid_like",
+            embodiment=get_robot_preset("franka_libero").embodiment,
+            convention=droid_like,
+        )
+        self.assertEqual(preset.action_dim, 7)
+        self.assertEqual(preset.state_key, "observation/joint_position")
+
+    def test_re_registering_a_convention_needs_an_explicit_replace(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            register_convention(
+                Convention(name="libero", image_keys=("a", "b"), state_key="q")
+            )
+        self.assertIn("replace=True", str(caught.exception))
+        self.assertIs(get_convention("libero"), LIBERO_CONVENTION)
+
+    def test_registering_something_that_is_not_a_convention_is_a_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            register_convention(Embodiment(name="myarm", num_cameras=1))
+
+
+class StateKeyIsRequiredWhenItIsReadTest(unittest.TestCase):
+    """``state_key`` has no default, and is demanded exactly when state is read.
+
+    The model layer used to default it to LIBERO's ``observation/state``, the same
+    dataset-in-the-model coupling the camera keys had. Dropping the default leaves
+    an asymmetry with ``image_keys``: a wrong camera key raises ``KeyError`` on the
+    first inference, but a missing state key is silent — the tokenizer just
+    injects nothing and the policy publishes ``state_key=null`` while proprioception
+    quietly disappears. So it is required whenever the chain discretizes state, and
+    allowed to stay ``None`` only when state is deliberately dropped.
+    """
+
+    def test_the_model_layer_defaults_no_state_key(self) -> None:
+        # Asserted on the signatures, not by grepping the source, so the prose
+        # explaining the old LIBERO default does not trip the check.
+        for func in (
+            pi05_module.Pi05Policy.__init__,
+            pi05_module.Pi05Policy.default_pipelines,
+            pi05_module.Pi05Policy.from_pretrained,
+            pi05_module.Pi05Policy.from_random,
+            Tokenize.__init__,
+        ):
+            with self.subTest(entry_point=func.__qualname__):
+                self.assertIsNone(inspect.signature(func).parameters["state_key"].default)
+
+    def test_a_discretizing_tokenizer_without_a_key_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            Tokenize(RecordingTokenizer(), None, None)
+        self.assertIn("state_key", str(caught.exception))
+
+    def test_a_dropping_tokenizer_without_a_key_is_fine(self) -> None:
+        # discrete_state=False means state is dropped on purpose; demanding a key
+        # for a value nothing reads would be noise.
+        tokenizer = RecordingTokenizer()
+        tokenizer.discrete_state = False
+        self.assertIsNone(Tokenize(tokenizer, None, None).state_key)
+
+    def test_a_policy_whose_chain_reads_state_is_rejected_without_a_key(self) -> None:
+        model = MockModel(num_views=2)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+            state_key="state",
+        )
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy(
+                model,
+                input_pipeline=input_pipeline,
+                output_pipeline=output_pipeline,
+                state_key=None,
+            )
+        self.assertIn("state_key", str(caught.exception))
+
+    def test_from_pretrained_refuses_discrete_state_without_a_key(self) -> None:
+        # Checked before the checkpoint is touched, so the message can name the
+        # flags the caller actually passed rather than failing deep in a load.
+        with self.assertRaises(ValueError) as caught:
+            Pi05Policy.from_pretrained("/nonexistent", discrete_state=True)
+        message = str(caught.exception)
+        self.assertIn("state_key", message)
+        self.assertIn("discrete_state=False", message)
+
+    def test_the_published_contract_may_say_no_state_key(self) -> None:
+        # A policy that drops state has no state key to publish, and null is the
+        # honest answer — a client reading metadata sees that state is unused.
+        policy = build_g1_mock_policy()
+        self.assertEqual(policy.metadata["state_key"], G1_STATE_KEY)
+        tokenizer = RecordingTokenizer()
+        tokenizer.discrete_state = False
+        model = MockModel(num_views=2)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model, tokenizer=tokenizer, unnormalizer=_identity_unnormalizer()
+        )
+        stateless = Pi05Policy(
+            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+        )
+        self.assertIsNone(stateless.metadata["state_key"])
+        self.assertFalse(stateless.metadata["discrete_state"])
 
 
 if __name__ == "__main__":

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -60,6 +60,7 @@ from apxinf.processors.transforms import (  # noqa: E402
     lookup_key,
     set_key,
 )
+from apxinf.policies.impls import pi05 as pi05_module  # noqa: E402
 from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
@@ -597,6 +598,76 @@ class UnitreeG1AdapterTest(unittest.TestCase):
         # A concrete policy reappearing here is the regression to catch.
         source = pathlib.Path(robot_adapter.__file__).read_text()
         self.assertNotIn("Pi05Policy", source)
+
+
+class ModelLayerHoldsNoWireKeysTest(unittest.TestCase):
+    """The policy layer must not carry any dataset's wire contract.
+
+    ``Pi05Policy`` used to default ``image_keys`` to LIBERO's
+    ``observation/image`` / ``observation/wrist_image``. As *the* default those
+    two keys silently applied to every checkpoint, so a G1 checkpoint served bare
+    ran LIBERO's contract and looked like an accuracy problem. The fallback is
+    now the model's own view slots, which cannot masquerade as anyone's keys.
+    """
+
+    def _policy(self, num_views: int) -> Pi05Policy:
+        model = MockModel(num_views=num_views)
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+        )
+        return Pi05Policy(
+            model, input_pipeline=input_pipeline, output_pipeline=output_pipeline
+        )
+
+    def test_unnamed_cameras_fall_back_to_the_models_own_slots(self) -> None:
+        policy = self._policy(2)
+        self.assertEqual(policy.image_keys, VIEW_SLOTS[:2])
+        # Same list in the published contract, so a client reading metadata sees
+        # exactly what the ImageStack step resolves.
+        self.assertEqual(policy.metadata["image_keys"], list(VIEW_SLOTS[:2]))
+
+    def test_the_fallback_is_not_any_datasets_convention(self) -> None:
+        policy = self._policy(2)
+        for key in ("observation/image", "observation/wrist_image", "images/cam_high"):
+            self.assertNotIn(key, policy.image_keys)
+
+    def test_a_libero_client_against_the_fallback_fails_loudly(self) -> None:
+        # The point of dropping the default: a mismatch is an error naming both
+        # sides, not a silent run on the wrong cameras.
+        policy = self._policy(2)
+        observation = {
+            "observation/image": np.zeros((IMAGE_SIZE, IMAGE_SIZE, 3), np.uint8),
+            "observation/wrist_image": np.zeros((IMAGE_SIZE, IMAGE_SIZE, 3), np.uint8),
+            "prompt": "pick up the block",
+        }
+        with self.assertRaises(KeyError) as caught:
+            policy.infer(observation)
+        message = str(caught.exception)
+        self.assertIn(VIEW_SLOTS[0], message)
+
+    def test_the_fallback_stays_total_beyond_the_declared_slots(self) -> None:
+        # default_pipelines requires len(image_keys) == model.num_views, so the
+        # fallback has to name *every* view a model claims, slots or not.
+        policy = self._policy(len(VIEW_SLOTS) + 1)
+        self.assertEqual(len(policy.image_keys), len(VIEW_SLOTS) + 1)
+        self.assertEqual(policy.image_keys[: len(VIEW_SLOTS)], VIEW_SLOTS)
+        self.assertEqual(len(set(policy.image_keys)), len(policy.image_keys))
+
+    def test_no_constructor_defaults_a_camera_key(self) -> None:
+        # Asserted on the signatures rather than by grepping the source, so the
+        # prose explaining the old LIBERO default does not trip the check. Every
+        # entry point that takes image_keys must leave them unnamed.
+        for func in (
+            pi05_module.Pi05Policy.__init__,
+            pi05_module.Pi05Policy.default_pipelines,
+            pi05_module.Pi05Policy.from_pretrained,
+            pi05_module.Pi05Policy.from_random,
+        ):
+            with self.subTest(entry_point=func.__qualname__):
+                default = inspect.signature(func).parameters["image_keys"].default
+                self.assertIsNone(default)
 
 
 class RunningServer:

--- a/tests/test_robot_presets.py
+++ b/tests/test_robot_presets.py
@@ -4,7 +4,7 @@ Covers the layer that decides *which keys a client must send*, which is where a
 deployment silently degrades rather than fails: a checkpoint served under the
 wrong embodiment still returns well-shaped actions.
 
-Three groups:
+Four groups:
 
 * :class:`KeyResolutionTest` — ``lookup_key`` / ``has_key`` / ``set_key``, the
   flat-vs-nested wire layouts (``"observation/image"`` vs
@@ -13,6 +13,9 @@ Three groups:
   :class:`BuildRobotPolicyTest` — the preset table's invariants, its overrides,
   and the contract it publishes (including what a checkpoint-free server must
   admit it cannot honour).
+* :class:`PipelineCompositionTest` / :class:`PolicyCompositionTest` /
+  :class:`UnitreeG1AdapterTest` — the robot/model seam: a robot's steps wrap a
+  model's chain from outside, without either layer naming the other.
 * :class:`UnitreeG1ServingTest` — an **unmodified openpi G1 observation** driven
   through the real websocket transport into a G1-wired policy, asserting camera
   →slot binding, state routing, and the delta→absolute / 32→16 output chain.
@@ -23,11 +26,14 @@ Runs offline against a mock model; no CUDA, no checkpoint.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import pathlib
 import sys
 import threading
+import types
 import unittest
+from unittest import mock
 
 import numpy as np
 from openpi_client import websocket_client_policy
@@ -39,7 +45,8 @@ os.environ["NO_PROXY"] = "127.0.0.1,localhost"
 os.environ["no_proxy"] = "127.0.0.1,localhost"
 
 from apxinf import Pi05Policy  # noqa: E402
-from apxinf.processors import Pipeline, PromptTokenizer, Unnormalizer  # noqa: E402
+from apxinf.policies.base import ComposablePolicy  # noqa: E402
+from apxinf.processors import Pipeline, ProcessorStep, PromptTokenizer, Unnormalizer  # noqa: E402
 from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
     G1_CAMERAS,
     G1_ROBOT_DIM,
@@ -49,11 +56,11 @@ from apxinf.processors.robots.unitree_g1 import (  # noqa: E402
     UnitreeG1EncodeActions,
 )
 from apxinf.processors.transforms import (  # noqa: E402
-    Unnormalize,
     has_key,
     lookup_key,
     set_key,
 )
+from apxinf.robots import unitree_g1 as robot_adapter  # noqa: E402
 from apxinf.robots.presets import (  # noqa: E402
     ROBOT_PRESETS,
     VIEW_SLOTS,
@@ -62,6 +69,7 @@ from apxinf.robots.presets import (  # noqa: E402
     build_robot_policy,
     get_robot_preset,
 )
+from apxinf.robots.unitree_g1 import build_unitree_g1_policy  # noqa: E402
 from apxinf.serving import WebsocketPolicyServer  # noqa: E402
 from apxinf.serving.websocket import health_check  # noqa: E402
 
@@ -291,6 +299,47 @@ class BuildRobotPolicyTest(unittest.TestCase):
         self.assertEqual(seen["metadata"]["robot_slots"], [["base_0_rgb", "rgb/front"]])
 
 
+class _Tag(ProcessorStep):
+    """Trivial step: append its own label to the flowing list."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __call__(self, value):
+        return list(value) + [self.label]
+
+
+class PipelineCompositionTest(unittest.TestCase):
+    """``prepend``/``append``: the only editing verbs that name no inner step.
+
+    Every other verb (``insert_before``, ``replace``, ...) needs a step name, so
+    an *outer* layer using them has to know the inner chain's private vocabulary.
+    A robot adapter's requirement is only "run outside the model's steps", and
+    these two say exactly that.
+    """
+
+    def _chain(self) -> Pipeline:
+        return Pipeline([("a", _Tag("a")), ("b", _Tag("b"))])
+
+    def test_wrapping_runs_outside_the_existing_steps_in_order(self) -> None:
+        chain = self._chain().prepend(("pre1", _Tag("pre1")), ("pre2", _Tag("pre2")))
+        chain = chain.append(("post1", _Tag("post1")), ("post2", _Tag("post2")))
+        self.assertEqual(chain([]), ["pre1", "pre2", "a", "b", "post1", "post2"])
+
+    def test_the_original_pipeline_is_untouched(self) -> None:
+        original = self._chain()
+        original.prepend(("pre", _Tag("pre")))
+        original.append(("post", _Tag("post")))
+        self.assertEqual(original.names, ["a", "b"])
+
+    def test_a_colliding_name_is_rejected_rather_than_shadowing(self) -> None:
+        # A wrapper that silently replaced an inner step would be the worst
+        # possible failure: the model's chain quietly loses a step.
+        with self.assertRaises(ValueError) as caught:
+            self._chain().prepend(("b", _Tag("b2")))
+        self.assertIn("'b'", str(caught.exception))
+
+
 class MockModel:
     """In-process ``BareModel`` stand-in returning a constant normalized action."""
 
@@ -326,9 +375,9 @@ class RecordingTokenizer(PromptTokenizer):
 def build_g1_mock_policy() -> Pi05Policy:
     """A G1-wired policy over a mock model: the real pipelines, no checkpoint.
 
-    Mirrors ``build_unitree_g1_policy`` but injects the model and an identity
-    unnormalizer, so the assertions isolate the adapter's arithmetic from
-    checkpoint norm_stats.
+    Takes the same route ``build_unitree_g1_policy`` does — a stock policy, then
+    ``with_adapter`` — but injects the model and an identity unnormalizer, so the
+    assertions isolate the adapter's arithmetic from checkpoint norm_stats.
     """
     model = MockModel(num_views=len(G1_CAMERAS))
     tokenizer = RecordingTokenizer()
@@ -342,27 +391,212 @@ def build_g1_mock_policy() -> Pi05Policy:
         image_keys=G1_CAMERAS,
         state_key=G1_STATE_KEY,
     )
-    input_pipeline = input_pipeline.insert_before(
-        "tokenize", ("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))
-    )
-    output_pipeline = Pipeline(
-        [
-            ("unnormalize", Unnormalize(identity)),
-            ("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY)),
-            ("g1_encode", UnitreeG1EncodeActions()),
-        ]
-    )
-    policy = Pi05Policy(
+    base = Pi05Policy(
         model,
         input_pipeline=input_pipeline,
         output_pipeline=output_pipeline,
         image_keys=G1_CAMERAS,
         state_key=G1_STATE_KEY,
+        metadata={"protocol": "openpi.websocket_policy"},
+    )
+    policy = base.with_adapter(
+        before=[("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))],
+        after=[
+            ("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY)),
+            ("g1_encode", UnitreeG1EncodeActions()),
+        ],
         action_dim=G1_ROBOT_DIM,
-        metadata={"robot": "unitree_g1", "protocol": "openpi.websocket_policy"},
+        metadata={"robot": "unitree_g1"},
     )
     policy.tokenizer = tokenizer
     return policy
+
+
+def _identity_unnormalizer() -> Unnormalizer:
+    return Unnormalizer(
+        q01=[-1.0] * MODEL_DIM, q99=[1.0] * MODEL_DIM, dims=MODEL_DIM, eps=0.0
+    )
+
+
+class PolicyCompositionTest(unittest.TestCase):
+    """``Pi05Policy.with_adapter``: the seam a robot adapter wraps.
+
+    Its contract is nesting — ``before`` outside the model's whole input chain,
+    ``after`` outside its whole output chain — plus republishing what the wrapped
+    policy actually serves. Getting the second part wrong is the failure this
+    layer exists to prevent: a policy advertising an ``action_dim`` its steps do
+    not emit degrades silently on the wire.
+    """
+
+    def _base(self) -> Pi05Policy:
+        model = MockModel(num_views=len(G1_CAMERAS))
+        input_pipeline, output_pipeline = Pi05Policy.default_pipelines(
+            model,
+            tokenizer=RecordingTokenizer(),
+            unnormalizer=_identity_unnormalizer(),
+            image_keys=G1_CAMERAS,
+            state_key=G1_STATE_KEY,
+        )
+        return Pi05Policy(
+            model,
+            input_pipeline=input_pipeline,
+            output_pipeline=output_pipeline,
+            image_keys=G1_CAMERAS,
+            state_key=G1_STATE_KEY,
+            metadata={"protocol": "openpi.websocket_policy"},
+        )
+
+    def test_steps_land_outside_the_model_chain_in_both_directions(self) -> None:
+        base = self._base()
+        wrapped = base.with_adapter(
+            before=[("g1_decode_state", UnitreeG1DecodeState(G1_STATE_KEY))],
+            after=[("g1_encode", UnitreeG1EncodeActions())],
+            action_dim=G1_ROBOT_DIM,
+        )
+        self.assertEqual(wrapped.input_pipeline.names[0], "g1_decode_state")
+        self.assertEqual(wrapped.output_pipeline.names[-1], "g1_encode")
+        # The model's own steps keep their order and their names; the wrapper
+        # never had to learn what they are.
+        self.assertEqual(wrapped.input_pipeline.names[1:], base.input_pipeline.names)
+        self.assertEqual(wrapped.output_pipeline.names[:-1], base.output_pipeline.names)
+
+    def test_the_original_policy_is_not_mutated(self) -> None:
+        base = self._base()
+        base.with_adapter(
+            after=[("g1_encode", UnitreeG1EncodeActions())], action_dim=G1_ROBOT_DIM
+        )
+        self.assertNotIn("g1_encode", base.output_pipeline.names)
+        self.assertEqual(base.action_dim, MODEL_DIM)
+
+    def test_the_published_contract_describes_the_wrapped_chain(self) -> None:
+        wrapped = self._base().with_adapter(
+            after=[("g1_encode", UnitreeG1EncodeActions())],
+            action_dim=G1_ROBOT_DIM,
+            metadata={"robot": "unitree_g1"},
+        )
+        # The derived half is recomputed: inheriting the pre-adapter action_dim
+        # would publish a width no step in this chain produces.
+        self.assertEqual(wrapped.metadata["action_dim"], G1_ROBOT_DIM)
+        self.assertIn("g1_encode", wrapped.metadata["output_pipeline"])
+        # The caller's half is carried forward and extended.
+        self.assertEqual(wrapped.metadata["protocol"], "openpi.websocket_policy")
+        self.assertEqual(wrapped.metadata["robot"], "unitree_g1")
+
+    def test_an_unchanged_width_is_inherited(self) -> None:
+        # An appended step that does not narrow the action needs no declaration.
+        wrapped = self._base().with_adapter(
+            after=[("g1_absolute", UnitreeG1AbsoluteActions(G1_STATE_KEY))]
+        )
+        self.assertEqual(wrapped.action_dim, MODEL_DIM)
+
+    def test_the_model_handle_is_shared_not_reloaded(self) -> None:
+        # Rewiring, not a second load: two handles on one GPU allocation would
+        # double the checkpoint's memory and make close() order matter.
+        base = self._base()
+        self.assertIs(base.with_adapter().model, base.model)
+
+    def test_a_wrapper_cannot_shadow_a_step_it_does_not_own(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            self._base().with_adapter(
+                before=[("tokenize", UnitreeG1DecodeState(G1_STATE_KEY))]
+            )
+        self.assertIn("tokenize", str(caught.exception))
+
+    def test_pi05_satisfies_the_composable_contract(self) -> None:
+        self.assertIsInstance(self._base(), ComposablePolicy)
+
+
+class _StubComposable:
+    """Minimal ``ComposablePolicy``: records what an adapter wrapped it with."""
+
+    def __init__(self) -> None:
+        self.wrapped: dict = {}
+
+    def with_adapter(self, *, before=(), after=(), action_dim=None, metadata=None):
+        self.wrapped = {
+            "before": [name for name, _ in before],
+            "after": [name for name, _ in after],
+            "action_dim": action_dim,
+            "metadata": dict(metadata or {}),
+        }
+        return self
+
+
+class UnitreeG1AdapterTest(unittest.TestCase):
+    """The G1 builder wraps a policy it never names, and hands load flags on.
+
+    These run against a stub loader, so they assert the *adapter's* behaviour
+    without a checkpoint: which steps it wraps, on which side, what width it
+    claims, and — the bug this split removes — that every keyword it forwards is
+    one the real loading path accepts.
+    """
+
+    def _patched_loader(self, captured: dict, policy):
+        def load(model_dir, *, model_type=None, **kwargs):
+            # Mirror AutoPolicy's real split: it consumes model_type itself and
+            # forwards the rest to a concrete from_pretrained that has **no**
+            # **kwargs. Binding against that signature reproduces the TypeError
+            # serving would raise, which is why this stub is not a bare Mock.
+            inspect.signature(Pi05Policy.from_pretrained).bind(model_dir, **kwargs)
+            captured.update(kwargs, model_dir=model_dir, model_type=model_type)
+            return policy
+
+        return mock.patch.object(
+            robot_adapter, "AutoPolicy", types.SimpleNamespace(from_pretrained=load)
+        )
+
+    def test_server_load_flags_reach_the_concrete_loader(self) -> None:
+        # --model-type travels server -> build_robot_policy -> this builder. It
+        # is AutoPolicy's argument, not the concrete policy's, so a builder that
+        # forwards it blindly raises TypeError the moment anyone serves a G1
+        # checkpoint. Only binding the real signature catches that.
+        captured: dict = {}
+        with self._patched_loader(captured, _StubComposable()):
+            build_robot_policy(
+                "unitree_g1", "/nowhere", model_type="pi05", precision="bf16"
+            )
+        self.assertEqual(captured["model_type"], "pi05")
+        self.assertEqual(captured["precision"], "bf16")
+        self.assertEqual(captured["state_key"], G1_STATE_KEY)
+        # Loaded at full model width: delta->absolute must see the whole action
+        # before g1_encode truncates it to 16.
+        self.assertIsNone(captured["action_dim"])
+
+    def test_the_g1_steps_wrap_the_model_chain_from_outside(self) -> None:
+        stub = _StubComposable()
+        with self._patched_loader({}, stub):
+            build_robot_policy("unitree_g1", "/nowhere")
+        self.assertEqual(stub.wrapped["before"], ["g1_decode_state"])
+        self.assertEqual(stub.wrapped["after"], ["g1_absolute", "g1_encode"])
+        self.assertEqual(stub.wrapped["action_dim"], G1_ROBOT_DIM)
+        self.assertEqual(stub.wrapped["metadata"]["robot"], "unitree_g1")
+
+    def test_without_the_truncating_step_no_width_is_claimed(self) -> None:
+        # adapt_to_pi=False drops g1_encode, so nothing narrows the action to 16.
+        # Advertising 16 regardless would publish a width no step produces.
+        stub = _StubComposable()
+        with self._patched_loader({}, stub):
+            build_unitree_g1_policy("/nowhere", adapt_to_pi=False)
+        self.assertEqual(stub.wrapped["before"], [])
+        self.assertEqual(stub.wrapped["after"], ["g1_absolute"])
+        self.assertIsNone(stub.wrapped["action_dim"])
+
+    def test_a_policy_that_cannot_be_wrapped_is_named_in_the_error(self) -> None:
+        class Unwrappable:
+            pass
+
+        with self._patched_loader({}, Unwrappable()):
+            with self.assertRaises(TypeError) as caught:
+                build_unitree_g1_policy("/nowhere")
+        message = str(caught.exception)
+        self.assertIn("Unwrappable", message)
+        self.assertIn("with_adapter", message)
+
+    def test_the_adapter_names_no_model_class(self) -> None:
+        # The whole point of the split: this module knows a body, not a model.
+        # A concrete policy reappearing here is the regression to catch.
+        source = pathlib.Path(robot_adapter.__file__).read_text()
+        self.assertNotIn("Pi05Policy", source)
 
 
 class RunningServer:


### PR DESCRIPTION
## Summary

- add a self-contained native ApxInf port for GR00T N1.7
- keep the full model execution GPU-resident under CUDA Graph capture
- add BF16 CUDA primitives, GPU RGB preprocessing, one-view and two-view policy profiles
- add an unscaled BF16 embedding path for GR00T while preserving the existing Pi0.5 scaling behavior
- avoid Torch, TensorRT, ONNX Runtime, and other third-party inference engines in the runtime path

## Validation

### Thor

- public GrootN17Policy RGB path correctness: 0 / 112 decoded tolerance violations
- maximum absolute error: 0.015625
- mean absolute error: 0.00232398
- release benchmark, batch 1, one camera, four denoise steps: median 64.68 ms, 15.46 Hz
- NVIDIA published reference: 80.4 ms, 12.4 Hz
- throughput improvement over the published reference: 24.7 percent

### Automated checks

- GR00T model family boundary check: passed
- Rust targeted tests: 3 passed
- Python policy layering tests: 19 passed, 1 skipped
- cargo fmt check: passed
- git diff check: passed
- native linkage check: no unresolved GR00T or FlashAttention entry points

## Pending before ready for review

- Orin correctness and performance validation
- target on Orin: better than the NVIDIA published 150.9 ms / 6.6 Hz result
- the available Orin hosts were unreachable during this run, so this PR remains Draft until that hardware gate is completed

## Scope

Only product code is included. Private checkpoints, fixtures, benchmark artifacts, and workflow evidence are intentionally excluded.