### PR TITLE
Port GR00T N1.7 to native ApxInf CUDA

### DIFF
--- a/crates/apxinf-cuda/adapters/fa2_adapter.cu
+++ b/crates/apxinf-cuda/adapters/fa2_adapter.cu
@@ -6,11 +6,11 @@
 extern "C" int apxinf_static_fa2_bf16(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
-    int query_heads, int kv_heads, int head_dim, float softmax_scale,
+    int query_heads, int kv_heads, int head_dim, float softmax_scale, bool causal,
     cudaStream_t stream) {
   return apxinf::cuda::cutlass_ops::fa2_bf16(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
-      query_heads, kv_heads, head_dim, softmax_scale, stream);
+      query_heads, kv_heads, head_dim, softmax_scale, causal, stream);
 }
 
 #if defined(APXINF_FA2_SM80)

--- a/crates/apxinf-cuda/adapters/static_bf16_adapter.cu
+++ b/crates/apxinf-cuda/adapters/static_bf16_adapter.cu
@@ -44,6 +44,21 @@ extern "C" cudaError_t apxinf_static_rgb_u8_to_patches_bf16(
   return cudaGetLastError();
 }
 
+extern "C" cudaError_t apxinf_static_groot_rgb_u8_to_patches_bf16(
+    const void* images, void* patches, int views, int layout,
+    cudaStream_t stream) {
+  if (views <= 0 || (layout != 0 && layout != 1)) return cudaErrorInvalidValue;
+  const int64_t count = static_cast<int64_t>(views) * 256 * 1536;
+  if (layout == 0) {
+    groot_rgb_u8_to_patches_bf16_kernel<true><<<blocks_for(count), kThreads, 0, stream>>>(
+        static_cast<const uint8_t*>(images), static_cast<__nv_bfloat16*>(patches), views);
+  } else {
+    groot_rgb_u8_to_patches_bf16_kernel<false><<<blocks_for(count), kThreads, 0, stream>>>(
+        static_cast<const uint8_t*>(images), static_cast<__nv_bfloat16*>(patches), views);
+  }
+  return cudaGetLastError();
+}
+
 extern "C" cudaError_t apxinf_static_bias_activation_bf16(
     const void* input, const void* bias, void* output,
     int rows, int cols, int activation, cudaStream_t stream) {
@@ -81,11 +96,13 @@ extern "C" cudaError_t apxinf_static_bias_activation_bf16(
 
 extern "C" cudaError_t apxinf_static_embedding_bf16(
     const void* table, const void* ids, void* output,
-    int tokens, int width, int vocab_size, cudaStream_t stream) {
+    int tokens, int width, int vocab_size, bool scale_by_sqrt_width,
+    cudaStream_t stream) {
   const int64_t count = static_cast<int64_t>(tokens) * width;
   embedding_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
       static_cast<const __nv_bfloat16*>(table), static_cast<const uint32_t*>(ids),
-      static_cast<__nv_bfloat16*>(output), tokens, width, vocab_size);
+      static_cast<__nv_bfloat16*>(output), tokens, width, vocab_size,
+      scale_by_sqrt_width);
   return cudaGetLastError();
 }
 
@@ -108,6 +125,34 @@ extern "C" cudaError_t apxinf_static_euler_update_bf16(
       static_cast<const __nv_bfloat16*>(state),
       static_cast<const __nv_bfloat16*>(velocity),
       static_cast<__nv_bfloat16*>(output), count, dt);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gather_rows_bf16(
+    const void* input, const void* rows, void* output,
+    int input_rows, int output_rows, int cols, cudaStream_t stream) {
+  if (input_rows <= 0 || output_rows <= 0 || cols <= 0) return cudaErrorInvalidValue;
+  const int64_t count = static_cast<int64_t>(output_rows) * cols;
+  gather_rows_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<const uint32_t*>(rows),
+      static_cast<__nv_bfloat16*>(output), count, cols);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_scatter_rows_bf16(
+    const void* base, const void* updates, const void* rows, void* output,
+    int base_rows, int update_rows, int cols, bool add, cudaStream_t stream) {
+  if (base_rows <= 0 || update_rows <= 0 || cols <= 0) return cudaErrorInvalidValue;
+  cudaError_t status = cudaMemcpyAsync(
+      output, base, static_cast<size_t>(base_rows) * cols * sizeof(__nv_bfloat16),
+      cudaMemcpyDeviceToDevice, stream);
+  if (status != cudaSuccess) return status;
+  const int64_t count = static_cast<int64_t>(update_rows) * cols;
+  scatter_rows_bf16_kernel<<<blocks_for(count), kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(updates),
+      static_cast<const uint32_t*>(rows),
+      static_cast<__nv_bfloat16*>(output), count, cols, add);
   return cudaGetLastError();
 }
 
@@ -210,6 +255,16 @@ extern "C" cudaError_t apxinf_static_ada_rms_norm_bf16(
   return cudaGetLastError();
 }
 
+extern "C" cudaError_t apxinf_static_ada_layer_norm_bf16(
+    const void* input, const void* style, void* output,
+    int rows, int cols, float eps, bool shift_first, cudaStream_t stream) {
+  ada_layer_norm_bf16_kernel<<<rows, kThreads, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<const __nv_bfloat16*>(style),
+      static_cast<__nv_bfloat16*>(output), rows, cols, eps, shift_first);
+  return cudaGetLastError();
+}
+
 extern "C" cudaError_t apxinf_static_ada_gate_residual_bf16(
     const void* projection, const void* residual, const void* style,
     void* output, int rows, int cols, cudaStream_t stream) {
@@ -288,6 +343,33 @@ extern "C" cudaError_t apxinf_static_mha_bf16(
       static_cast<const __nv_bfloat16*>(k),
       static_cast<const __nv_bfloat16*>(v),
       static_cast<__nv_bfloat16*>(output), tokens_per_batch, heads, head_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_cross_mha_bf16(
+    const void* q, const void* k, const void* v, void* output,
+    int query_tokens, int key_tokens, int heads, int head_dim,
+    cudaStream_t stream) {
+  dim3 grid(query_tokens, heads, 1);
+  const size_t shared = static_cast<size_t>(key_tokens + 8) * sizeof(float);
+  cross_mha_bf16_kernel<<<grid, kThreads, shared, stream>>>(
+      static_cast<const __nv_bfloat16*>(q),
+      static_cast<const __nv_bfloat16*>(k),
+      static_cast<const __nv_bfloat16*>(v),
+      static_cast<__nv_bfloat16*>(output), query_tokens, key_tokens,
+      heads, head_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_causal_gqa_bf16(
+    const void* q, const void* k, const void* v, void* output,
+    int tokens, int q_heads, int kv_heads, int head_dim, cudaStream_t stream) {
+  const int threads = 128;
+  const size_t shared = static_cast<size_t>(tokens + threads / 32) * sizeof(float);
+  causal_gqa_bf16_kernel<<<dim3(tokens, q_heads), threads, shared, stream>>>(
+      static_cast<const __nv_bfloat16*>(q), static_cast<const __nv_bfloat16*>(k),
+      static_cast<const __nv_bfloat16*>(v), static_cast<__nv_bfloat16*>(output),
+      tokens, q_heads, kv_heads, head_dim);
   return cudaGetLastError();
 }
 

--- a/crates/apxinf-cuda/build.rs
+++ b/crates/apxinf-cuda/build.rs
@@ -114,6 +114,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(apxinf_cutlass_bf16_sm89)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_cutlass_int8_sm80)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_sm80)");
+    println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_bf16)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_f16_sm100)");
     println!("cargo:rustc-check-cfg=cfg(apxinf_fa2_direct_e4m3_sm100)");
     println!("cargo:rerun-if-env-changed=APXINF_CUDA_ARCH");
@@ -287,7 +288,8 @@ fn main() {
             let cutlass_fmha = std::path::Path::new(&adapters_dir).join("cutlass_fmha_adapter.cu");
             let cutlass_gemm = std::path::Path::new(&adapters_dir).join("cutlass_fp8_adapter.cu");
             let cutlass_bf16 = std::path::Path::new(&adapters_dir).join("cutlass_bf16_adapter.cu");
-            let cutlass_bf16_sm89 = std::path::Path::new(&adapters_dir).join("cutlass_bf16_sm89_adapter.cu");
+            let cutlass_bf16_sm89 =
+                std::path::Path::new(&adapters_dir).join("cutlass_bf16_sm89_adapter.cu");
             let cutlass_int8 = std::path::Path::new(&adapters_dir).join("cutlass_w8a8_adapter.cu");
             let mut cutlass_includes = Vec::new();
             if cutlass_arch.as_deref().is_some_and(is_cutlass_sm100_family) {
@@ -386,6 +388,7 @@ fn main() {
             let fa2_sm80 = nvcc_arch.as_deref().is_some_and(is_fa2_sm80_family);
             let fa2_f16_sm100 = nvcc_arch.as_deref().is_some_and(is_cutlass_sm100_family);
             if fa2_sm80 || fa2_f16_sm100 {
+                println!("cargo:rustc-cfg=apxinf_fa2_bf16");
                 let fa2_hdim96 = fa2_root.join("flash_attn/flash_fwd_hdim96_bf16_sm80.cu");
                 let fa2_hdim256 = fa2_root.join("flash_attn/flash_fwd_hdim256_bf16_sm80.cu");
                 let fa2_f16_hdim96 = fa2_root.join("flash_attn/flash_fwd_hdim96_fp16.cu");

--- a/crates/apxinf-cuda/kernels/custom/activation.cuh
+++ b/crates/apxinf-cuda/kernels/custom/activation.cuh
@@ -251,6 +251,7 @@ __global__ void bias_activation_bf16_kernel(
     if (bias != nullptr) value += __bfloat162float(bias[index % cols]);
     if (activation == 1) value = gelu_tanh(value);
     if (activation == 2) value = value / (1.0f + expf(-value));
+    if (activation == 3) value = fmaxf(value, 0.0f);
     output[index] = __float2bfloat16(value);
   }
 }
@@ -283,6 +284,10 @@ __global__ void bias_activation_bf16_packed2_kernel(
     if (activation == 2) {
       first = first / (1.0f + expf(-first));
       second = second / (1.0f + expf(-second));
+    }
+    if (activation == 3) {
+      first = fmaxf(first, 0.0f);
+      second = fmaxf(second, 0.0f);
     }
     output2[pair_index] = __floats2bfloat162_rn(first, second);
   }
@@ -321,6 +326,10 @@ __global__ void bias_activation_bf16_packed4_kernel(
 #pragma unroll
       for (int i = 0; i < 4; ++i)
         values[i] = values[i] / (1.0f + expf(-values[i]));
+    }
+    if (activation == 3) {
+#pragma unroll
+      for (int i = 0; i < 4; ++i) values[i] = fmaxf(values[i], 0.0f);
     }
     output4[quad_index] = Bf16x4{
         __floats2bfloat162_rn(values[0], values[1]),

--- a/crates/apxinf-cuda/kernels/custom/attention.cuh
+++ b/crates/apxinf-cuda/kernels/custom/attention.cuh
@@ -871,5 +871,115 @@ __global__ void mha_bf16_kernel(
   }
 }
 
+__global__ void cross_mha_bf16_kernel(
+    const __nv_bfloat16* q, const __nv_bfloat16* k,
+    const __nv_bfloat16* v, __nv_bfloat16* output,
+    int query_tokens, int key_tokens, int heads, int head_dim) {
+  extern __shared__ float shared[];
+  float* scores = shared;
+  float* warp_sums = scores + key_tokens;
+  const int query = blockIdx.x;
+  const int head = blockIdx.y;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps = blockDim.x >> 5;
+  const __nv_bfloat16* query_ptr = q + (query * heads + head) * head_dim;
+  const float scale = rsqrtf(static_cast<float>(head_dim));
+  for (int token = 0; token < key_tokens; ++token) {
+    const __nv_bfloat16* key = k + (static_cast<int64_t>(token) * heads + head) * head_dim;
+    float dot = tid < head_dim
+        ? __bfloat162float(query_ptr[tid]) * __bfloat162float(key[tid])
+        : 0.0f;
+    dot = warp_sum(dot);
+    if (lane == 0) warp_sums[warp] = dot;
+    __syncthreads();
+    if (warp == 0) {
+      float total = lane < warps ? warp_sums[lane] : 0.0f;
+      total = warp_sum(total);
+      if (lane == 0) scores[token] = total * scale;
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float maximum = -3.402823466e+38F;
+    for (int token = 0; token < key_tokens; ++token)
+      maximum = fmaxf(maximum, scores[token]);
+    float denominator = 0.0f;
+    for (int token = 0; token < key_tokens; ++token) {
+      scores[token] = expf(scores[token] - maximum);
+      denominator += scores[token];
+    }
+    for (int token = 0; token < key_tokens; ++token)
+      scores[token] /= denominator;
+  }
+  __syncthreads();
+  if (tid < head_dim) {
+    float accumulator = 0.0f;
+    for (int token = 0; token < key_tokens; ++token) {
+      const __nv_bfloat16* value =
+          v + (static_cast<int64_t>(token) * heads + head) * head_dim;
+      accumulator += scores[token] * __bfloat162float(value[tid]);
+    }
+    output[(query * heads + head) * head_dim + tid] =
+        __float2bfloat16(accumulator);
+  }
+}
 
-
+// Fixed-shape causal GQA used by multimodal prefill. Q is
+// [tokens,q_heads,head_dim], K/V are [tokens,kv_heads,head_dim].
+__global__ void causal_gqa_bf16_kernel(
+    const __nv_bfloat16* q, const __nv_bfloat16* k,
+    const __nv_bfloat16* v, __nv_bfloat16* output,
+    int tokens, int q_heads, int kv_heads, int head_dim) {
+  extern __shared__ float shared[];
+  float* scores = shared;
+  float* warp_sums = scores + tokens;
+  const int query = blockIdx.x;
+  const int q_head = blockIdx.y;
+  const int kv_head = q_head / (q_heads / kv_heads);
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps = blockDim.x >> 5;
+  const __nv_bfloat16* query_ptr =
+      q + (static_cast<int64_t>(query) * q_heads + q_head) * head_dim;
+  const float scale = rsqrtf(static_cast<float>(head_dim));
+  for (int token = 0; token <= query; ++token) {
+    const __nv_bfloat16* key =
+        k + (static_cast<int64_t>(token) * kv_heads + kv_head) * head_dim;
+    float dot = tid < head_dim
+        ? __bfloat162float(query_ptr[tid]) * __bfloat162float(key[tid]) : 0.0f;
+    dot = warp_sum(dot);
+    if (lane == 0) warp_sums[warp] = dot;
+    __syncthreads();
+    if (warp == 0) {
+      float total = lane < warps ? warp_sums[lane] : 0.0f;
+      total = warp_sum(total);
+      if (lane == 0) scores[token] = total * scale;
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    float maximum = -3.402823466e+38F;
+    for (int token = 0; token <= query; ++token)
+      maximum = fmaxf(maximum, scores[token]);
+    float denominator = 0.0f;
+    for (int token = 0; token <= query; ++token) {
+      scores[token] = expf(scores[token] - maximum);
+      denominator += scores[token];
+    }
+    for (int token = 0; token <= query; ++token) scores[token] /= denominator;
+  }
+  __syncthreads();
+  if (tid < head_dim) {
+    float accumulator = 0.0f;
+    for (int token = 0; token <= query; ++token) {
+      const __nv_bfloat16* value =
+          v + (static_cast<int64_t>(token) * kv_heads + kv_head) * head_dim;
+      accumulator += scores[token] * __bfloat162float(value[tid]);
+    }
+    output[(static_cast<int64_t>(query) * q_heads + q_head) * head_dim + tid] =
+        __float2bfloat16(accumulator);
+  }
+}

--- a/crates/apxinf-cuda/kernels/custom/elementwise.cuh
+++ b/crates/apxinf-cuda/kernels/custom/elementwise.cuh
@@ -181,4 +181,32 @@ __global__ void bias_position_bf16_kernel(
   }
 }
 
+__global__ void gather_rows_bf16_kernel(
+    const __nv_bfloat16* input, const uint32_t* rows,
+    __nv_bfloat16* output, int64_t count, int cols) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const int output_row = static_cast<int>(index / cols);
+    const int col = static_cast<int>(index % cols);
+    output[index] = input[static_cast<int64_t>(rows[output_row]) * cols + col];
+  }
+}
 
+__global__ void scatter_rows_bf16_kernel(
+    const __nv_bfloat16* updates, const uint32_t* rows,
+    __nv_bfloat16* output, int64_t count, int cols, bool add) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const int update_row = static_cast<int>(index / cols);
+    const int col = static_cast<int>(index % cols);
+    const int64_t output_index = static_cast<int64_t>(rows[update_row]) * cols + col;
+    if (add) {
+      output[output_index] = __float2bfloat16(
+          __bfloat162float(output[output_index]) + __bfloat162float(updates[index]));
+    } else {
+      output[output_index] = updates[index];
+    }
+  }
+}

--- a/crates/apxinf-cuda/kernels/custom/embedding.cuh
+++ b/crates/apxinf-cuda/kernels/custom/embedding.cuh
@@ -57,9 +57,10 @@ __global__ void embedding_f16_kernel(
 
 __global__ void embedding_bf16_kernel(
     const __nv_bfloat16* table, const uint32_t* ids, __nv_bfloat16* output,
-    int tokens, int width, int vocab_size) {
+    int tokens, int width, int vocab_size, bool scale_by_sqrt_width) {
   const int64_t count = static_cast<int64_t>(tokens) * width;
-  const float normalizer = sqrtf(static_cast<float>(width));
+  const float normalizer = scale_by_sqrt_width
+      ? sqrtf(static_cast<float>(width)) : 1.0f;
   int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   for (; index < count; index += stride) {
@@ -72,6 +73,5 @@ __global__ void embedding_bf16_kernel(
         : __float2bfloat16(0.0f);
   }
 }
-
 
 

--- a/crates/apxinf-cuda/kernels/custom/normalization.cuh
+++ b/crates/apxinf-cuda/kernels/custom/normalization.cuh
@@ -255,5 +255,28 @@ __global__ void ada_rms_norm_bf16_kernel(
   }
 }
 
-
+__global__ void ada_layer_norm_bf16_kernel(
+    const __nv_bfloat16* input, const __nv_bfloat16* style,
+    __nv_bfloat16* output, int rows, int cols, float eps, bool shift_first) {
+  __shared__ float scratch[8];
+  const int row = blockIdx.x;
+  float sum = 0.0f;
+  for (int col = threadIdx.x; col < cols; col += blockDim.x)
+    sum += __bfloat162float(input[static_cast<int64_t>(row) * cols + col]);
+  const float mean = block_sum(sum, scratch) / cols;
+  float variance_sum = 0.0f;
+  for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+    const float centered =
+        __bfloat162float(input[static_cast<int64_t>(row) * cols + col]) - mean;
+    variance_sum += centered * centered;
+  }
+  const float inverse_std = rsqrtf(block_sum(variance_sum, scratch) / cols + eps);
+  for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+    const int64_t index = static_cast<int64_t>(row) * cols + col;
+    const float normalized = (__bfloat162float(input[index]) - mean) * inverse_std;
+    const float scale = __bfloat162float(style[(shift_first ? cols : 0) + col]);
+    const float shift = __bfloat162float(style[(shift_first ? 0 : cols) + col]);
+    output[index] = __float2bfloat16(normalized * (1.0f + scale) + shift);
+  }
+}
 

--- a/crates/apxinf-cuda/kernels/custom/preprocess.cuh
+++ b/crates/apxinf-cuda/kernels/custom/preprocess.cuh
@@ -96,5 +96,44 @@ __global__ void rgb_u8_to_patches_bf16_kernel(
   }
 }
 
+// GR00T N1.7 stacks two identical temporal frames inside each 16x16 patch.
+// Patch rows follow [coarse_y, coarse_x, sub_y, sub_x], while features follow
+// [channel, time, patch_y, patch_x].
+template <bool kNhwc>
+__global__ void groot_rgb_u8_to_patches_bf16_kernel(
+    const uint8_t* images, __nv_bfloat16* patches, int views) {
+  constexpr int image_size = 256;
+  constexpr int patch_size = 16;
+  constexpr int patches_per_view = 256;
+  constexpr int patch_width = 1536;
+  const int64_t count = static_cast<int64_t>(views) * patches_per_view * patch_width;
+  int64_t output_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; output_index < count; output_index += stride) {
+    int feature = static_cast<int>(output_index % patch_width);
+    int patch = static_cast<int>((output_index / patch_width) % patches_per_view);
+    const int view = static_cast<int>(output_index / (patch_width * patches_per_view));
+    const int dx = feature % patch_size;
+    feature /= patch_size;
+    const int dy = feature % patch_size;
+    feature /= patch_size;
+    feature /= 2;  // The temporal dimension contains two copies of the same frame.
+    const int channel = feature;
+    const int sub_x = patch % 2;
+    patch /= 2;
+    const int sub_y = patch % 2;
+    patch /= 2;
+    const int coarse_x = patch % 8;
+    const int coarse_y = patch / 8;
+    const int x = (coarse_x * 2 + sub_x) * patch_size + dx;
+    const int y = (coarse_y * 2 + sub_y) * patch_size + dy;
+    const int64_t input_index = kNhwc
+        ? ((static_cast<int64_t>(view) * image_size + y) * image_size + x) * 3 + channel
+        : ((static_cast<int64_t>(view) * 3 + channel) * image_size + y) * image_size + x;
+    const float normalized =
+        (static_cast<float>(images[input_index]) / 255.0f) * 2.0f - 1.0f;
+    patches[output_index] = __float2bfloat16(normalized);
+  }
+}
 
 

--- a/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim256_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim256_bf16_sm80.cu
@@ -11,4 +11,9 @@ void run_mha_fwd_<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cud
     run_mha_fwd_hdim256<cutlass::bfloat16_t, false>(params, stream);
 }
 
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::bfloat16_t, true>(params, stream);
+}
+
 } // namespace FLASH_NAMESPACE

--- a/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim96_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2/flash_attn/flash_fwd_hdim96_bf16_sm80.cu
@@ -11,4 +11,9 @@ void run_mha_fwd_<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cuda
     run_mha_fwd_hdim96<cutlass::bfloat16_t, false>(params, stream);
 }
 
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::bfloat16_t, true>(params, stream);
+}
+
 } // namespace FLASH_NAMESPACE

--- a/crates/apxinf-cuda/kernels/cutlass/fa2_bf16_sm80.cu
+++ b/crates/apxinf-cuda/kernels/cutlass/fa2_bf16_sm80.cu
@@ -33,7 +33,7 @@ void fill_params(FLASH_NAMESPACE::Flash_fwd_params& params, bool is_bf16,
                  const void* q, const void* k, const void* v, void* output,
                  void* softmax_lse, int batch, int query_tokens,
                  int key_tokens, int query_heads, int kv_heads, int head_dim,
-                 float softmax_scale) {
+                 float softmax_scale, bool causal) {
   params = {};
   params.is_bf16 = is_bf16;
   params.q_ptr = const_cast<void*>(q);
@@ -75,7 +75,7 @@ void fill_params(FLASH_NAMESPACE::Flash_fwd_params& params, bool is_bf16,
   params.p_dropout_in_uint8_t = 255;
   params.rp_dropout = 1.0f;
 
-  params.is_causal = false;
+  params.is_causal = causal;
   params.window_size_left = -1;
   params.window_size_right = -1;
   params.is_seqlens_k_cumulative = true;
@@ -143,7 +143,7 @@ int setup_splitkv(FLASH_NAMESPACE::Flash_fwd_params& params,
 
 namespace apxinf::cuda::cutlass_ops {
 
-template <typename Element>
+template <typename Element, bool IsCausal>
 int fa2(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
@@ -159,11 +159,11 @@ int fa2(
   FLASH_NAMESPACE::Flash_fwd_params params;
   fill_params(params, std::is_same<Element, cutlass::bfloat16_t>::value,
               q, k, v, output, softmax_lse, batch, query_tokens,
-              key_tokens, query_heads, kv_heads, head_dim, softmax_scale);
+              key_tokens, query_heads, kv_heads, head_dim, softmax_scale, IsCausal);
   if (head_dim <= 96) {
-    FLASH_NAMESPACE::run_mha_fwd_<Element, 96, false>(params, stream);
+    FLASH_NAMESPACE::run_mha_fwd_<Element, 96, IsCausal>(params, stream);
   } else {
-    FLASH_NAMESPACE::run_mha_fwd_<Element, 256, false>(params, stream);
+    FLASH_NAMESPACE::run_mha_fwd_<Element, 256, IsCausal>(params, stream);
   }
   return static_cast<int>(cudaSuccess);
 }
@@ -186,7 +186,7 @@ int fa2_splitkv(
   FLASH_NAMESPACE::Flash_fwd_params params;
   fill_params(params, std::is_same<Element, cutlass::bfloat16_t>::value,
               q, k, v, output, softmax_lse, batch, query_tokens,
-              key_tokens, query_heads, kv_heads, head_dim, softmax_scale);
+              key_tokens, query_heads, kv_heads, head_dim, softmax_scale, false);
   const int num_splits =
       setup_splitkv(params, softmax_lse_accum, o_accum, num_sms, query_tokens,
                     key_tokens, head_dim, batch, query_heads);
@@ -211,9 +211,14 @@ int fa2_splitkv(
 int fa2_bf16(
     const void* q, const void* k, const void* v, void* output,
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
-    int query_heads, int kv_heads, int head_dim, float softmax_scale,
+    int query_heads, int kv_heads, int head_dim, float softmax_scale, bool causal,
     cudaStream_t stream) {
-  return fa2<cutlass::bfloat16_t>(
+  if (causal) {
+    return fa2<cutlass::bfloat16_t, true>(
+        q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
+        query_heads, kv_heads, head_dim, softmax_scale, stream);
+  }
+  return fa2<cutlass::bfloat16_t, false>(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
       query_heads, kv_heads, head_dim, softmax_scale, stream);
 }
@@ -236,7 +241,7 @@ int fa2_f16(
     void* softmax_lse, int batch, int query_tokens, int key_tokens,
     int query_heads, int kv_heads, int head_dim, float softmax_scale,
     cudaStream_t stream) {
-  return fa2<cutlass::half_t>(
+  return fa2<cutlass::half_t, false>(
       q, k, v, output, softmax_lse, batch, query_tokens, key_tokens,
       query_heads, kv_heads, head_dim, softmax_scale, stream);
 }

--- a/crates/apxinf-cuda/src/backend.rs
+++ b/crates/apxinf-cuda/src/backend.rs
@@ -208,7 +208,7 @@ impl Backend for CudaBackend {
             }
         }
         let out_bytes = rows * total_cols * elem;
-        let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+        let out_buf = crate::workspace::output_buffer(&self.ctx, out_bytes)?;
         let dst_pitch = total_cols * elem;
         let mut col_offset = 0usize;
         for t in tensors {

--- a/crates/apxinf-cuda/src/ffi/custom.rs
+++ b/crates/apxinf-cuda/src/ffi/custom.rs
@@ -338,8 +338,15 @@ extern "C" {
         layout: i32,
         stream: cudaStream_t,
     ) -> cudaError_t;
+    pub fn apxinf_static_groot_rgb_u8_to_patches_bf16(
+        images: *const c_void,
+        patches: *mut c_void,
+        views: i32,
+        layout: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
     /// BF16 bias/activation epilogue. `activation`: 0=identity, 1=GELU-tanh,
-    /// 2=SiLU.
+    /// 2=SiLU, 3=ReLU.
     pub fn apxinf_static_bias_activation_bf16(
         input: *const c_void,
         bias: *const c_void,
@@ -356,6 +363,7 @@ extern "C" {
         tokens: i32,
         width: i32,
         vocab_size: i32,
+        scale_by_sqrt_width: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
     pub fn apxinf_static_concat_rows_bf16(
@@ -373,6 +381,26 @@ extern "C" {
         output: *mut c_void,
         count: i64,
         dt: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_gather_rows_bf16(
+        input: *const c_void,
+        rows: *const c_void,
+        output: *mut c_void,
+        input_rows: i32,
+        output_rows: i32,
+        cols: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_scatter_rows_bf16(
+        base: *const c_void,
+        updates: *const c_void,
+        rows: *const c_void,
+        output: *mut c_void,
+        base_rows: i32,
+        update_rows: i32,
+        cols: i32,
+        add: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
     pub fn apxinf_static_geglu_bf16(
@@ -444,6 +472,16 @@ extern "C" {
         eps: f32,
         stream: cudaStream_t,
     ) -> cudaError_t;
+    pub fn apxinf_static_ada_layer_norm_bf16(
+        input: *const c_void,
+        style: *const c_void,
+        output: *mut c_void,
+        rows: i32,
+        cols: i32,
+        eps: f32,
+        shift_first: bool,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
     pub fn apxinf_static_ada_gate_residual_bf16(
         projection: *const c_void,
         residual: *const c_void,
@@ -509,6 +547,28 @@ extern "C" {
         tokens_per_batch: i32,
         batches: i32,
         heads: i32,
+        head_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_cross_mha_bf16(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        output: *mut c_void,
+        query_tokens: i32,
+        key_tokens: i32,
+        heads: i32,
+        head_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_causal_gqa_bf16(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        output: *mut c_void,
+        tokens: i32,
+        q_heads: i32,
+        kv_heads: i32,
         head_dim: i32,
         stream: cudaStream_t,
     ) -> cudaError_t;

--- a/crates/apxinf-cuda/src/ffi/fa2.rs
+++ b/crates/apxinf-cuda/src/ffi/fa2.rs
@@ -39,7 +39,7 @@ extern "C" {
         stream: cudaStream_t,
     ) -> cudaError_t;
 
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     pub fn apxinf_static_fa2_bf16(
         q: *const c_void,
         k: *const c_void,
@@ -53,6 +53,7 @@ extern "C" {
         kv_heads: i32,
         head_dim: i32,
         softmax_scale: f32,
+        causal: bool,
         stream: cudaStream_t,
     ) -> cudaError_t;
 

--- a/crates/apxinf-cuda/src/kernels/activation.rs
+++ b/crates/apxinf-cuda/src/kernels/activation.rs
@@ -9,6 +9,7 @@ use super::contracts::{
 use crate::buffer::CudaBuffer;
 use crate::context::CudaContext;
 use crate::ffi;
+use crate::workspace::output_buffer;
 
 /// Allocation-free SiLU into caller-owned decode storage.
 pub fn silu_into(
@@ -87,7 +88,7 @@ pub fn silu(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     let count = input.numel() as u32;
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -117,7 +118,7 @@ pub fn gelu_tanh(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     }
     let device_id = ctx.device_id();
     let count = input.numel() as u32;
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res =
             ffi::apxinf_gelu_tanh_bf16(gpu_ptr(input)?, out_buf.ptr(), count, ctx.stream().handle());
@@ -166,6 +167,11 @@ pub fn bias_gelu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>)
 
 pub fn bias_silu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>) -> Result<Tensor> {
     bias_activation(ctx, input, value, 2)
+}
+
+/// Broadcast-add an optional BF16 bias and apply ReLU on device.
+pub fn bias_relu_bf16(ctx: &CudaContext, input: &Tensor, value: Option<&Tensor>) -> Result<Tensor> {
+    bias_activation(ctx, input, value, 3)
 }
 
 pub fn geglu_bf16(ctx: &CudaContext, gate_up: &Tensor) -> Result<Tensor> {

--- a/crates/apxinf-cuda/src/kernels/attention.rs
+++ b/crates/apxinf-cuda/src/kernels/attention.rs
@@ -335,7 +335,7 @@ pub fn softmax(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
     let cols = *dims.last().unwrap();
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -539,7 +539,7 @@ pub fn split_qkv_bias_bf16(
     })
 }
 
-#[cfg(apxinf_fa2_sm80)]
+#[cfg(apxinf_fa2_bf16)]
 #[allow(clippy::too_many_arguments)]
 fn fa2_attention(
     ctx: &CudaContext,
@@ -552,6 +552,7 @@ fn fa2_attention(
     query_heads: usize,
     kv_heads: usize,
     head_dim: usize,
+    causal: bool,
 ) -> Result<Tensor> {
     let output = output_buffer(ctx, q.size_in_bytes())?;
     let lse_elements = batches
@@ -580,6 +581,7 @@ fn fa2_attention(
             kv_heads as i32,
             head_dim as i32,
             (head_dim as f32).sqrt().recip(),
+            causal,
             ctx.stream().handle(),
         ))
         .map_err(Error::Cuda)?;
@@ -603,10 +605,7 @@ fn fa2_splitkv_enabled(
     if std::env::var_os("APXINF_DISABLE_FA2_SPLITKV").is_some() {
         return false;
     }
-    query_tokens <= 64
-        && key_tokens > query_tokens
-        && query_heads > kv_heads
-        && head_dim == 256
+    query_tokens <= 64 && key_tokens > query_tokens && query_heads > kv_heads && head_dim == 256
 }
 
 #[cfg(apxinf_fa2_sm80)]
@@ -749,24 +748,25 @@ pub fn mqa_bf16(
             "static inference BF16 MQA shape mismatch".into(),
         ));
     }
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     {
+        #[cfg(apxinf_fa2_sm80)]
         if fa2_splitkv_enabled(q_shape[0], key_tokens, q_shape[1], 1, q_shape[2]) {
             return fa2_attention_splitkv(
                 ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2],
             );
         }
         return fa2_attention(
-            ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2],
+            ctx, q, k, v, 1, q_shape[0], key_tokens, q_shape[1], 1, q_shape[2], false,
         );
     }
-    #[cfg(apxinf_cutlass_fmha)]
+    #[cfg(all(apxinf_cutlass_fmha, not(apxinf_fa2_bf16)))]
     {
         return cublas_mqa_bf16(ctx, q, k, v, key_tokens);
     }
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     let output = output_buffer(ctx, q.size_in_bytes())?;
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     unsafe {
         ffi::check_cuda(ffi::apxinf_static_mqa_bf16(
             gpu_ptr(q)?,
@@ -781,7 +781,7 @@ pub fn mqa_bf16(
         ))
         .map_err(Error::Cuda)?;
     }
-    #[cfg(all(not(apxinf_fa2_sm80), not(apxinf_cutlass_fmha)))]
+    #[cfg(all(not(apxinf_fa2_bf16), not(apxinf_cutlass_fmha)))]
     Ok(make_gpu_tensor(
         q.shape().clone(),
         DType::BF16,
@@ -812,7 +812,7 @@ pub fn mha_bf16(
             "static inference BF16 MHA shape mismatch".into(),
         ));
     }
-    #[cfg(apxinf_fa2_sm80)]
+    #[cfg(apxinf_fa2_bf16)]
     {
         return fa2_attention(
             ctx,
@@ -825,9 +825,10 @@ pub fn mha_bf16(
             shape[1],
             shape[1],
             shape[2],
+            false,
         );
     }
-    #[cfg(apxinf_cutlass_fmha)]
+    #[cfg(all(apxinf_cutlass_fmha, not(apxinf_fa2_bf16)))]
     if tokens_per_batch == 256 && shape[1] == 16 && shape[2] == 72 {
         let output = output_buffer(ctx, q.size_in_bytes())?;
         unsafe {
@@ -878,9 +879,9 @@ pub fn mha_bf16(
             ));
         }
     }
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
     let output = output_buffer(ctx, q.size_in_bytes())?;
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
     unsafe {
         ffi::check_cuda(ffi::apxinf_static_mha_bf16(
             gpu_ptr(q)?,
@@ -895,7 +896,100 @@ pub fn mha_bf16(
         ))
         .map_err(Error::Cuda)?;
     }
-    #[cfg(not(apxinf_fa2_sm80))]
+    #[cfg(not(apxinf_fa2_bf16))]
+    Ok(make_gpu_tensor(
+        q.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Non-causal BF16 multi-head cross attention with distinct query/key lengths.
+pub fn cross_mha_bf16(ctx: &CudaContext, q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+    let q_shape = q.shape().dims();
+    let k_shape = k.shape().dims();
+    if [q, k, v]
+        .into_iter()
+        .any(|tensor| tensor.dtype() != DType::BF16)
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape() != k.shape()
+        || q_shape[1..] != k_shape[1..]
+        || q_shape[2] > 256
+        || q_shape[0] == 0
+        || k_shape[0] == 0
+    {
+        return Err(Error::Other(
+            "static inference BF16 cross-MHA shape mismatch".into(),
+        ));
+    }
+    #[cfg(apxinf_fa2_bf16)]
+    {
+        return fa2_attention(
+            ctx, q, k, v, 1, q_shape[0], k_shape[0], q_shape[1], k_shape[1], q_shape[2], false,
+        );
+    }
+    #[cfg(not(apxinf_fa2_bf16))]
+    let output = output_buffer(ctx, q.size_in_bytes())?;
+    #[cfg(not(apxinf_fa2_bf16))]
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_cross_mha_bf16(
+            gpu_ptr(q)?,
+            gpu_ptr(k)?,
+            gpu_ptr(v)?,
+            output.ptr(),
+            q_shape[0] as i32,
+            k_shape[0] as i32,
+            q_shape[1] as i32,
+            q_shape[2] as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    #[cfg(not(apxinf_fa2_bf16))]
+    Ok(make_gpu_tensor(
+        q.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Causal BF16 grouped-query attention for a complete prefill sequence.
+pub fn causal_gqa_bf16(ctx: &CudaContext, q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+    let q_shape = q.shape().dims();
+    let k_shape = k.shape().dims();
+    if [q, k, v]
+        .into_iter()
+        .any(|tensor| tensor.dtype() != DType::BF16)
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape() != k.shape()
+        || q_shape[0] != k_shape[0]
+        || q_shape[2] != k_shape[2]
+        || q_shape[1] % k_shape[1] != 0
+        || q_shape[2] > 256
+    {
+        return Err(Error::Other(
+            "static inference BF16 causal GQA shape mismatch".into(),
+        ));
+    }
+    let output = output_buffer(ctx, q.size_in_bytes())?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_causal_gqa_bf16(
+            gpu_ptr(q)?,
+            gpu_ptr(k)?,
+            gpu_ptr(v)?,
+            output.ptr(),
+            q_shape[0] as i32,
+            q_shape[1] as i32,
+            k_shape[1] as i32,
+            q_shape[2] as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
     Ok(make_gpu_tensor(
         q.shape().clone(),
         DType::BF16,

--- a/crates/apxinf-cuda/src/kernels/elementwise.rs
+++ b/crates/apxinf-cuda/src/kernels/elementwise.rs
@@ -105,7 +105,7 @@ pub fn add_bias(ctx: &CudaContext, input: &Tensor, bias: &Tensor) -> Result<Tens
     } else {
         dims[dims.len() - 1]
     };
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res = ffi::apxinf_add_bias_bf16(
             gpu_ptr(input)?,
@@ -130,7 +130,7 @@ pub fn add(ctx: &CudaContext, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     let count = a.numel() as u32;
 
     let out_bytes = a.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match a.dtype() {
@@ -167,7 +167,7 @@ pub fn mul(ctx: &CudaContext, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     let count = a.numel() as u32;
 
     let out_bytes = a.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match a.dtype() {
@@ -290,6 +290,116 @@ pub fn euler_update_bf16(
     }
     Ok(make_gpu_tensor(
         state.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Stable device-side u32 row indices for graph-captured gather/scatter.
+pub struct RowIndices {
+    buffer: CudaBuffer,
+    len: usize,
+    max: u32,
+}
+
+impl RowIndices {
+    pub fn new(device_id: usize, rows: &[u32]) -> Result<Self> {
+        if rows.is_empty() {
+            return Err(Error::Other("row indices cannot be empty".into()));
+        }
+        let mut sorted = rows.to_vec();
+        sorted.sort_unstable();
+        if sorted.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(Error::Other("row indices must be unique".into()));
+        }
+        let bytes = bytemuck::cast_slice(rows);
+        let buffer = CudaBuffer::alloc(bytes.len(), device_id).map_err(Error::Cuda)?;
+        buffer.copy_from_host(bytes).map_err(Error::Cuda)?;
+        Ok(Self {
+            buffer,
+            len: rows.len(),
+            max: *sorted.last().unwrap(),
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+pub fn gather_rows_bf16(ctx: &CudaContext, input: &Tensor, rows: &RowIndices) -> Result<Tensor> {
+    let (input_rows, cols) = matrix_shape(input, "BF16 gather rows")?;
+    if input.dtype() != DType::BF16
+        || rows.buffer.device() != ctx.device_id()
+        || rows.max as usize >= input_rows
+    {
+        return Err(Error::Other(
+            "BF16 gather rows dtype/device mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, rows.len, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_gather_rows_bf16(
+            gpu_ptr(input)?,
+            rows.buffer.ptr(),
+            output.ptr(),
+            input_rows as i32,
+            rows.len as i32,
+            cols as i32,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows.len, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+pub fn scatter_rows_bf16(
+    ctx: &CudaContext,
+    base: &Tensor,
+    updates: &Tensor,
+    rows: &RowIndices,
+    add: bool,
+) -> Result<Tensor> {
+    let (base_rows, cols) = matrix_shape(base, "BF16 scatter rows base")?;
+    let (update_rows, update_cols) = matrix_shape(updates, "BF16 scatter rows updates")?;
+    if base.dtype() != DType::BF16
+        || updates.dtype() != DType::BF16
+        || update_rows != rows.len
+        || update_cols != cols
+        || rows.buffer.device() != ctx.device_id()
+        || rows.max as usize >= base_rows
+    {
+        return Err(Error::Other(
+            "BF16 scatter rows shape/dtype/device mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, base_rows, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_scatter_rows_bf16(
+            gpu_ptr(base)?,
+            gpu_ptr(updates)?,
+            rows.buffer.ptr(),
+            output.ptr(),
+            base_rows as i32,
+            update_rows as i32,
+            cols as i32,
+            add,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(make_gpu_tensor(
+        Shape::new(vec![base_rows, cols]),
         DType::BF16,
         ctx.device_id(),
         output,

--- a/crates/apxinf-cuda/src/kernels/embedding.rs
+++ b/crates/apxinf-cuda/src/kernels/embedding.rs
@@ -114,6 +114,26 @@ pub fn lookup_bf16(
     ids: &CudaBuffer,
     tokens: usize,
 ) -> Result<Tensor> {
+    lookup_bf16_impl(ctx, table, ids, tokens, true)
+}
+
+/// Raw BF16 embedding lookup without model-specific input scaling.
+pub fn lookup_unscaled_bf16(
+    ctx: &CudaContext,
+    table: &Tensor,
+    ids: &CudaBuffer,
+    tokens: usize,
+) -> Result<Tensor> {
+    lookup_bf16_impl(ctx, table, ids, tokens, false)
+}
+
+fn lookup_bf16_impl(
+    ctx: &CudaContext,
+    table: &Tensor,
+    ids: &CudaBuffer,
+    tokens: usize,
+    scale_by_sqrt_width: bool,
+) -> Result<Tensor> {
     let dims = table.shape().dims();
     if table.dtype() != DType::BF16 || dims.len() != 2 || ids.len() < tokens * 4 || tokens == 0 {
         return Err(Error::Other(
@@ -129,6 +149,7 @@ pub fn lookup_bf16(
             tokens as i32,
             dims[1] as i32,
             dims[0] as i32,
+            scale_by_sqrt_width,
             ctx.stream().handle(),
         ))
         .map_err(Error::Cuda)?;

--- a/crates/apxinf-cuda/src/kernels/gemm/mod.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/mod.rs
@@ -8,6 +8,7 @@ use super::contracts::{checked_bytes, require_buffers, require_finite};
 use crate::buffer::CudaBuffer;
 use crate::context::CudaContext;
 use crate::cublas::CublasTranspose;
+use crate::workspace::output_buffer;
 
 pub use bf16::{
     autotune_cublaslt_bf16, gemm_bf16 as bf16, gemm_bf16_geglu_fused as bf16_geglu_fused,
@@ -48,11 +49,10 @@ pub fn matmul(ctx: &CudaContext, activation: &Tensor, weight: &Tensor) -> Result
     let m = activation.shape().dims()[activation.ndim() - 2];
     let k = activation.shape().dims()[activation.ndim() - 1];
     let n = weight.shape().dims()[weight.ndim() - 1];
-    let output = CudaBuffer::alloc_zeros(
+    let output = output_buffer(
+        ctx,
         output_shape.numel() * activation.dtype().size_in_bytes(),
-        ctx.device_id(),
-    )
-    .map_err(Error::Cuda)?;
+    )?;
     let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
     let weight_buffer = CudaBuffer::from_tensor(weight).map_err(Error::Cuda)?;
     ctx.cublas()

--- a/crates/apxinf-cuda/src/kernels/norm.rs
+++ b/crates/apxinf-cuda/src/kernels/norm.rs
@@ -285,6 +285,43 @@ pub fn adaptive_rms_bf16(
     }
     Ok(matrix_tensor(ctx, rows, cols, output))
 }
+
+/// Affine-free LayerNorm followed by timestep shift/scale.
+/// `style` is `[2 * cols]` or `[1, 2 * cols]`, broadcast across rows and laid
+/// out as `(scale, shift)` unless `shift_first` is set.
+pub fn adaptive_layer_bf16(
+    ctx: &CudaContext,
+    input: &Tensor,
+    style: &Tensor,
+    eps: f32,
+    shift_first: bool,
+) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(input, "AdaLayerNorm")?;
+    let style_dims = style.shape().dims();
+    if input.dtype() != DType::BF16
+        || style.dtype() != DType::BF16
+        || (style_dims != [2 * cols] && style_dims != [1, 2 * cols])
+    {
+        return Err(Error::Other(
+            "static inference BF16 AdaLayerNorm shape mismatch".into(),
+        ));
+    }
+    let output = bf16_output(ctx, rows, cols)?;
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_ada_layer_norm_bf16(
+            gpu_ptr(input)?,
+            gpu_ptr(style)?,
+            output.ptr(),
+            rows as i32,
+            cols as i32,
+            eps,
+            shift_first,
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)?;
+    }
+    Ok(matrix_tensor(ctx, rows, cols, output))
+}
 pub fn rms_quant_f16_e4m3(
     ctx: &CudaContext,
     input: &Tensor,

--- a/crates/apxinf-cuda/src/kernels/preprocess.rs
+++ b/crates/apxinf-cuda/src/kernels/preprocess.rs
@@ -80,6 +80,37 @@ pub fn rgb_u8_to_patches_bf16(
         .map_err(Error::Cuda)
     }
 }
+
+/// GR00T N1.7 two-frame patch packing from already resized 256x256 RGB views.
+pub fn groot_rgb_u8_to_patches_bf16(
+    ctx: &CudaContext,
+    images: &CudaBuffer,
+    patches: &Tensor,
+    views: usize,
+    layout: ImageLayout,
+) -> Result<()> {
+    let expected_bytes = views * 256 * 256 * 3;
+    if views == 0
+        || images.device() != ctx.device_id()
+        || images.len() != expected_bytes
+        || patches.dtype() != DType::BF16
+        || patches.shape().dims() != [views * 256, 1536]
+    {
+        return Err(Error::Other(
+            "GR00T BF16 raw image/preprocessed patch mismatch".into(),
+        ));
+    }
+    unsafe {
+        ffi::check_cuda(ffi::apxinf_static_groot_rgb_u8_to_patches_bf16(
+            images.ptr(),
+            gpu_ptr(patches)?,
+            views as i32,
+            layout.kernel_value(),
+            ctx.stream().handle(),
+        ))
+        .map_err(Error::Cuda)
+    }
+}
 /// Fused static inference image preprocessing for an already resized RGB image batch.
 ///
 /// The input is `uint8` NHWC or NCHW. The output is patch-major E4M3 with

--- a/crates/apxinf-cuda/src/kernels/rope.rs
+++ b/crates/apxinf-cuda/src/kernels/rope.rs
@@ -10,6 +10,7 @@ use super::contracts::{
 use crate::buffer::{CudaBuffer, CudaDeviceAddress};
 use crate::context::CudaContext;
 use crate::ffi;
+use crate::workspace::output_buffer;
 
 /// Apply RoPE into caller-owned storage using a device-resident position.
 #[allow(clippy::too_many_arguments)]
@@ -169,7 +170,7 @@ pub fn apply(
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
 
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     unsafe {
         let res = match input.dtype() {
@@ -226,7 +227,7 @@ pub fn apply_mrope(
     let dims = input.shape().dims();
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
     let out_bytes = input.size_in_bytes();
-    let out_buf = CudaBuffer::alloc_zeros(out_bytes, device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, out_bytes)?;
 
     if input.dtype() != DType::BF16 {
         return Err(Error::Other("rope_mrope: only BF16 supported".into()));
@@ -272,7 +273,7 @@ pub fn apply_vision_2d(
     let device_id = ctx.device_id();
     let dims = input.shape().dims();
     let seq_len = if dims.len() == 2 { 1 } else { dims[0] };
-    let out_buf = CudaBuffer::alloc_zeros(input.size_in_bytes(), device_id).map_err(Error::Cuda)?;
+    let out_buf = output_buffer(ctx, input.size_in_bytes())?;
     unsafe {
         let res = ffi::apxinf_rope_vision_2d_bf16(
             gpu_ptr(input)?,

--- a/crates/apxinf-model/src/builtin.rs
+++ b/crates/apxinf-model/src/builtin.rs
@@ -20,6 +20,8 @@ pub fn register_builtin_models() {
 
     #[cfg(feature = "cuda")]
     crate::pi05::register_builtin();
+    #[cfg(feature = "cuda")]
+    crate::gr00t_n17::register_builtin();
 }
 fn load_llama(
     path: &Path,

--- a/crates/apxinf-model/src/gr00t_n17/action_executor.rs
+++ b/crates/apxinf-model/src/gr00t_n17/action_executor.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use apxinf_core::{Backend, Error, Result, Tensor};
+use apxinf_cuda::kernels::{activation, attention, elementwise, gemm, norm};
+use apxinf_cuda::{CudaBackend, CudaContext};
+use half::bf16;
+
+use super::{
+    AttentionWeights, CategoryMlpWeights, FeedForwardWeights, GrootN17ActionWeights,
+    GrootN17Config, LayerNormWeights, LinearWeights,
+};
+
+struct StepConditioning {
+    action_time: Tensor,
+    block_styles: Vec<Tensor>,
+    final_style: Tensor,
+}
+
+pub struct GrootN17ActionExecutor {
+    config: Arc<GrootN17Config>,
+    weights: Arc<GrootN17ActionWeights>,
+    conditions: Vec<StepConditioning>,
+    unit_norm: LayerNormWeights,
+    action_rows: elementwise::RowIndices,
+}
+
+impl GrootN17ActionExecutor {
+    pub fn new(
+        config: Arc<GrootN17Config>,
+        weights: Arc<GrootN17ActionWeights>,
+        backend: &dyn Backend,
+        cuda: &CudaBackend,
+    ) -> Result<Self> {
+        let width = config.action_width();
+        let unit_norm = LayerNormWeights {
+            weight: backend.to_device(&Tensor::from_bf16(
+                vec![width],
+                &vec![bf16::from_f32(1.0); width],
+            )?)?,
+            bias: backend.to_device(&Tensor::from_bf16(
+                vec![width],
+                &vec![bf16::from_f32(0.0); width],
+            )?)?,
+        };
+        let action_rows = elementwise::RowIndices::new(
+            cuda.device_id(),
+            &(1..=config.action_horizon as u32).collect::<Vec<_>>(),
+        )?;
+        let mut conditions = Vec::with_capacity(config.num_inference_timesteps);
+        for timestep in config.timestep_values() {
+            let action_time = backend.to_device(&action_time_embedding(
+                timestep,
+                config.action_horizon,
+                width,
+            )?)?;
+            let timestep_input = backend.to_device(&dit_time_embedding(timestep, 256)?)?;
+            let temb = linear(cuda.context(), &timestep_input, &weights.timestep_in)?;
+            let temb = activation::bias_silu_bf16(
+                cuda.context(),
+                &temb,
+                weights.timestep_in.bias.as_ref(),
+            )?;
+            let temb = linear_bias(cuda.context(), &temb, &weights.timestep_out)?;
+            let activated_temb = activation::silu(cuda.context(), &temb)?;
+            let mut block_styles = Vec::with_capacity(weights.dit_blocks.len());
+            for block in &weights.dit_blocks {
+                block_styles.push(linear_bias(
+                    cuda.context(),
+                    &activated_temb,
+                    &block.ada_norm,
+                )?);
+            }
+            let final_style =
+                linear_bias(cuda.context(), &activated_temb, &weights.final_condition)?;
+            conditions.push(StepConditioning {
+                action_time,
+                block_styles,
+                final_style,
+            });
+        }
+        backend.synchronize()?;
+        Ok(Self {
+            config,
+            weights,
+            conditions,
+            unit_norm,
+            action_rows,
+        })
+    }
+
+    pub fn refine_backbone(&self, ctx: &CudaContext, features: &Tensor) -> Result<Tensor> {
+        let mut hidden = norm::layer_bf16(
+            ctx,
+            features,
+            &self.weights.vlln.weight,
+            &self.weights.vlln.bias,
+            1e-5,
+        )?;
+        for block in &self.weights.vl_blocks {
+            hidden = self.vl_block(ctx, &hidden, block)?;
+        }
+        Ok(hidden)
+    }
+
+    pub fn infer(
+        &self,
+        ctx: &CudaContext,
+        refined_backbone: &Tensor,
+        state: &Tensor,
+        initial_noise: &Tensor,
+        text_rows: &elementwise::RowIndices,
+        image_rows: &elementwise::RowIndices,
+        backend: &dyn Backend,
+    ) -> Result<Tensor> {
+        let state_features = category_mlp(ctx, state, &self.weights.state_encoder)?;
+        let text_features = elementwise::gather_rows_bf16(ctx, refined_backbone, text_rows)?;
+        let image_features = elementwise::gather_rows_bf16(ctx, refined_backbone, image_rows)?;
+
+        let mut cross_kv = Vec::with_capacity(self.weights.dit_blocks.len());
+        for (index, block) in self.weights.dit_blocks.iter().enumerate() {
+            if index % 2 == 1 {
+                cross_kv.push(None);
+                continue;
+            }
+            let encoder = if index % 4 == 0 {
+                &text_features
+            } else {
+                &image_features
+            };
+            let key = linear_bias(ctx, encoder, &block.attention.k)?.reshape(vec![
+                encoder.shape().dims()[0],
+                self.config.diffusion_model_cfg.num_attention_heads,
+                self.config.diffusion_model_cfg.attention_head_dim,
+            ])?;
+            let value = linear_bias(ctx, encoder, &block.attention.v)?.reshape(vec![
+                encoder.shape().dims()[0],
+                self.config.diffusion_model_cfg.num_attention_heads,
+                self.config.diffusion_model_cfg.attention_head_dim,
+            ])?;
+            cross_kv.push(Some((key, value)));
+        }
+
+        let mut actions = initial_noise.clone();
+        for condition in &self.conditions {
+            let action_base = linear_bias(ctx, &actions, &self.weights.action_encoder.w1)?;
+            let encoded = backend.concat_2d(&[&action_base, &condition.action_time])?;
+            let encoded = linear(ctx, &encoded, &self.weights.action_encoder.w2)?;
+            let encoded = activation::bias_silu_bf16(
+                ctx,
+                &encoded,
+                self.weights.action_encoder.w2.bias.as_ref(),
+            )?;
+            let action_features = linear_bias(ctx, &encoded, &self.weights.action_encoder.w3)?;
+            let action_features =
+                backend.add(&action_features, &self.weights.position_embedding)?;
+            let mut hidden = elementwise::concat_rows_bf16(ctx, &state_features, &action_features)?;
+
+            for (index, block) in self.weights.dit_blocks.iter().enumerate() {
+                let normalized = norm::adaptive_layer_bf16(
+                    ctx,
+                    &hidden,
+                    &condition.block_styles[index],
+                    1e-5,
+                    false,
+                )?;
+                let query = linear_bias(ctx, &normalized, &block.attention.q)?.reshape(vec![
+                    hidden.shape().dims()[0],
+                    self.config.diffusion_model_cfg.num_attention_heads,
+                    self.config.diffusion_model_cfg.attention_head_dim,
+                ])?;
+                let attended = if let Some((key, value)) = &cross_kv[index] {
+                    attention::cross_mha_bf16(ctx, &query, key, value)?
+                } else {
+                    let key = linear_bias(ctx, &normalized, &block.attention.k)?.reshape(vec![
+                        hidden.shape().dims()[0],
+                        self.config.diffusion_model_cfg.num_attention_heads,
+                        self.config.diffusion_model_cfg.attention_head_dim,
+                    ])?;
+                    let value =
+                        linear_bias(ctx, &normalized, &block.attention.v)?.reshape(vec![
+                            hidden.shape().dims()[0],
+                            self.config.diffusion_model_cfg.num_attention_heads,
+                            self.config.diffusion_model_cfg.attention_head_dim,
+                        ])?;
+                    attention::mha_bf16(ctx, &query, &key, &value, hidden.shape().dims()[0])?
+                };
+                let attended =
+                    attended.reshape(vec![hidden.shape().dims()[0], self.config.action_width()])?;
+                let projected = linear_bias(ctx, &attended, &block.attention.output)?;
+                hidden = backend.add(&hidden, &projected)?;
+                let normalized = norm::layer_bf16(
+                    ctx,
+                    &hidden,
+                    &self.unit_norm.weight,
+                    &self.unit_norm.bias,
+                    1e-5,
+                )?;
+                let ff = linear(ctx, &normalized, &block.feed_forward.input)?;
+                let ff =
+                    activation::bias_gelu_bf16(ctx, &ff, block.feed_forward.input.bias.as_ref())?;
+                let ff = linear_bias(ctx, &ff, &block.feed_forward.output)?;
+                hidden = backend.add(&hidden, &ff)?;
+            }
+
+            hidden = norm::adaptive_layer_bf16(ctx, &hidden, &condition.final_style, 1e-6, true)?;
+            let decoded_input = linear_bias(ctx, &hidden, &self.weights.final_projection)?;
+            let decoded_input =
+                elementwise::gather_rows_bf16(ctx, &decoded_input, &self.action_rows)?;
+            let velocity = category_mlp(ctx, &decoded_input, &self.weights.action_decoder)?;
+            actions = elementwise::euler_update_bf16(
+                ctx,
+                &actions,
+                &velocity,
+                1.0 / self.config.num_inference_timesteps as f32,
+            )?;
+        }
+        Ok(actions)
+    }
+
+    fn vl_block(
+        &self,
+        ctx: &CudaContext,
+        hidden: &Tensor,
+        block: &super::VlBlockWeights,
+    ) -> Result<Tensor> {
+        let normalized =
+            norm::layer_bf16(ctx, hidden, &block.norm1.weight, &block.norm1.bias, 1e-5)?;
+        let attended = self_attention(
+            ctx,
+            &normalized,
+            &block.attention,
+            self.config.vl_self_attention_cfg.num_attention_heads,
+            self.config.vl_self_attention_cfg.attention_head_dim,
+        )?;
+        let mut hidden = apxinf_cuda::kernels::elementwise::add(ctx, hidden, &attended)?;
+        let normalized =
+            norm::layer_bf16(ctx, &hidden, &block.norm3.weight, &block.norm3.bias, 1e-5)?;
+        let ff = feed_forward(ctx, &normalized, &block.feed_forward)?;
+        hidden = apxinf_cuda::kernels::elementwise::add(ctx, &hidden, &ff)?;
+        Ok(hidden)
+    }
+}
+
+fn linear(ctx: &CudaContext, input: &Tensor, weights: &LinearWeights) -> Result<Tensor> {
+    gemm::matmul(ctx, input, &weights.weight)
+}
+
+fn linear_bias(ctx: &CudaContext, input: &Tensor, weights: &LinearWeights) -> Result<Tensor> {
+    let output = linear(ctx, input, weights)?;
+    elementwise::bias_bf16(ctx, &output, weights.bias.as_ref())
+}
+
+fn category_mlp(ctx: &CudaContext, input: &Tensor, weights: &CategoryMlpWeights) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &weights.layer1)?;
+    let hidden = activation::bias_relu_bf16(ctx, &hidden, weights.layer1.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &weights.layer2)
+}
+
+fn feed_forward(ctx: &CudaContext, input: &Tensor, weights: &FeedForwardWeights) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &weights.input)?;
+    let hidden = activation::bias_gelu_bf16(ctx, &hidden, weights.input.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &weights.output)
+}
+
+fn self_attention(
+    ctx: &CudaContext,
+    input: &Tensor,
+    weights: &AttentionWeights,
+    heads: usize,
+    head_dim: usize,
+) -> Result<Tensor> {
+    let tokens = input.shape().dims()[0];
+    let q = linear_bias(ctx, input, &weights.q)?.reshape(vec![tokens, heads, head_dim])?;
+    let k = linear_bias(ctx, input, &weights.k)?.reshape(vec![tokens, heads, head_dim])?;
+    let v = linear_bias(ctx, input, &weights.v)?.reshape(vec![tokens, heads, head_dim])?;
+    let attended = attention::mha_bf16(ctx, &q, &k, &v, tokens)?;
+    let attended = attended.reshape(vec![tokens, heads * head_dim])?;
+    linear_bias(ctx, &attended, &weights.output)
+}
+
+fn action_time_embedding(timestep: u32, rows: usize, width: usize) -> Result<Tensor> {
+    let half = width / 2;
+    let mut row = Vec::with_capacity(width);
+    for index in 0..half {
+        let frequency = (-((index as f32) * 10000.0f32.ln() / half as f32)).exp();
+        row.push(bf16::from_f32((timestep as f32 * frequency).sin()));
+    }
+    for index in 0..half {
+        let frequency = (-((index as f32) * 10000.0f32.ln() / half as f32)).exp();
+        row.push(bf16::from_f32((timestep as f32 * frequency).cos()));
+    }
+    let values = row.repeat(rows);
+    Tensor::from_bf16(vec![rows, width], &values)
+}
+
+fn dit_time_embedding(timestep: u32, width: usize) -> Result<Tensor> {
+    if width % 2 != 0 || width < 4 {
+        return Err(Error::Other("invalid DiT timestep embedding width".into()));
+    }
+    let half = width / 2;
+    let denominator = (half - 1) as f32;
+    let mut cosine = Vec::with_capacity(half);
+    let mut sine = Vec::with_capacity(half);
+    for index in 0..half {
+        let frequency = (-(10000.0f32.ln()) * index as f32 / denominator).exp();
+        let phase = timestep as f32 * frequency;
+        cosine.push(bf16::from_f32(phase.cos()));
+        sine.push(bf16::from_f32(phase.sin()));
+    }
+    cosine.extend(sine);
+    Tensor::from_bf16(vec![1, width], &cosine)
+}

--- a/crates/apxinf-model/src/gr00t_n17/backbone_executor.rs
+++ b/crates/apxinf-model/src/gr00t_n17/backbone_executor.rs
@@ -1,0 +1,317 @@
+//! Fixed-shape, GPU-resident Cosmos/Qwen3-VL backbone for GR00T N1.7 LIBERO.
+
+use apxinf_core::{Error, Result, Tensor};
+use apxinf_cuda::buffer::CudaBuffer;
+use apxinf_cuda::kernels::{activation, attention, elementwise, embedding, gemm, norm, rope};
+use apxinf_cuda::CudaContext;
+use std::sync::Arc;
+
+use super::backbone_weights::{GrootLanguageLayer, GrootVisionMerger};
+use super::{GrootN17BackboneWeights, LayerNormWeights, LinearWeights};
+
+pub struct GrootN17BackboneExecutor {
+    weights: Arc<GrootN17BackboneWeights>,
+    token_count: usize,
+    view_count: usize,
+    patch_rows: usize,
+    token_ids: CudaBuffer,
+    language_positions: CudaBuffer,
+    vision_positions: CudaBuffer,
+    image_rows: elementwise::RowIndices,
+}
+
+impl GrootN17BackboneExecutor {
+    pub fn new(
+        weights: Arc<GrootN17BackboneWeights>,
+        token_ids: &[u32],
+        device: usize,
+    ) -> Result<Self> {
+        let view_count = match token_ids.len() {
+            76 => 1,
+            142 => 2,
+            count => {
+                return Err(Error::Other(format!(
+                    "GR00T profile requires 76 or 142 tokens, got {count}"
+                )))
+            }
+        };
+        let image_positions = token_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &token)| (token == 151655).then_some(i as u32))
+            .collect::<Vec<_>>();
+        if image_positions.len() != view_count * 64 {
+            return Err(Error::Other(format!(
+                "GR00T {view_count}-view profile requires {} image tokens, got {}",
+                view_count * 64,
+                image_positions.len()
+            )));
+        }
+        Ok(Self {
+            weights,
+            token_count: token_ids.len(),
+            view_count,
+            patch_rows: view_count * 256,
+            token_ids: upload_u32(device, token_ids)?,
+            language_positions: upload_u32(device, &mrope_positions(token_ids, view_count)?)?,
+            vision_positions: upload_u32(device, &vision_positions(view_count))?,
+            image_rows: elementwise::RowIndices::new(device, &image_positions)?,
+        })
+    }
+
+    pub fn forward(&self, ctx: &CudaContext, patches: &Tensor) -> Result<Tensor> {
+        if patches.shape().dims() != [self.patch_rows, 1536] {
+            return Err(Error::Other(format!(
+                "GR00T patches must be [{},1536], got {:?}",
+                self.patch_rows,
+                patches.shape().dims()
+            )));
+        }
+        let vision = self
+            .forward_vision(ctx, patches)
+            .map_err(|error| Error::Other(format!("GR00T vision tower: {error}")))?;
+        let mut hidden = embedding::lookup_unscaled_bf16(
+            ctx,
+            &self.weights.embedding,
+            &self.token_ids,
+            self.token_count,
+        )
+        .map_err(|error| Error::Other(format!("GR00T token embedding: {error}")))?;
+        hidden = elementwise::scatter_rows_bf16(ctx, &hidden, &vision.0, &self.image_rows, false)
+            .map_err(|error| {
+            Error::Other(format!("GR00T primary vision injection: {error}"))
+        })?;
+        for (index, layer) in self.weights.language_layers.iter().enumerate() {
+            hidden = language_layer(
+                ctx,
+                &hidden,
+                layer,
+                &self.language_positions,
+                self.token_count,
+            )
+            .map_err(|error| Error::Other(format!("GR00T language layer {index}: {error}")))?;
+            if index < vision.1.len() {
+                hidden = elementwise::scatter_rows_bf16(
+                    ctx,
+                    &hidden,
+                    &vision.1[index],
+                    &self.image_rows,
+                    true,
+                )
+                .map_err(|error| {
+                    Error::Other(format!("GR00T deepstack injection {index}: {error}"))
+                })?;
+            }
+        }
+        // GR00T selects `outputs.hidden_states[-1]` from the truncated Qwen
+        // backbone. Transformers records that boundary before the language
+        // model's final RMSNorm; the action head's own VLLN is the next norm.
+        Ok(hidden)
+    }
+
+    pub fn update_token_ids(&self, token_ids: &[u32]) -> Result<()> {
+        if token_ids.len() != self.token_count {
+            return Err(Error::Other(format!(
+                "GR00T prepared graph requires {} token IDs",
+                self.token_count
+            )));
+        }
+        let image_positions = token_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &token)| (token == 151655).then_some(i))
+            .collect::<Vec<_>>();
+        let expected = if self.view_count == 1 {
+            (4..68).collect::<Vec<_>>()
+        } else {
+            (4..68).chain(70..134).collect::<Vec<_>>()
+        };
+        if image_positions != expected {
+            return Err(Error::Other(
+                "GR00T token image spans do not match the prepared graph".into(),
+            ));
+        }
+        let bytes = token_ids
+            .iter()
+            .flat_map(|value| value.to_ne_bytes())
+            .collect::<Vec<_>>();
+        self.token_ids.copy_from_host(&bytes).map_err(Error::Cuda)
+    }
+
+    fn forward_vision(&self, ctx: &CudaContext, patches: &Tensor) -> Result<(Tensor, Vec<Tensor>)> {
+        let w = &self.weights.vision;
+        let mut hidden = linear_bias(ctx, patches, &w.patch)
+            .map_err(|error| Error::Other(format!("patch projection: {error}")))?;
+        let position = if self.view_count == 1 {
+            &w.position_one_view
+        } else {
+            &w.position_two_view
+        };
+        hidden = elementwise::add(ctx, &hidden, position)
+            .map_err(|error| Error::Other(format!("vision position add: {error}")))?;
+        let mut deep = Vec::with_capacity(3);
+        for (index, block) in w.blocks.iter().enumerate() {
+            hidden = (|| -> Result<Tensor> {
+                let normalized = layer_norm(ctx, &hidden, &block.norm1, 1e-6)?;
+                let q = linear_bias(ctx, &normalized, &block.q)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let k = linear_bias(ctx, &normalized, &block.k)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let v = linear_bias(ctx, &normalized, &block.v)?.reshape(vec![
+                    self.patch_rows,
+                    16,
+                    64,
+                ])?;
+                let q = rope::apply_vision_2d(ctx, &q, 16, 64, 10000.0, &self.vision_positions)?;
+                let k = rope::apply_vision_2d(ctx, &k, 16, 64, 10000.0, &self.vision_positions)?;
+                let attended = attention::mha_bf16(ctx, &q, &k, &v, 256)?
+                    .reshape(vec![self.patch_rows, 1024])?;
+                let output =
+                    elementwise::add(ctx, &hidden, &linear_bias(ctx, &attended, &block.output)?)?;
+                let normalized = layer_norm(ctx, &output, &block.norm2, 1e-6)?;
+                let ff = linear(ctx, &normalized, &block.fc1)?;
+                let ff = activation::bias_gelu_bf16(ctx, &ff, block.fc1.bias.as_ref())?;
+                elementwise::add(ctx, &output, &linear_bias(ctx, &ff, &block.fc2)?)
+            })()
+            .map_err(|error| Error::Other(format!("vision block {index}: {error}")))?;
+            if matches!(index, 5 | 11 | 17) {
+                deep.push(hidden.clone());
+            }
+        }
+        let merged_rows = self.view_count * 64;
+        let primary = merge_primary(ctx, &hidden, &w.primary_merger, merged_rows)
+            .map_err(|error| Error::Other(format!("primary merger: {error}")))?;
+        let deep = deep
+            .iter()
+            .zip(&w.deepstack_mergers)
+            .enumerate()
+            .map(|(index, (value, merger))| {
+                merge_deep(ctx, value, merger, merged_rows)
+                    .map_err(|error| Error::Other(format!("deepstack merger {index}: {error}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok((primary, deep))
+    }
+}
+
+fn language_layer(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootLanguageLayer,
+    positions: &CudaBuffer,
+    tokens: usize,
+) -> Result<Tensor> {
+    let normalized = norm::rms_bf16(ctx, input, &w.input_norm, 1e-6)?;
+    let q = linear(ctx, &normalized, &w.q)?.reshape(vec![tokens * 16, 128])?;
+    let k = linear(ctx, &normalized, &w.k)?.reshape(vec![tokens * 8, 128])?;
+    let q = norm::rms_bf16(ctx, &q, &w.q_norm, 1e-6)?.reshape(vec![tokens, 16, 128])?;
+    let k = norm::rms_bf16(ctx, &k, &w.k_norm, 1e-6)?.reshape(vec![tokens, 8, 128])?;
+    let v = linear(ctx, &normalized, &w.v)?.reshape(vec![tokens, 8, 128])?;
+    let q = rope::apply_mrope(ctx, &q, 16, 128, 5_000_000.0, [24, 20, 20], positions)?;
+    let k = rope::apply_mrope(ctx, &k, 8, 128, 5_000_000.0, [24, 20, 20], positions)?;
+    let attended = attention::causal_gqa_bf16(ctx, &q, &k, &v)?.reshape(vec![tokens, 2048])?;
+    let hidden = elementwise::add(ctx, input, &linear(ctx, &attended, &w.output)?)?;
+    let normalized = norm::rms_bf16(ctx, &hidden, &w.post_norm, 1e-6)?;
+    let gate = activation::silu(ctx, &linear(ctx, &normalized, &w.gate)?)?;
+    let up = linear(ctx, &normalized, &w.up)?;
+    let ff = elementwise::mul(ctx, &gate, &up)?;
+    elementwise::add(ctx, &hidden, &linear(ctx, &ff, &w.down)?)
+}
+
+fn merge_primary(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootVisionMerger,
+    rows: usize,
+) -> Result<Tensor> {
+    let normalized = layer_norm(ctx, input, &w.norm, 1e-6)?.reshape(vec![rows, 4096])?;
+    merger_mlp(ctx, &normalized, w)
+}
+
+fn merge_deep(
+    ctx: &CudaContext,
+    input: &Tensor,
+    w: &GrootVisionMerger,
+    rows: usize,
+) -> Result<Tensor> {
+    let merged = input.reshape(vec![rows, 4096])?;
+    let normalized = layer_norm(ctx, &merged, &w.norm, 1e-6)?;
+    merger_mlp(ctx, &normalized, w)
+}
+
+fn merger_mlp(ctx: &CudaContext, input: &Tensor, w: &GrootVisionMerger) -> Result<Tensor> {
+    let hidden = linear(ctx, input, &w.fc1)?;
+    let hidden = activation::bias_gelu_bf16(ctx, &hidden, w.fc1.bias.as_ref())?;
+    linear_bias(ctx, &hidden, &w.fc2)
+}
+
+fn linear(ctx: &CudaContext, input: &Tensor, w: &LinearWeights) -> Result<Tensor> {
+    gemm::matmul(ctx, input, &w.weight)
+}
+fn linear_bias(ctx: &CudaContext, input: &Tensor, w: &LinearWeights) -> Result<Tensor> {
+    elementwise::bias_bf16(ctx, &linear(ctx, input, w)?, w.bias.as_ref())
+}
+fn layer_norm(ctx: &CudaContext, input: &Tensor, w: &LayerNormWeights, eps: f32) -> Result<Tensor> {
+    norm::layer_bf16(ctx, input, &w.weight, &w.bias, eps)
+}
+
+fn upload_u32(device: usize, values: &[u32]) -> Result<CudaBuffer> {
+    let bytes = values
+        .iter()
+        .flat_map(|value| value.to_ne_bytes())
+        .collect::<Vec<_>>();
+    let output = CudaBuffer::alloc(bytes.len(), device).map_err(Error::Cuda)?;
+    output.copy_from_host(&bytes).map_err(Error::Cuda)?;
+    Ok(output)
+}
+
+fn vision_positions(views: usize) -> Vec<u32> {
+    let mut output = Vec::with_capacity(views * 512);
+    for _ in 0..views {
+        for mr in 0..8 {
+            for mc in 0..8 {
+                for ir in 0..2 {
+                    for ic in 0..2 {
+                        output.extend_from_slice(&[(mr * 2 + ir) as u32, (mc * 2 + ic) as u32]);
+                    }
+                }
+            }
+        }
+    }
+    output
+}
+
+fn mrope_positions(tokens: &[u32], expected_images: usize) -> Result<Vec<u32>> {
+    let mut output = Vec::with_capacity(tokens.len() * 3);
+    let mut cursor = 0usize;
+    let mut next = 0u32;
+    let mut images = 0;
+    while cursor < tokens.len() {
+        if tokens[cursor] != 151655 {
+            output.extend_from_slice(&[next, next, next]);
+            next += 1;
+            cursor += 1;
+            continue;
+        }
+        images += 1;
+        for row in 0..8 {
+            for col in 0..8 {
+                output.extend_from_slice(&[next, next + row, next + col]);
+            }
+        }
+        next += 8;
+        cursor += 64;
+    }
+    if images != expected_images {
+        return Err(Error::Other(format!(
+            "expected {expected_images} image spans, got {images}"
+        )));
+    }
+    Ok(output)
+}

--- a/crates/apxinf-model/src/gr00t_n17/backbone_weights.rs
+++ b/crates/apxinf-model/src/gr00t_n17/backbone_weights.rs
@@ -1,0 +1,309 @@
+//! GR00T-owned Cosmos/Qwen3-VL backbone weights.
+
+use super::weights::{take, transpose_2d, upload_linear};
+use super::{LayerNormWeights, LinearWeights};
+use apxinf_core::{Backend, DType, Error, Result, Tensor};
+use std::collections::HashMap;
+
+pub struct GrootLanguageLayer {
+    pub input_norm: Tensor,
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+    pub post_norm: Tensor,
+    pub gate: LinearWeights,
+    pub up: LinearWeights,
+    pub down: LinearWeights,
+}
+
+pub struct GrootVisionBlock {
+    pub norm1: LayerNormWeights,
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+    pub norm2: LayerNormWeights,
+    pub fc1: LinearWeights,
+    pub fc2: LinearWeights,
+}
+
+pub struct GrootVisionMerger {
+    pub norm: LayerNormWeights,
+    pub fc1: LinearWeights,
+    pub fc2: LinearWeights,
+}
+
+pub struct GrootVisionWeights {
+    pub patch: LinearWeights,
+    pub position_one_view: Tensor,
+    pub position_two_view: Tensor,
+    pub blocks: Vec<GrootVisionBlock>,
+    pub primary_merger: GrootVisionMerger,
+    pub deepstack_mergers: Vec<GrootVisionMerger>,
+}
+
+pub struct GrootN17BackboneWeights {
+    pub embedding: Tensor,
+    pub language_layers: Vec<GrootLanguageLayer>,
+    pub output_norm: Tensor,
+    pub vision: GrootVisionWeights,
+}
+
+impl GrootN17BackboneWeights {
+    pub fn from_map(tensors: &mut HashMap<String, Tensor>) -> Result<Self> {
+        const ROOT: &str = "backbone.model.model";
+        let mut language_layers = Vec::with_capacity(16);
+        for index in 0..16 {
+            let prefix = format!("{ROOT}.language_model.layers.{index}");
+            language_layers.push(GrootLanguageLayer {
+                input_norm: take(tensors, &format!("{prefix}.input_layernorm.weight"))?,
+                q: take_linear(tensors, &format!("{prefix}.self_attn.q_proj"), false)?,
+                k: take_linear(tensors, &format!("{prefix}.self_attn.k_proj"), false)?,
+                v: take_linear(tensors, &format!("{prefix}.self_attn.v_proj"), false)?,
+                output: take_linear(tensors, &format!("{prefix}.self_attn.o_proj"), false)?,
+                q_norm: take(tensors, &format!("{prefix}.self_attn.q_norm.weight"))?,
+                k_norm: take(tensors, &format!("{prefix}.self_attn.k_norm.weight"))?,
+                post_norm: take(
+                    tensors,
+                    &format!("{prefix}.post_attention_layernorm.weight"),
+                )?,
+                gate: take_linear(tensors, &format!("{prefix}.mlp.gate_proj"), false)?,
+                up: take_linear(tensors, &format!("{prefix}.mlp.up_proj"), false)?,
+                down: take_linear(tensors, &format!("{prefix}.mlp.down_proj"), false)?,
+            });
+        }
+        let mut blocks = Vec::with_capacity(24);
+        for index in 0..24 {
+            let prefix = format!("{ROOT}.visual.blocks.{index}");
+            let qkv_weight = take(tensors, &format!("{prefix}.attn.qkv.weight"))?;
+            let qkv_bias = take(tensors, &format!("{prefix}.attn.qkv.bias"))?;
+            blocks.push(GrootVisionBlock {
+                norm1: take_norm(tensors, &format!("{prefix}.norm1"))?,
+                q: split_linear(&qkv_weight, &qkv_bias, 0)?,
+                k: split_linear(&qkv_weight, &qkv_bias, 1)?,
+                v: split_linear(&qkv_weight, &qkv_bias, 2)?,
+                output: take_linear(tensors, &format!("{prefix}.attn.proj"), true)?,
+                norm2: take_norm(tensors, &format!("{prefix}.norm2"))?,
+                fc1: take_linear(tensors, &format!("{prefix}.mlp.linear_fc1"), true)?,
+                fc2: take_linear(tensors, &format!("{prefix}.mlp.linear_fc2"), true)?,
+            });
+        }
+        let patch_raw = take(tensors, &format!("{ROOT}.visual.patch_embed.proj.weight"))?;
+        let patch_weight = flatten_transpose(&patch_raw, 1024, 1536)?;
+        let patch_bias = take(tensors, &format!("{ROOT}.visual.patch_embed.proj.bias"))?;
+        Ok(Self {
+            embedding: take(
+                tensors,
+                &format!("{ROOT}.language_model.embed_tokens.weight"),
+            )?,
+            language_layers,
+            output_norm: take(tensors, &format!("{ROOT}.language_model.norm.weight"))?,
+            vision: GrootVisionWeights {
+                patch: LinearWeights {
+                    weight: patch_weight,
+                    bias: Some(patch_bias),
+                },
+                position_one_view: take(tensors, &format!("{ROOT}.visual.pos_embed.weight"))?,
+                position_two_view: Tensor::zeros(vec![1], DType::BF16),
+                blocks,
+                primary_merger: take_merger(tensors, &format!("{ROOT}.visual.merger"))?,
+                deepstack_mergers: (0..3)
+                    .map(|i| {
+                        take_merger(tensors, &format!("{ROOT}.visual.deepstack_merger_list.{i}"))
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            },
+        })
+    }
+
+    pub fn to_device(mut self, backend: &dyn Backend) -> Result<Self> {
+        self.embedding = backend.to_device(&self.embedding)?;
+        self.output_norm = backend.to_device(&self.output_norm)?;
+        for layer in &mut self.language_layers {
+            layer.input_norm = backend.to_device(&layer.input_norm)?;
+            layer.q_norm = backend.to_device(&layer.q_norm)?;
+            layer.k_norm = backend.to_device(&layer.k_norm)?;
+            layer.post_norm = backend.to_device(&layer.post_norm)?;
+            for linear in [
+                &mut layer.q,
+                &mut layer.k,
+                &mut layer.v,
+                &mut layer.output,
+                &mut layer.gate,
+                &mut layer.up,
+                &mut layer.down,
+            ] {
+                upload_linear(linear, backend)?;
+            }
+        }
+        upload_linear(&mut self.vision.patch, backend)?;
+        let (one_view, two_view) = fixed_vision_positions(&self.vision.position_one_view)?;
+        self.vision.position_one_view = backend.to_device(&one_view)?;
+        self.vision.position_two_view = backend.to_device(&two_view)?;
+        for block in &mut self.vision.blocks {
+            upload_norm(&mut block.norm1, backend)?;
+            upload_norm(&mut block.norm2, backend)?;
+            for linear in [
+                &mut block.q,
+                &mut block.k,
+                &mut block.v,
+                &mut block.output,
+                &mut block.fc1,
+                &mut block.fc2,
+            ] {
+                upload_linear(linear, backend)?;
+            }
+        }
+        upload_merger(&mut self.vision.primary_merger, backend)?;
+        for merger in &mut self.vision.deepstack_mergers {
+            upload_merger(merger, backend)?;
+        }
+        Ok(self)
+    }
+}
+
+fn take_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    bias: bool,
+) -> Result<LinearWeights> {
+    Ok(LinearWeights {
+        weight: transpose_2d(&take(tensors, &format!("{prefix}.weight"))?)?,
+        bias: bias
+            .then(|| take(tensors, &format!("{prefix}.bias")))
+            .transpose()?,
+    })
+}
+
+fn take_norm(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<LayerNormWeights> {
+    Ok(LayerNormWeights {
+        weight: take(tensors, &format!("{prefix}.weight"))?,
+        bias: take(tensors, &format!("{prefix}.bias"))?,
+    })
+}
+
+fn take_merger(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<GrootVisionMerger> {
+    Ok(GrootVisionMerger {
+        norm: take_norm(tensors, &format!("{prefix}.norm"))?,
+        fc1: take_linear(tensors, &format!("{prefix}.linear_fc1"), true)?,
+        fc2: take_linear(tensors, &format!("{prefix}.linear_fc2"), true)?,
+    })
+}
+
+fn upload_norm(value: &mut LayerNormWeights, backend: &dyn Backend) -> Result<()> {
+    value.weight = backend.to_device(&value.weight)?;
+    value.bias = backend.to_device(&value.bias)?;
+    Ok(())
+}
+
+fn upload_merger(value: &mut GrootVisionMerger, backend: &dyn Backend) -> Result<()> {
+    upload_norm(&mut value.norm, backend)?;
+    upload_linear(&mut value.fc1, backend)?;
+    upload_linear(&mut value.fc2, backend)
+}
+
+fn split_linear(weight: &Tensor, bias: &Tensor, part: usize) -> Result<LinearWeights> {
+    let width = weight.shape().dims()[0] / 3;
+    Ok(LinearWeights {
+        weight: transpose_2d(&slice_rows(weight, part * width, width)?)?,
+        bias: Some(slice_rows(bias, part * width, width)?),
+    })
+}
+
+fn slice_rows(tensor: &Tensor, start: usize, rows: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    let stride: usize = dims.get(1..).unwrap_or(&[]).iter().product();
+    let mut shape = dims.to_vec();
+    shape[0] = rows;
+    match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(
+            shape,
+            &tensor.as_bf16()?[start * stride..(start + rows) * stride],
+        ),
+        DType::F32 => Tensor::from_f32(
+            shape,
+            &tensor.as_f32()?[start * stride..(start + rows) * stride],
+        ),
+        dtype => Err(Error::Other(format!("unsupported backbone dtype {dtype}"))),
+    }
+}
+
+fn flatten_transpose(tensor: &Tensor, rows: usize, cols: usize) -> Result<Tensor> {
+    let reshaped = match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(vec![rows, cols], tensor.as_bf16()?)?,
+        DType::F32 => Tensor::from_f32(vec![rows, cols], tensor.as_f32()?)?,
+        dtype => return Err(Error::Other(format!("unsupported patch dtype {dtype}"))),
+    };
+    transpose_2d(&reshaped)
+}
+
+fn fixed_vision_positions(table: &Tensor) -> Result<(Tensor, Tensor)> {
+    const SOURCE: usize = 48;
+    const TARGET: usize = 16;
+    const WIDTH: usize = 1024;
+    let values = table.to_f32_vec()?;
+    let mut one_view = vec![0.0f32; TARGET * TARGET * WIDTH];
+    for row in 0..TARGET {
+        let yf = row as f32 * (SOURCE - 1) as f32 / (TARGET - 1) as f32;
+        let y0 = yf.floor() as usize;
+        let y1 = (y0 + 1).min(SOURCE - 1);
+        let dy = yf - y0 as f32;
+        for col in 0..TARGET {
+            let xf = col as f32 * (SOURCE - 1) as f32 / (TARGET - 1) as f32;
+            let x0 = xf.floor() as usize;
+            let x1 = (x0 + 1).min(SOURCE - 1);
+            let dx = xf - x0 as f32;
+            // Transformers casts the interpolation weights to the embedding
+            // table's BF16 dtype before multiplying, then performs the four
+            // additions in BF16. Preserve those rounding boundaries: doing
+            // the complete bilinear expression in f32 measurably changes the
+            // frozen vision prefix after 24 residual blocks.
+            let round = |value: f32| half::bf16::from_f32(value).to_f32();
+            let weights = [
+                round((1.0 - dy) * (1.0 - dx)),
+                round((1.0 - dy) * dx),
+                round(dy * (1.0 - dx)),
+                round(dy * dx),
+            ];
+            for channel in 0..WIDTH {
+                let at = |y, x| values[(y * SOURCE + x) * WIDTH + channel];
+                let products = [
+                    round(at(y0, x0) * weights[0]),
+                    round(at(y0, x1) * weights[1]),
+                    round(at(y1, x0) * weights[2]),
+                    round(at(y1, x1) * weights[3]),
+                ];
+                let sum =
+                    round(round(round(products[0] + products[1]) + products[2]) + products[3]);
+                one_view[(row * TARGET + col) * WIDTH + channel] = sum;
+            }
+        }
+    }
+    // Processor patch order already groups each 2x2 merge tile contiguously.
+    let mut permuted = Vec::with_capacity(one_view.len());
+    for macro_row in 0..TARGET / 2 {
+        for macro_col in 0..TARGET / 2 {
+            for inner_row in 0..2 {
+                for inner_col in 0..2 {
+                    let offset =
+                        ((macro_row * 2 + inner_row) * TARGET + macro_col * 2 + inner_col) * WIDTH;
+                    permuted.extend_from_slice(&one_view[offset..offset + WIDTH]);
+                }
+            }
+        }
+    }
+    let one_values = permuted
+        .into_iter()
+        .map(half::bf16::from_f32)
+        .collect::<Vec<_>>();
+    let mut two_values = Vec::with_capacity(one_values.len() * 2);
+    two_values.extend_from_slice(&one_values);
+    two_values.extend_from_slice(&one_values);
+    Ok((
+        Tensor::from_bf16(vec![256, WIDTH], &one_values)?,
+        Tensor::from_bf16(vec![512, WIDTH], &two_values)?,
+    ))
+}

--- a/crates/apxinf-model/src/gr00t_n17/config.rs
+++ b/crates/apxinf-model/src/gr00t_n17/config.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use apxinf_core::{Error, Result};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17DiffusionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+    pub output_dim: usize,
+    pub interleave_self_attention: bool,
+    pub norm_type: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17VlSelfAttentionConfig {
+    pub attention_head_dim: usize,
+    pub num_attention_heads: usize,
+    pub num_layers: usize,
+}
+
+/// Frozen architecture fields used by the native GR00T N1.7 executor.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GrootN17Config {
+    pub model_type: String,
+    pub model_name: String,
+    pub dtype: String,
+    pub action_horizon: usize,
+    pub max_action_dim: usize,
+    pub max_state_dim: usize,
+    pub max_num_embodiments: usize,
+    pub max_seq_len: usize,
+    pub hidden_size: usize,
+    pub backbone_embedding_dim: usize,
+    pub select_layer: usize,
+    pub num_inference_timesteps: usize,
+    pub num_timestep_buckets: usize,
+    pub add_pos_embed: bool,
+    pub use_alternate_vl_dit: bool,
+    pub use_vlln: bool,
+    pub diffusion_model_cfg: GrootN17DiffusionConfig,
+    pub vl_self_attention_cfg: GrootN17VlSelfAttentionConfig,
+}
+
+impl GrootN17Config {
+    pub const LIBERO_EMBODIMENT_ID: usize = 2;
+    pub const LIBERO_ACTION_HORIZON: usize = 16;
+    pub const LIBERO_ACTION_DIM: usize = 7;
+
+    pub fn from_json_file(path: &Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|error| Error::Other(format!("read {}: {error}", path.display())))?;
+        let config: Self = serde_json::from_str(&raw)
+            .map_err(|error| Error::Other(format!("parse {}: {error}", path.display())))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn action_width(&self) -> usize {
+        self.diffusion_model_cfg.num_attention_heads
+            * self.diffusion_model_cfg.attention_head_dim
+    }
+
+    pub fn vl_attention_width(&self) -> usize {
+        self.vl_self_attention_cfg.num_attention_heads
+            * self.vl_self_attention_cfg.attention_head_dim
+    }
+
+    pub fn timestep_values(&self) -> Vec<u32> {
+        (0..self.num_inference_timesteps)
+            .map(|step| step * self.num_timestep_buckets / self.num_inference_timesteps)
+            .map(|value| value as u32)
+            .collect()
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let expected = [
+            (self.model_type == "Gr00tN1d7", "model_type must be Gr00tN1d7"),
+            (self.dtype == "bfloat16", "only the BF16 checkpoint is supported"),
+            (self.action_horizon == 40, "action_horizon must be 40"),
+            (self.max_action_dim == 132, "max_action_dim must be 132"),
+            (self.max_state_dim == 132, "max_state_dim must be 132"),
+            (self.select_layer == 16, "select_layer must be 16"),
+            (self.num_inference_timesteps == 4, "denoising steps must be 4"),
+            (self.num_timestep_buckets == 1000, "timestep buckets must be 1000"),
+            (self.add_pos_embed, "action position embedding is required"),
+            (self.use_alternate_vl_dit, "alternate VL DiT is required"),
+            (self.use_vlln, "VL LayerNorm is required"),
+            (self.action_width() == 1536, "DiT width must be 1536"),
+            (self.diffusion_model_cfg.num_layers == 32, "DiT depth must be 32"),
+            (self.diffusion_model_cfg.output_dim == 1024, "DiT output must be 1024"),
+            (self.diffusion_model_cfg.interleave_self_attention, "DiT must interleave self attention"),
+            (self.diffusion_model_cfg.norm_type == "ada_norm", "DiT must use ada_norm"),
+            (self.vl_attention_width() == 2048, "VL attention width must be 2048"),
+            (self.vl_self_attention_cfg.num_layers == 4, "VL attention depth must be 4"),
+        ];
+        if let Some((_, message)) = expected.into_iter().find(|(ok, _)| !ok) {
+            return Err(Error::Other(format!("unsupported GR00T N1.7 config: {message}")));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GrootN17Config;
+
+    #[test]
+    fn parses_frozen_libero_checkpoint() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../experiment/gr00t-n1d7-workflow-validation/checkpoint_metadata/config.json");
+        if !path.is_file() {
+            return;
+        }
+        let config = GrootN17Config::from_json_file(&path).unwrap();
+        assert_eq!(config.action_width(), 1536);
+        assert_eq!(config.vl_attention_width(), 2048);
+        assert_eq!(config.timestep_values(), [0, 250, 500, 750]);
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/mod.rs
+++ b/crates/apxinf-model/src/gr00t_n17/mod.rs
@@ -1,0 +1,34 @@
+//! NVIDIA GR00T N1.7 vision-language-action model.
+//!
+//! The family owns its model orchestration, weight names, fixed LIBERO profile,
+//! and CUDA Graph boundary. It shares only model-neutral ApxInf backend and
+//! kernel interfaces with other families.
+
+mod config;
+#[cfg(feature = "cuda")]
+mod action_executor;
+#[cfg(feature = "cuda")]
+mod backbone_executor;
+#[cfg(feature = "cuda")]
+mod vla_runtime;
+mod backbone_weights;
+mod weights;
+
+#[cfg(feature = "cuda")]
+pub use action_executor::GrootN17ActionExecutor;
+#[cfg(feature = "cuda")]
+pub use backbone_executor::GrootN17BackboneExecutor;
+#[cfg(feature = "cuda")]
+pub use vla_runtime::GrootN17VlaRuntime;
+pub use backbone_weights::GrootN17BackboneWeights;
+
+pub use config::{GrootN17Config, GrootN17DiffusionConfig, GrootN17VlSelfAttentionConfig};
+pub use weights::{
+    ActionEncoderWeights, AttentionWeights, CategoryMlpWeights, DitBlockWeights,
+    FeedForwardWeights, GrootN17ActionWeights, LayerNormWeights, LinearWeights, VlBlockWeights,
+};
+
+#[cfg(feature = "cuda")]
+pub(crate) fn register_builtin() {
+    crate::registry::register("Gr00tN1d7-cuda", vla_runtime::load_registered);
+}

--- a/crates/apxinf-model/src/gr00t_n17/vla_runtime.rs
+++ b/crates/apxinf-model/src/gr00t_n17/vla_runtime.rs
@@ -1,0 +1,348 @@
+//! Owning CUDA runtime and whole-model CUDA Graph for GR00T N1.7 LIBERO.
+
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use apxinf_core::{
+    Backend, DType, Device, Error, Graph, NormalGenerator, Result, SamplingBackend, Tensor,
+};
+use apxinf_cuda::buffer::CudaBuffer;
+use apxinf_cuda::kernels::preprocess::{self, ImageLayout as KernelImageLayout};
+use apxinf_cuda::kernels::{self, GraphWorkspace};
+use apxinf_cuda::transfers;
+use apxinf_cuda::CudaBackend;
+
+use crate::accelerator::cuda::downcast_arc;
+use crate::auto::{LoadOptions, LoadedModel, ModelPrecision};
+use crate::vla::{
+    Action, InferenceSpec, InitialLatent, PreparedInference, VisionObservation, VlaRequest,
+    VlaRuntime,
+};
+
+use super::{
+    GrootN17ActionExecutor, GrootN17ActionWeights, GrootN17BackboneExecutor,
+    GrootN17BackboneWeights, GrootN17Config,
+};
+
+const GRAPH_WORKSPACE_BYTES: usize = 3 * 1024 * 1024 * 1024;
+
+pub struct GrootN17VlaRuntime {
+    backend: Arc<CudaBackend>,
+    backbone_weights: Arc<GrootN17BackboneWeights>,
+    action: Arc<GrootN17ActionExecutor>,
+    prepared: RefCell<Option<Rc<GrootPrepared>>>,
+}
+
+struct GrootPrepared {
+    spec: InferenceSpec,
+    backbone: GrootN17BackboneExecutor,
+    graph: Box<dyn Graph>,
+    output: Tensor,
+    patches: Tensor,
+    state: Tensor,
+    noise: Tensor,
+    normal: RefCell<Box<dyn NormalGenerator>>,
+    _raw_images: Option<CudaBuffer>,
+    _text_rows: apxinf_cuda::kernels::elementwise::RowIndices,
+    _image_rows: apxinf_cuda::kernels::elementwise::RowIndices,
+    _workspace: GraphWorkspace,
+    _action: Arc<GrootN17ActionExecutor>,
+}
+
+impl GrootN17VlaRuntime {
+    fn build_prepared(&self, spec: &InferenceSpec) -> Result<GrootPrepared> {
+        let view_count = match spec.token_count {
+            76 => 1,
+            142 => 2,
+            _ => return Err(Error::Other(format!(
+                "GR00T N1.7 requires the 76-token one-view or 142-token two-view patch profile, got {spec:?}"))),
+        };
+        let mut template = vec![0u32; spec.token_count];
+        for row in 4..68 {
+            template[row] = 151655;
+        }
+        if view_count == 2 {
+            for row in 70..134 {
+                template[row] = 151655;
+            }
+        }
+        let backbone = GrootN17BackboneExecutor::new(
+            Arc::clone(&self.backbone_weights),
+            &template,
+            self.backend.device_id(),
+        )?;
+        let patches = self
+            .backend
+            .to_device(&Tensor::zeros((view_count * 256, 1536), DType::BF16))?;
+        let raw_images = spec
+            .image_layout
+            .map(|_| CudaBuffer::alloc(view_count * 256 * 256 * 3, self.backend.device_id()))
+            .transpose()
+            .map_err(Error::Cuda)?;
+        let state = self
+            .backend
+            .to_device(&Tensor::zeros((1, 132), DType::BF16))?;
+        let noise = self
+            .backend
+            .to_device(&Tensor::zeros((40, 132), DType::BF16))?;
+        let normal = self.backend.create_normal_generator(noise.clone())?;
+        let workspace = GraphWorkspace::new(GRAPH_WORKSPACE_BYTES, self.backend.device_id())?;
+        let image_rows = image_rows(self.backend.device_id(), &template)?;
+        let text_rows = text_rows(self.backend.device_id(), &template)?;
+        let execute = || -> Result<Tensor> {
+            if let (Some(images), Some(layout)) = (&raw_images, spec.image_layout) {
+                preprocess::groot_rgb_u8_to_patches_bf16(
+                    self.backend.context(),
+                    images,
+                    &patches,
+                    view_count,
+                    kernel_image_layout(layout),
+                )?;
+            }
+            let features = backbone
+                .forward(self.backend.context(), &patches)
+                .map_err(|error| Error::Other(format!("GR00T backbone execution: {error}")))?;
+            let refined = self
+                .action
+                .refine_backbone(self.backend.context(), &features)
+                .map_err(|error| Error::Other(format!("GR00T VL refinement: {error}")))?;
+            let output = self
+                .action
+                .infer(
+                    self.backend.context(),
+                    &refined,
+                    &state,
+                    &noise,
+                    &text_rows,
+                    &image_rows,
+                    &*self.backend,
+                )
+                .map_err(|error| Error::Other(format!("GR00T action execution: {error}")))?;
+            Ok(output)
+        };
+        let eager = kernels::prepare_with_workspace(&workspace, || execute())?;
+        self.backend.synchronize()?;
+        drop(eager);
+        self.backend.begin_capture()?;
+        let output = match kernels::with_workspace(&workspace, || execute()) {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = self.backend.end_capture();
+                return Err(error);
+            }
+        };
+        let graph = self.backend.end_capture()?;
+        Ok(GrootPrepared {
+            spec: *spec,
+            backbone,
+            graph,
+            output,
+            patches,
+            state,
+            noise,
+            normal: RefCell::new(normal),
+            _raw_images: raw_images,
+            _workspace: workspace,
+            _text_rows: text_rows,
+            _image_rows: image_rows,
+            _action: Arc::clone(&self.action),
+        })
+    }
+}
+
+impl PreparedInference for GrootPrepared {
+    fn spec(&self) -> &InferenceSpec {
+        &self.spec
+    }
+
+    fn run(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        if !self.spec.matches(request.observation) {
+            return Err(Error::Other(
+                "GR00T prepared shape does not match request".into(),
+            ));
+        }
+        match &request.observation.vision {
+            VisionObservation::Patches(value) => {
+                if self._raw_images.is_some() {
+                    return Err(Error::Other(
+                        "GR00T prepared RGB graph received patches".into(),
+                    ));
+                }
+                let patch_rows = if self.spec.token_count == 76 {
+                    256
+                } else {
+                    512
+                };
+                let patches = normalize_cpu(value, [patch_rows, 1536], "patches")?;
+                transfers::copy_cpu_to_cuda(&patches, &self.patches)?;
+            }
+            VisionObservation::RgbU8 { bytes, .. } => {
+                let images = self._raw_images.as_ref().ok_or_else(|| {
+                    Error::Other("GR00T prepared patch graph received RGB".into())
+                })?;
+                if bytes.len() != images.len() {
+                    return Err(Error::Other(format!(
+                        "GR00T RGB input expected {} bytes, got {}",
+                        images.len(),
+                        bytes.len()
+                    )));
+                }
+                images.copy_from_host(bytes).map_err(Error::Cuda)?;
+            }
+        }
+        let state = normalize_cpu(
+            request
+                .state
+                .ok_or_else(|| Error::Other("GR00T inference requires normalized state".into()))?,
+            [1, 132],
+            "state",
+        )?;
+        transfers::copy_cpu_to_cuda(&state, &self.state)?;
+        self.backbone
+            .update_token_ids(&request.observation.token_ids)?;
+        match request.initial_latent {
+            InitialLatent::Provided(value) => {
+                let noise = normalize_cpu(value, [40, 132], "initial latent")?;
+                transfers::copy_cpu_to_cuda(&noise, &self.noise)?;
+            }
+            InitialLatent::Generate { rng } => {
+                self.normal.borrow_mut().generate(rng)?;
+            }
+        }
+        self.graph.replay()?;
+        Ok(Action::new(self.output.clone()))
+    }
+}
+
+impl VlaRuntime for GrootN17VlaRuntime {
+    fn infer(&self, request: &VlaRequest<'_>) -> Result<Action> {
+        let spec = request.observation.inference_spec();
+        let prepared = self
+            .prepared
+            .borrow()
+            .as_ref()
+            .filter(|value| value.spec == spec)
+            .map(Rc::clone);
+        let prepared = if let Some(value) = prepared {
+            value
+        } else {
+            self.prepared.borrow_mut().take();
+            let value = Rc::new(self.build_prepared(&spec)?);
+            *self.prepared.borrow_mut() = Some(Rc::clone(&value));
+            value
+        };
+        prepared.run(request)
+    }
+
+    fn prepare(&self, spec: &InferenceSpec) -> Result<Box<dyn PreparedInference>> {
+        Ok(Box::new(self.build_prepared(spec)?))
+    }
+
+    fn infer_host_f32(&self, request: &VlaRequest<'_>) -> Result<Vec<f32>> {
+        let action = self.infer(request)?;
+        self.backend.to_cpu(action.tensor())?.to_f32_vec()
+    }
+}
+
+pub(crate) fn load_registered(
+    path: &Path,
+    device: Device,
+    backend: Arc<dyn Backend>,
+    options: &LoadOptions,
+) -> Result<LoadedModel> {
+    if !matches!(device, Device::Cuda(_)) {
+        return Err(Error::Other("GR00T requires CUDA".into()));
+    }
+    if !matches!(
+        options.precision,
+        ModelPrecision::Auto | ModelPrecision::Bf16
+    ) {
+        return Err(Error::Other(
+            "GR00T N1.7 currently requires BF16 precision".into(),
+        ));
+    }
+    let backend =
+        downcast_arc(backend).ok_or_else(|| Error::Other("GR00T requires CudaBackend".into()))?;
+    let root = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(Path::new("."))
+    };
+    let config = Arc::new(GrootN17Config::from_json_file(&root.join("config.json"))?);
+    let (mut tensors, _) = apxinf_loader::safetensors::load_native_path(path)
+        .map_err(|error| Error::Other(format!("load GR00T checkpoint: {error}")))?;
+    let backbone_weights =
+        Arc::new(GrootN17BackboneWeights::from_map(&mut tensors)?.to_device(&*backend)?);
+    let action_weights =
+        Arc::new(GrootN17ActionWeights::from_map(&config, &mut tensors)?.to_device(&*backend)?);
+    let action = Arc::new(GrootN17ActionExecutor::new(
+        Arc::clone(&config),
+        action_weights,
+        &*backend,
+        &backend,
+    )?);
+    Ok(LoadedModel::Vla(Box::new(GrootN17VlaRuntime {
+        backend,
+        backbone_weights,
+        action,
+        prepared: RefCell::new(None),
+    })))
+}
+
+fn normalize_cpu<const N: usize>(
+    tensor: &Tensor,
+    shape: [usize; N],
+    label: &str,
+) -> Result<Tensor> {
+    if tensor.device() != Device::Cpu || tensor.shape().dims() != shape {
+        return Err(Error::Other(format!(
+            "GR00T {label} must be CPU {:?}, got {:?} on {}",
+            shape,
+            tensor.shape().dims(),
+            tensor.device()
+        )));
+    }
+    if tensor.dtype() == DType::BF16 {
+        return Ok(tensor.clone());
+    }
+    Tensor::from_bf16(
+        shape.to_vec(),
+        &tensor
+            .to_f32_vec()?
+            .into_iter()
+            .map(half::bf16::from_f32)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn image_rows(
+    device: usize,
+    tokens: &[u32],
+) -> Result<apxinf_cuda::kernels::elementwise::RowIndices> {
+    let rows = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &token)| (token == 151655).then_some(index as u32))
+        .collect::<Vec<_>>();
+    apxinf_cuda::kernels::elementwise::RowIndices::new(device, &rows)
+}
+fn text_rows(
+    device: usize,
+    tokens: &[u32],
+) -> Result<apxinf_cuda::kernels::elementwise::RowIndices> {
+    let rows = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &token)| (token != 151655).then_some(index as u32))
+        .collect::<Vec<_>>();
+    apxinf_cuda::kernels::elementwise::RowIndices::new(device, &rows)
+}
+
+fn kernel_image_layout(layout: crate::vla::ImageLayout) -> KernelImageLayout {
+    match layout {
+        crate::vla::ImageLayout::Nhwc => KernelImageLayout::Nhwc,
+        crate::vla::ImageLayout::Nchw => KernelImageLayout::Nchw,
+    }
+}

--- a/crates/apxinf-model/src/gr00t_n17/weights.rs
+++ b/crates/apxinf-model/src/gr00t_n17/weights.rs
@@ -1,0 +1,398 @@
+//! Typed GR00T action-head weights.
+//!
+//! Hugging Face `nn.Linear` tensors are `[out, in]`; native GEMMs consume
+//! `[in, out]`. Category-specific tensors are already `[category, in, out]`,
+//! so the fixed LIBERO category is sliced without transposition.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use apxinf_core::{Backend, DType, Error, Result, Tensor};
+
+use super::GrootN17Config;
+
+#[derive(Debug)]
+pub struct LinearWeights {
+    pub weight: Tensor,
+    pub bias: Option<Tensor>,
+}
+
+#[derive(Debug)]
+pub struct LayerNormWeights {
+    pub weight: Tensor,
+    pub bias: Tensor,
+}
+
+#[derive(Debug)]
+pub struct AttentionWeights {
+    pub q: LinearWeights,
+    pub k: LinearWeights,
+    pub v: LinearWeights,
+    pub output: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct FeedForwardWeights {
+    pub input: LinearWeights,
+    pub output: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct VlBlockWeights {
+    pub norm1: LayerNormWeights,
+    pub attention: AttentionWeights,
+    pub norm3: LayerNormWeights,
+    pub feed_forward: FeedForwardWeights,
+}
+
+#[derive(Debug)]
+pub struct DitBlockWeights {
+    /// Timestep conditioning projection `[1536, 3072]`.
+    pub ada_norm: LinearWeights,
+    pub attention: AttentionWeights,
+    pub feed_forward: FeedForwardWeights,
+}
+
+#[derive(Debug)]
+pub struct CategoryMlpWeights {
+    pub layer1: LinearWeights,
+    pub layer2: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct ActionEncoderWeights {
+    pub w1: LinearWeights,
+    pub w2: LinearWeights,
+    pub w3: LinearWeights,
+}
+
+#[derive(Debug)]
+pub struct GrootN17ActionWeights {
+    pub vlln: LayerNormWeights,
+    pub vl_blocks: Vec<VlBlockWeights>,
+    pub state_encoder: CategoryMlpWeights,
+    pub action_encoder: ActionEncoderWeights,
+    pub position_embedding: Tensor,
+    pub timestep_in: LinearWeights,
+    pub timestep_out: LinearWeights,
+    pub dit_blocks: Vec<DitBlockWeights>,
+    pub final_condition: LinearWeights,
+    pub final_projection: LinearWeights,
+    pub action_decoder: CategoryMlpWeights,
+}
+
+impl GrootN17ActionWeights {
+    pub fn from_safetensors(config: &GrootN17Config, path: &Path) -> Result<Self> {
+        let (mut tensors, _) = apxinf_loader::safetensors::load_native_path(path)
+            .map_err(|error| Error::Other(format!("load GR00T SafeTensors: {error}")))?;
+        Self::from_map(config, &mut tensors)
+    }
+
+    pub fn from_map(
+        config: &GrootN17Config,
+        tensors: &mut HashMap<String, Tensor>,
+    ) -> Result<Self> {
+        config.validate()?;
+        let root = "action_head";
+        let mut vl_blocks = Vec::with_capacity(config.vl_self_attention_cfg.num_layers);
+        for index in 0..config.vl_self_attention_cfg.num_layers {
+            let prefix = format!("{root}.vl_self_attention.transformer_blocks.{index}");
+            vl_blocks.push(VlBlockWeights {
+                norm1: take_layer_norm(tensors, &format!("{prefix}.norm1"))?,
+                attention: take_attention(tensors, &prefix)?,
+                norm3: take_layer_norm(tensors, &format!("{prefix}.norm3"))?,
+                feed_forward: take_feed_forward(tensors, &prefix)?,
+            });
+        }
+
+        let mut dit_blocks = Vec::with_capacity(config.diffusion_model_cfg.num_layers);
+        for index in 0..config.diffusion_model_cfg.num_layers {
+            let prefix = format!("{root}.model.transformer_blocks.{index}");
+            dit_blocks.push(DitBlockWeights {
+                ada_norm: take_linear(tensors, &format!("{prefix}.norm1.linear"), true)?,
+                attention: take_attention(tensors, &prefix)?,
+                feed_forward: take_feed_forward(tensors, &prefix)?,
+            });
+        }
+
+        Ok(Self {
+            vlln: take_layer_norm(tensors, &format!("{root}.vlln"))?,
+            vl_blocks,
+            state_encoder: take_category_mlp(
+                tensors,
+                &format!("{root}.state_encoder"),
+                GrootN17Config::LIBERO_EMBODIMENT_ID,
+            )?,
+            action_encoder: ActionEncoderWeights {
+                w1: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W1"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+                w2: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W2"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+                w3: take_category_linear(
+                    tensors,
+                    &format!("{root}.action_encoder.W3"),
+                    GrootN17Config::LIBERO_EMBODIMENT_ID,
+                )?,
+            },
+            position_embedding: take_leading_rows(
+                &take(tensors, &format!("{root}.position_embedding.weight"))?,
+                config.action_horizon,
+            )?,
+            timestep_in: take_linear(
+                tensors,
+                &format!("{root}.model.timestep_encoder.timestep_embedder.linear_1"),
+                true,
+            )?,
+            timestep_out: take_linear(
+                tensors,
+                &format!("{root}.model.timestep_encoder.timestep_embedder.linear_2"),
+                true,
+            )?,
+            dit_blocks,
+            final_condition: take_linear(tensors, &format!("{root}.model.proj_out_1"), true)?,
+            final_projection: take_linear(tensors, &format!("{root}.model.proj_out_2"), true)?,
+            action_decoder: take_category_mlp(
+                tensors,
+                &format!("{root}.action_decoder"),
+                GrootN17Config::LIBERO_EMBODIMENT_ID,
+            )?,
+        })
+    }
+
+    pub fn to_device(mut self, backend: &dyn Backend) -> Result<Self> {
+        upload_norm(&mut self.vlln, backend)?;
+        for block in &mut self.vl_blocks {
+            upload_norm(&mut block.norm1, backend)?;
+            upload_attention(&mut block.attention, backend)?;
+            upload_norm(&mut block.norm3, backend)?;
+            upload_feed_forward(&mut block.feed_forward, backend)?;
+        }
+        upload_category_mlp(&mut self.state_encoder, backend)?;
+        upload_linear(&mut self.action_encoder.w1, backend)?;
+        upload_linear(&mut self.action_encoder.w2, backend)?;
+        upload_linear(&mut self.action_encoder.w3, backend)?;
+        self.position_embedding = backend.to_device(&self.position_embedding)?;
+        upload_linear(&mut self.timestep_in, backend)?;
+        upload_linear(&mut self.timestep_out, backend)?;
+        for block in &mut self.dit_blocks {
+            upload_linear(&mut block.ada_norm, backend)?;
+            upload_attention(&mut block.attention, backend)?;
+            upload_feed_forward(&mut block.feed_forward, backend)?;
+        }
+        upload_linear(&mut self.final_condition, backend)?;
+        upload_linear(&mut self.final_projection, backend)?;
+        upload_category_mlp(&mut self.action_decoder, backend)?;
+        Ok(self)
+    }
+}
+
+pub(super) fn upload_linear(linear: &mut LinearWeights, backend: &dyn Backend) -> Result<()> {
+    linear.weight = backend.to_device(&linear.weight)?;
+    if let Some(bias) = &linear.bias {
+        linear.bias = Some(backend.to_device(bias)?);
+    }
+    Ok(())
+}
+
+fn upload_norm(norm: &mut LayerNormWeights, backend: &dyn Backend) -> Result<()> {
+    norm.weight = backend.to_device(&norm.weight)?;
+    norm.bias = backend.to_device(&norm.bias)?;
+    Ok(())
+}
+
+fn upload_attention(attention: &mut AttentionWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut attention.q, backend)?;
+    upload_linear(&mut attention.k, backend)?;
+    upload_linear(&mut attention.v, backend)?;
+    upload_linear(&mut attention.output, backend)
+}
+
+fn upload_feed_forward(feed_forward: &mut FeedForwardWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut feed_forward.input, backend)?;
+    upload_linear(&mut feed_forward.output, backend)
+}
+
+fn upload_category_mlp(mlp: &mut CategoryMlpWeights, backend: &dyn Backend) -> Result<()> {
+    upload_linear(&mut mlp.layer1, backend)?;
+    upload_linear(&mut mlp.layer2, backend)
+}
+
+fn take_attention(tensors: &mut HashMap<String, Tensor>, prefix: &str) -> Result<AttentionWeights> {
+    Ok(AttentionWeights {
+        q: take_linear(tensors, &format!("{prefix}.attn1.to_q"), true)?,
+        k: take_linear(tensors, &format!("{prefix}.attn1.to_k"), true)?,
+        v: take_linear(tensors, &format!("{prefix}.attn1.to_v"), true)?,
+        output: take_linear(tensors, &format!("{prefix}.attn1.to_out.0"), true)?,
+    })
+}
+
+fn take_feed_forward(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+) -> Result<FeedForwardWeights> {
+    Ok(FeedForwardWeights {
+        input: take_linear(tensors, &format!("{prefix}.ff.net.0.proj"), true)?,
+        output: take_linear(tensors, &format!("{prefix}.ff.net.2"), true)?,
+    })
+}
+
+fn take_category_mlp(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    category: usize,
+) -> Result<CategoryMlpWeights> {
+    Ok(CategoryMlpWeights {
+        layer1: take_category_linear(tensors, &format!("{prefix}.layer1"), category)?,
+        layer2: take_category_linear(tensors, &format!("{prefix}.layer2"), category)?,
+    })
+}
+
+fn take_layer_norm(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+) -> Result<LayerNormWeights> {
+    Ok(LayerNormWeights {
+        weight: take(tensors, &format!("{prefix}.weight"))?,
+        bias: take(tensors, &format!("{prefix}.bias"))?,
+    })
+}
+
+fn take_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    bias: bool,
+) -> Result<LinearWeights> {
+    let weight = transpose_2d(&take(tensors, &format!("{prefix}.weight"))?)?;
+    let bias = bias
+        .then(|| take(tensors, &format!("{prefix}.bias")))
+        .transpose()?;
+    Ok(LinearWeights { weight, bias })
+}
+
+fn take_category_linear(
+    tensors: &mut HashMap<String, Tensor>,
+    prefix: &str,
+    category: usize,
+) -> Result<LinearWeights> {
+    let weight = select_category(&take(tensors, &format!("{prefix}.W"))?, category)?;
+    let bias = select_category(&take(tensors, &format!("{prefix}.b"))?, category)?;
+    Ok(LinearWeights {
+        weight,
+        bias: Some(bias),
+    })
+}
+
+pub(super) fn take(tensors: &mut HashMap<String, Tensor>, name: &str) -> Result<Tensor> {
+    tensors
+        .remove(name)
+        .ok_or_else(|| Error::Other(format!("missing GR00T tensor `{name}`")))
+}
+
+fn select_category(tensor: &Tensor, category: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() < 2 || category >= dims[0] {
+        return Err(Error::Other(format!(
+            "category {category} is invalid for shape {dims:?}"
+        )));
+    }
+    let category_elements: usize = dims[1..].iter().product();
+    let output_shape = dims[1..].to_vec();
+    match tensor.dtype() {
+        DType::BF16 => {
+            let values = tensor.as_bf16()?;
+            let start = category * category_elements;
+            Tensor::from_bf16(output_shape, &values[start..start + category_elements])
+        }
+        DType::F32 => {
+            let values = tensor.as_f32()?;
+            let start = category * category_elements;
+            Tensor::from_f32(output_shape, &values[start..start + category_elements])
+        }
+        dtype => Err(Error::Other(format!(
+            "GR00T category weights require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+fn take_leading_rows(tensor: &Tensor, rows: usize) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() != 2 || rows > dims[0] {
+        return Err(Error::Other(format!(
+            "cannot take {rows} leading rows from shape {dims:?}"
+        )));
+    }
+    let cols = dims[1];
+    match tensor.dtype() {
+        DType::BF16 => Tensor::from_bf16(vec![rows, cols], &tensor.as_bf16()?[..rows * cols]),
+        DType::F32 => Tensor::from_f32(vec![rows, cols], &tensor.as_f32()?[..rows * cols]),
+        dtype => Err(Error::Other(format!(
+            "GR00T leading rows require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+pub(super) fn transpose_2d(tensor: &Tensor) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() != 2 {
+        return Err(Error::Other(format!(
+            "GR00T linear weight must be 2D, got {dims:?}"
+        )));
+    }
+    let (rows, cols) = (dims[0], dims[1]);
+    match tensor.dtype() {
+        DType::BF16 => {
+            let input = tensor.as_bf16()?;
+            let mut output = vec![half::bf16::from_f32(0.0); input.len()];
+            for row in 0..rows {
+                for col in 0..cols {
+                    output[col * rows + row] = input[row * cols + col];
+                }
+            }
+            Tensor::from_bf16(vec![cols, rows], &output)
+        }
+        DType::F32 => {
+            let input = tensor.as_f32()?;
+            let mut output = vec![0.0; input.len()];
+            for row in 0..rows {
+                for col in 0..cols {
+                    output[col * rows + row] = input[row * cols + col];
+                }
+            }
+            Tensor::from_f32(vec![cols, rows], &output)
+        }
+        dtype => Err(Error::Other(format!(
+            "GR00T linear weights require BF16/F32, got {dtype}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use apxinf_core::Tensor;
+    use half::bf16;
+
+    use super::{select_category, transpose_2d};
+
+    #[test]
+    fn category_slice_preserves_in_out_layout() {
+        let values = (0..24).map(|value| bf16::from_f32(value as f32)).collect::<Vec<_>>();
+        let tensor = Tensor::from_bf16(vec![2, 3, 4], &values).unwrap();
+        let selected = select_category(&tensor, 1).unwrap();
+        assert_eq!(selected.shape().dims(), [3, 4]);
+        assert_eq!(selected.to_f32_vec().unwrap(), (12..24).map(|v| v as f32).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn transposes_hugging_face_linear_weight() {
+        let tensor = Tensor::from_f32(vec![2, 3], &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        let transposed = transpose_2d(&tensor).unwrap();
+        assert_eq!(transposed.shape().dims(), [3, 2]);
+        assert_eq!(transposed.as_f32().unwrap(), &[0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+    }
+}

--- a/crates/apxinf-model/src/lib.rs
+++ b/crates/apxinf-model/src/lib.rs
@@ -4,6 +4,7 @@ mod accelerator;
 pub mod builtin;
 pub mod debug;
 mod generation_config;
+pub mod gr00t_n17;
 pub mod llama;
 pub mod llm_trait;
 pub mod registry;
@@ -16,6 +17,7 @@ pub mod vla;
 pub use builtin::register_builtin_models;
 pub use debug::{DebugCapture, DebugConfig};
 pub use generation_config::{GenerationConfigSource, GenerationOptions, SamplingMode};
+pub use gr00t_n17::GrootN17Config;
 pub use llama::{GeneralLlama, LlamaModel, LlamaWeights, TransformerLayer, KVCache};
 pub use llm_trait::{
     generate_streaming, generate_streaming_with_options, GeneratedToken, GenerationOutput,

--- a/crates/apxinf-model/src/vla/mod.rs
+++ b/crates/apxinf-model/src/vla/mod.rs
@@ -61,6 +61,8 @@ pub enum InitialLatent<'a> {
 pub struct VlaRequest<'a> {
     pub observation: &'a Observation,
     pub initial_latent: InitialLatent<'a>,
+    /// Optional normalized proprioceptive state for state-conditioned VLAs.
+    pub state: Option<&'a Tensor>,
 }
 
 impl<'a> VlaRequest<'a> {
@@ -68,6 +70,7 @@ impl<'a> VlaRequest<'a> {
         Self {
             observation,
             initial_latent: InitialLatent::Generate { rng },
+            state: None,
         }
     }
 
@@ -75,7 +78,13 @@ impl<'a> VlaRequest<'a> {
         Self {
             observation,
             initial_latent: InitialLatent::Provided(latent),
+            state: None,
         }
+    }
+
+    pub const fn with_state(mut self, state: &'a Tensor) -> Self {
+        self.state = Some(state);
+        self
     }
 }
 

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -43,6 +43,46 @@ use apxinf_model::{
     SyntheticWeights, VisionObservation, VlaRequest,
 };
 
+#[derive(Clone)]
+struct RuntimeShape {
+    num_views: usize,
+    image_size: usize,
+    patch_size: usize,
+    action_horizon: usize,
+    action_dim: usize,
+    max_token_len: usize,
+    groot: bool,
+}
+
+impl RuntimeShape {
+    fn from_pi(config: &Pi05Config) -> Self {
+        Self {
+            num_views: config.num_views,
+            image_size: config.image_size,
+            patch_size: config.patch_size,
+            action_horizon: config.action_horizon,
+            action_dim: config.action_dim,
+            max_token_len: config.max_token_len,
+            groot: false,
+        }
+    }
+    fn groot(num_views: usize) -> Self {
+        Self {
+            num_views,
+            image_size: 256,
+            patch_size: 16,
+            action_horizon: 40,
+            action_dim: 132,
+            max_token_len: 142,
+            groot: true,
+        }
+    }
+    fn patches_per_view(&self) -> usize {
+        let side = self.image_size / self.patch_size;
+        side * side
+    }
+}
+
 /// Map any Rust error into a Python `RuntimeError`.
 fn runtime_err<E: std::fmt::Display>(error: E) -> PyErr {
     PyRuntimeError::new_err(error.to_string())
@@ -117,7 +157,7 @@ fn load_config(checkpoint: &Path) -> PyResult<Pi05Config> {
 #[pyclass(unsendable)]
 pub struct Model {
     model: LoadedModel,
-    config: Pi05Config,
+    config: RuntimeShape,
     device: Device,
     sampling_seed: Cell<u64>,
     sampling_draw: Cell<u64>,
@@ -129,7 +169,8 @@ impl Model {
     }
 
     fn patch_width(&self) -> usize {
-        3 * self.config.patch_size * self.config.patch_size
+        let temporal_patch = if self.config.groot { 2 } else { 1 };
+        temporal_patch * 3 * self.config.patch_size * self.config.patch_size
     }
 
     fn validate_tokens(&self, token_ids: &[u32]) -> PyResult<()> {
@@ -162,11 +203,7 @@ impl Model {
         let data = noise.as_slice().map_err(|_| {
             PyValueError::new_err("apxinf_py.infer: noise must be C-contiguous float32")
         })?;
-        Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            data,
-        )
-        .map_err(runtime_err)
+        Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), data).map_err(runtime_err)
     }
 
     fn action_array<'py>(
@@ -210,8 +247,12 @@ impl Model {
         py: Python<'py>,
         observation: Observation,
         latent: Tensor,
+        state: Option<Tensor>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
-        let request = VlaRequest::provided(&observation, &latent);
+        let mut request = VlaRequest::provided(&observation, &latent);
+        if let Some(value) = state.as_ref() {
+            request = request.with_state(value);
+        }
         let flat = self.model.infer_host_f32(&request).map_err(runtime_err)?;
         self.action_array(py, flat)
     }
@@ -223,8 +264,12 @@ impl Model {
         py: Python<'py>,
         observation: Observation,
         rng: RngKey,
+        state: Option<Tensor>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
-        let request = VlaRequest::generated(&observation, rng);
+        let mut request = VlaRequest::generated(&observation, rng);
+        if let Some(value) = state.as_ref() {
+            request = request.with_state(value);
+        }
         let flat = self.model.infer_host_f32(&request).map_err(runtime_err)?;
         self.action_array(py, flat)
     }
@@ -268,44 +313,64 @@ impl Model {
         sampling_seed: u64,
     ) -> PyResult<Self> {
         let device = parse_device(device)?;
-        let mut config = load_config(&path)?;
+        let is_groot = model.eq_ignore_ascii_case("Gr00tN1d7");
+        if is_groot && action_horizon.is_some() {
+            return Err(PyValueError::new_err(
+                "apxinf_py.load: GR00T N1.7 architecture overrides are unsupported",
+            ));
+        }
+        let groot_views = num_views.unwrap_or(2);
+        if is_groot && !matches!(groot_views, 1 | 2) {
+            return Err(PyValueError::new_err(
+                "apxinf_py.load: GR00T N1.7 num_views must be 1 or 2",
+            ));
+        }
         // Only hand the loader an explicit config when the caller actually
         // overrode something; otherwise it reads `config.json` itself, exactly
-        // as before.
+        // as before. GR00T owns a fixed architecture contract instead.
+        let mut pi_config = if is_groot {
+            Pi05Config::default()
+        } else {
+            load_config(&path)?
+        };
         let mut overridden = false;
         if let Some(horizon) = action_horizon {
-            config.action_horizon = horizon;
+            pi_config.action_horizon = horizon;
             overridden = true;
         }
         if let Some(views) = num_views {
-            if views == 0 || views > config.num_views {
+            if views == 0 || views > pi_config.num_views {
                 return Err(PyValueError::new_err(format!(
                     "apxinf_py.load: num_views={views} must be in 1..={} (the \
                      checkpoint's view count); a checkpoint cannot serve more \
                      cameras than it was trained on",
-                    config.num_views
+                    pi_config.num_views
                 )));
             }
-            config.num_views = views;
+            pi_config.num_views = views;
             overridden = true;
         }
         // Validate once, after every override, so a combination that is
         // individually valid but jointly is not still fails here.
         if overridden {
-            config.validate().map_err(runtime_err)?;
+            pi_config.validate().map_err(runtime_err)?;
         }
         let options = LoadOptions {
             model_name: Some(model.to_owned()),
             precision: parse_precision(precision)?,
             calibration_path: calibration,
             tuning_path: tactics,
-            config: overridden.then(|| config.clone()),
+            config: (!is_groot && overridden).then(|| pi_config.clone()),
             ..LoadOptions::default()
         };
         let loaded = AutoModel::load_model(device, &path, &options).map_err(runtime_err)?;
         Ok(Self {
             model: loaded,
-            config,
+            config: if is_groot {
+                RuntimeShape::groot(groot_views)
+            } else {
+                RuntimeShape::from_pi(&pi_config)
+            },
             device,
             sampling_seed: Cell::new(sampling_seed),
             sampling_draw: Cell::new(0),
@@ -396,11 +461,10 @@ impl Model {
             uniform_fp8_scale,
             ..LoadOptions::default()
         };
-        let loaded = AutoModel::load_model(device, Path::new(""), &options)
-            .map_err(runtime_err)?;
+        let loaded = AutoModel::load_model(device, Path::new(""), &options).map_err(runtime_err)?;
         Ok(Self {
             model: loaded,
-            config,
+            config: RuntimeShape::from_pi(&config),
             device,
             sampling_seed: Cell::new(sampling_seed),
             sampling_draw: Cell::new(0),
@@ -417,13 +481,14 @@ impl Model {
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
-    #[pyo3(name = "_infer_patches", signature = (patches, token_ids, noise=None))]
+    #[pyo3(name = "_infer_patches", signature = (patches, token_ids, noise=None, state=None))]
     fn infer_patches<'py>(
         &self,
         py: Python<'py>,
         patches: PyReadonlyArray2<'py, f32>,
         token_ids: PyReadonlyArray1<'py, u32>,
         noise: Option<PyReadonlyArray2<'py, f32>>,
+        state: Option<PyReadonlyArray2<'py, f32>>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
         let expected = [self.patch_rows(), self.patch_width()];
         let shape = patches.shape();
@@ -439,27 +504,52 @@ impl Model {
         let tokens = token_ids
             .as_slice()
             .map_err(|_| {
-                PyValueError::new_err("apxinf_py._infer_patches: token_ids must be C-contiguous uint32")
+                PyValueError::new_err(
+                    "apxinf_py._infer_patches: token_ids must be C-contiguous uint32",
+                )
             })?
             .to_vec();
         self.validate_tokens(&tokens)?;
 
-        let patch_tensor = Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            patch_data,
-        )
-        .map_err(runtime_err)?;
+        let patch_tensor = Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), patch_data)
+            .map_err(runtime_err)?;
 
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
         };
+        let state = match state {
+            Some(value) => {
+                if value.shape() != [1, 132] {
+                    return Err(PyValueError::new_err(
+                        "apxinf_py._infer_patches: GR00T state must have shape [1,132]",
+                    ));
+                }
+                Some(
+                    Tensor::from_f32(
+                        (1, 132),
+                        value.as_slice().map_err(|_| {
+                            PyValueError::new_err(
+                                "apxinf_py._infer_patches: state must be contiguous float32",
+                            )
+                        })?,
+                    )
+                    .map_err(runtime_err)?,
+                )
+            }
+            None => None,
+        };
+        if self.config.groot && state.is_none() {
+            return Err(PyValueError::new_err(
+                "apxinf_py._infer_patches: GR00T requires state",
+            ));
+        }
         match noise {
             Some(noise) => {
                 let noise_tensor = self.noise_tensor(noise)?;
-                self.run_provided(py, observation, noise_tensor)
+                self.run_provided(py, observation, noise_tensor, state)
             }
-            None => self.run_generated(py, observation, self.next_sampling_rng()?),
+            None => self.run_generated(py, observation, self.next_sampling_rng()?, state),
         }
     }
 
@@ -497,16 +587,13 @@ impl Model {
             })?
             .to_vec();
         self.validate_tokens(&tokens)?;
-        let patch_tensor = Tensor::from_f32(
-            Shape::new(vec![expected[0], expected[1]]),
-            patch_data,
-        )
-        .map_err(runtime_err)?;
+        let patch_tensor = Tensor::from_f32(Shape::new(vec![expected[0], expected[1]]), patch_data)
+            .map_err(runtime_err)?;
         let observation = Observation {
             vision: VisionObservation::Patches(patch_tensor),
             token_ids: tokens,
         };
-        self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
+        self.run_generated(py, observation, RngKey::new(seed, sequence, draw), None)
     }
 
     /// **L1** — infer from resized RGB `uint8` images; vision→patches runs in the
@@ -520,7 +607,7 @@ impl Model {
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
-    #[pyo3(signature = (rgb_u8, layout, token_ids, noise=None))]
+    #[pyo3(signature = (rgb_u8, layout, token_ids, noise=None, state=None))]
     fn infer_rgb<'py>(
         &self,
         py: Python<'py>,
@@ -528,6 +615,7 @@ impl Model {
         layout: &str,
         token_ids: PyReadonlyArray1<'py, u32>,
         noise: Option<PyReadonlyArray2<'py, f32>>,
+        state: Option<PyReadonlyArray2<'py, f32>>,
     ) -> PyResult<Bound<'py, PyArray2<f32>>> {
         let layout = parse_layout(layout)?;
         let expected_bytes =
@@ -559,12 +647,38 @@ impl Model {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
         };
+        let state = match state {
+            Some(value) => {
+                if value.shape() != [1, 132] {
+                    return Err(PyValueError::new_err(
+                        "apxinf_py.infer_rgb: GR00T state must have shape [1,132]",
+                    ));
+                }
+                Some(
+                    Tensor::from_f32(
+                        (1, 132),
+                        value.as_slice().map_err(|_| {
+                            PyValueError::new_err(
+                                "apxinf_py.infer_rgb: state must be contiguous float32",
+                            )
+                        })?,
+                    )
+                    .map_err(runtime_err)?,
+                )
+            }
+            None => None,
+        };
+        if self.config.groot && state.is_none() {
+            return Err(PyValueError::new_err(
+                "apxinf_py.infer_rgb: GR00T requires state",
+            ));
+        }
         match noise {
             Some(noise) => {
                 let noise_tensor = self.noise_tensor(noise)?;
-                self.run_provided(py, observation, noise_tensor)
+                self.run_provided(py, observation, noise_tensor, state)
             }
-            None => self.run_generated(py, observation, self.next_sampling_rng()?),
+            None => self.run_generated(py, observation, self.next_sampling_rng()?, state),
         }
     }
 
@@ -615,7 +729,7 @@ impl Model {
             vision: VisionObservation::RgbU8 { bytes, layout },
             token_ids: tokens,
         };
-        self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
+        self.run_generated(py, observation, RngKey::new(seed, sequence, draw), None)
     }
 
     /// Reset the implicit device-side sampling stream used when `noise=None`.

--- a/python/apxinf/apxinf/__init__.py
+++ b/python/apxinf/apxinf/__init__.py
@@ -34,7 +34,7 @@ policy's ``from_pretrained`` pull in the ``apxinf_py`` binding.
 from __future__ import annotations
 
 from . import processors
-from .policies import AutoPolicy, Pi05Policy, Policy
+from .policies import AutoPolicy, GrootN17Policy, Pi05Policy, Policy
 from .robots import (
     ROBOT_PRESETS,
     RobotPreset,
@@ -60,6 +60,7 @@ __all__ = [
     "Policy",
     # L2 policies
     "Pi05Policy",
+    "GrootN17Policy",
     "AutoPolicy",
     # robot adapters
     "build_unitree_g1_policy",

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -28,7 +28,7 @@ from .base import BareModel, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
-from .impls import Pi05Policy
+from .impls import GrootN17Policy, Pi05Policy
 
 __all__ = [
     "Policy",
@@ -38,5 +38,5 @@ __all__ = [
     "get_policy",
     "available_policies",
     "Pi05Policy",
+    "GrootN17Policy",
 ]
-

--- a/python/apxinf/apxinf/policies/impls/__init__.py
+++ b/python/apxinf/apxinf/policies/impls/__init__.py
@@ -18,5 +18,6 @@ inside ``from_pretrained``, so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .pi05 import Pi05Policy
+from .groot_n17 import GrootN17Policy
 
-__all__ = ["Pi05Policy"]
+__all__ = ["Pi05Policy", "GrootN17Policy"]

--- a/python/apxinf/apxinf/policies/impls/groot_n17.py
+++ b/python/apxinf/apxinf/policies/impls/groot_n17.py
@@ -1,0 +1,167 @@
+"""Native ApxInf policy for the frozen NVIDIA GR00T N1.7 LIBERO profile."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+
+from ..registry import register_policy
+from ...processors.transforms import lookup_key
+
+__all__ = ["GrootN17Policy"]
+
+_IMAGE_TOKEN = 151655
+_STATE_KEYS = ("x", "y", "z", "roll", "pitch", "yaw", "gripper")
+_ACTION_KEYS = ("x", "y", "z", "roll", "pitch", "yaw", "gripper")
+
+
+@register_policy("Gr00tN1d7")
+class GrootN17Policy:
+    """One- or two-view LIBERO policy backed only by ApxInf CUDA execution."""
+
+    def __init__(self, model, tokenizer, statistics: Mapping, *,
+                 image_keys: Sequence[str] = ("observation/image", "observation/wrist_image"),
+                 state_prefix: str = "observation/state", prompt_key: str = "prompt"):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.statistics = statistics
+        self.image_keys = tuple(image_keys)
+        if len(self.image_keys) not in (1, 2):
+            raise ValueError("GrootN17Policy requires one or two image keys")
+        self.state_prefix = state_prefix.rstrip("/")
+        self.prompt_key = prompt_key
+        self.metadata = {"model_type": "Gr00tN1d7", "action_horizon": 16,
+            "action_dim": 7, "model_action_horizon": 40, "model_action_dim": 132,
+            "num_views": len(self.image_keys), "image_size": [256, 256],
+            "image_keys": list(self.image_keys),
+            "prompt_key": prompt_key, "state_keys": list(_STATE_KEYS),
+            "precision": "bf16", "cuda_graph": "whole-model"}
+
+    @classmethod
+    def from_pretrained(cls, model_dir, *, backbone_dir=None, model=None,
+                        device="cuda:0", precision="bf16", image_keys=None,
+                        state_prefix="observation/state", prompt_key="prompt", seed=0, **kwargs):
+        if kwargs:
+            raise TypeError(f"unsupported GR00T policy options: {sorted(kwargs)}")
+        model_dir = Path(model_dir)
+        if model is None:
+            import apxinf_py
+            selected_keys = tuple(image_keys or ("observation/image", "observation/wrist_image"))
+            model = apxinf_py.Model.load("Gr00tN1d7", model_dir, device=device,
+                                         precision=precision, num_views=len(selected_keys),
+                                         sampling_seed=int(seed))
+        tokenizer_root = Path(backbone_dir) if backbone_dir is not None else model_dir
+        try:
+            from tokenizers import Tokenizer
+        except ImportError as exc:
+            raise ImportError("GrootN17Policy requires `pip install apxinf[groot]`") from exc
+        tokenizer_file = tokenizer_root / "tokenizer.json"
+        if not tokenizer_file.is_file():
+            raise FileNotFoundError(
+                f"GR00T tokenizer not found at {tokenizer_file}; pass backbone_dir=Cosmos-Reason2-2B")
+        tokenizer = Tokenizer.from_file(str(tokenizer_file))
+        stats_path = model_dir / "statistics.json"
+        statistics = json.loads(stats_path.read_text())["libero_sim"]
+        return cls(model, tokenizer, statistics,
+                   image_keys=image_keys or ("observation/image", "observation/wrist_image"),
+                   state_prefix=state_prefix, prompt_key=prompt_key)
+
+    def infer(self, observation: Mapping, *, noise: np.ndarray | None = None):
+        started = time.perf_counter()
+        missing = [key for key in (*self.image_keys, self.prompt_key)
+                   if not _has_key(observation, key)]
+        if missing:
+            raise KeyError(f"GrootN17Policy missing observation keys: {missing}")
+        images = np.ascontiguousarray(
+            np.stack([_prepare_image(lookup_key(observation, key)) for key in self.image_keys]),
+            dtype=np.uint8,
+        )
+        prompt = str(lookup_key(observation, self.prompt_key))
+        token_ids = self._token_ids(prompt)
+        state = self._state(observation)
+        model_started = time.perf_counter()
+        normalized = self.model.infer_rgb(
+            images,
+            "nhwc",
+            np.asarray(token_ids, dtype=np.uint32),
+            **({"noise": np.ascontiguousarray(noise, dtype=np.float32)} if noise is not None else {}),
+            state=np.ascontiguousarray(state[None], dtype=np.float32),
+        )
+        model_ms = (time.perf_counter() - model_started) * 1000.0
+        normalized = np.asarray(normalized, dtype=np.float32)[:16, :7]
+        actions = self._decode(normalized)
+        return {"actions": actions, "normalized_actions": normalized,
+                "token_ids": np.asarray(token_ids, dtype=np.uint32),
+                "timing": {"model_ms": model_ms,
+                           "total_ms": (time.perf_counter() - started) * 1000.0},
+                "metadata": self.metadata}
+
+    __call__ = infer
+
+    def _token_ids(self, prompt: str) -> list[int]:
+        prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False).ids
+        if len(prompt_ids) != 5:
+            raise ValueError(
+                f"GR00T validated CUDA graph accepts a five-token instruction, got {len(prompt_ids)}")
+        ids = [151644, 872, 198, 151652] + [_IMAGE_TOKEN] * 64 + [151653]
+        if len(self.image_keys) == 2:
+            ids += [151652] + [_IMAGE_TOKEN] * 64 + [151653]
+        ids += prompt_ids + [151645, 198]
+        assert len(ids) == (76 if len(self.image_keys) == 1 else 142)
+        return ids
+
+    def _state(self, observation: Mapping) -> np.ndarray:
+        values = []
+        stats = self.statistics["state"]
+        for key in _STATE_KEYS:
+            path = f"{self.state_prefix}/{key}"
+            if not _has_key(observation, path):
+                raise KeyError(f"GrootN17Policy missing state key {path!r}")
+            raw = np.asarray(lookup_key(observation, path), dtype=np.float32).reshape(-1)
+            low = np.asarray(stats[key]["q01"], dtype=np.float32)
+            high = np.asarray(stats[key]["q99"], dtype=np.float32)
+            values.extend(np.clip(2.0 * (raw - low) / (high - low + 1e-6) - 1.0, -1.0, 1.0))
+        output = np.zeros(132, dtype=np.float32)
+        output[:len(values)] = values
+        return output
+
+    def _decode(self, normalized: np.ndarray) -> np.ndarray:
+        output = np.empty_like(normalized)
+        stats = self.statistics["action"]
+        for index, key in enumerate(_ACTION_KEYS):
+            low = float(stats[key]["q01"][0]); high = float(stats[key]["q99"][0])
+            output[:, index] = (normalized[:, index] + 1.0) * 0.5 * (high - low) + low
+        return output
+
+    @property
+    def action_dim(self): return 7
+
+    @property
+    def action_horizon(self): return 16
+
+    def close(self):
+        close = getattr(self.model, "close", None)
+        if callable(close): close()
+
+
+def _prepare_image(value) -> np.ndarray:
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError("GrootN17Policy requires `pip install apxinf[groot]`") from exc
+    image = np.asarray(value)
+    while image.ndim > 3: image = image[0]
+    image = cv2.resize(image.astype(np.uint8), (256, 256), interpolation=cv2.INTER_AREA)
+    # The frozen checkpoint uses the newer shortest-edge/crop-fraction path:
+    # int(256 * .95) = 243, centered at offset 6, then resized to 256.
+    image = cv2.resize(image[6:249, 6:249], (256, 256), interpolation=cv2.INTER_AREA)
+    return np.ascontiguousarray(image, dtype=np.uint8)
+
+
+def _has_key(mapping: Mapping, path: str) -> bool:
+    try: lookup_key(mapping, path); return True
+    except (KeyError, TypeError): return False

--- a/python/apxinf/pyproject.toml
+++ b/python/apxinf/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
 
 [project.optional-dependencies]
 # The prompt tokenizer needs sentencepiece; the golden/layering tests want it too.
-tokenizer = ["sentencepiece>=0.1.99"]
+tokenizer = ["sentencepiece>=0.1.99", "tokenizers>=0.20"]
+groot = ["tokenizers>=0.20", "opencv-python-headless>=4.8"]
 # A live Pi05Policy binds the PyO3 model handle (Phase 1).
 policy = ["apxinf-py>=0.1.0"]
 # The OpenPI-compatible websocket server (apxinf.serving) needs the transport deps.


### PR DESCRIPTION
## Summary

- port GR00T N1.7 to a self-contained native ApxInf CUDA execution path
- keep whole-model execution GPU-resident under CUDA Graph capture
- add BF16 CUDA primitives and GPU RGB preprocessing for one-view and two-view policies
- add an unscaled BF16 embedding path for GR00T while preserving Pi0.5 scaling
- avoid Torch, TensorRT, ONNX Runtime, and other third-party inference engines in the runtime path

This branch is rebuilt directly on the latest upstream/main and contains exactly one model-port commit.

## Validation

### Rebuilt branch

- commit count over upstream/main: 1
- Python policy layering tests: 19 passed, 1 skipped
- git diff check: passed
- no private checkpoints, fixtures, benchmark artifacts, or workflow evidence included

### Thor evidence from the port validation run

- public GrootN17Policy RGB correctness: 0 / 112 decoded tolerance violations
- maximum absolute error: 0.015625
- mean absolute error: 0.00232398
- release benchmark, batch 1, one camera, four denoise steps: median 64.68 ms, 15.46 Hz
- NVIDIA published reference: 80.4 ms, 12.4 Hz
- throughput improvement over the published reference: 24.7 percent

## Pending before ready for review

- CI and Rust/CUDA compilation on the rebuilt upstream/main baseline
- Orin correctness and performance validation
- Orin target: better than the NVIDIA published 150.9 ms / 6.6 Hz result
- available Orin hosts were unreachable during the validation run

The PR remains Draft until these gates are complete.