### PR TITLE
feat(tuning): autotune fused GeGLU implementations

### DIFF
--- a/configs/tuning/nvidia/thor-sm110/tactics.json
+++ b/configs/tuning/nvidia/thor-sm110/tactics.json
@@ -433,7 +433,7 @@
     {
       "key": {
         "activation_dtype": "bf16",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "k": 2048,
         "layout": "row_major",
         "m": 522,
@@ -1742,10 +1742,10 @@
         "k": 2048,
         "activation_dtype": "f8e4m3",
         "weight_dtype": "f8e4m3",
-        "output_dtype": "f16",
+        "output_dtype": "f8e4m3",
         "layout": "row_major",
         "scale_mode": "per_tensor",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "workspace_limit": 18446744073709551615
       },
       "tactic": {
@@ -1842,10 +1842,10 @@
         "k": 2048,
         "activation_dtype": "f8e4m3",
         "weight_dtype": "f8e4m3",
-        "output_dtype": "f16",
+        "output_dtype": "f8e4m3",
         "layout": "row_major",
         "scale_mode": "per_tensor",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "workspace_limit": 18446744073709551615
       },
       "tactic": {

--- a/configs/tuning/nvidia/thor-sm110/tuning_report.json
+++ b/configs/tuning/nvidia/thor-sm110/tuning_report.json
@@ -792,7 +792,7 @@
     {
       "key": {
         "activation_dtype": "bf16",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "k": 2048,
         "layout": "row_major",
         "m": 522,
@@ -4899,10 +4899,10 @@
         "k": 2048,
         "activation_dtype": "f8e4m3",
         "weight_dtype": "f8e4m3",
-        "output_dtype": "f16",
+        "output_dtype": "f8e4m3",
         "layout": "row_major",
         "scale_mode": "per_tensor",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "workspace_limit": 18446744073709551615
       },
       "winner": {
@@ -5423,10 +5423,10 @@
         "k": 2048,
         "activation_dtype": "f8e4m3",
         "weight_dtype": "f8e4m3",
-        "output_dtype": "f16",
+        "output_dtype": "f8e4m3",
         "layout": "row_major",
         "scale_mode": "per_tensor",
-        "epilogue": "none",
+        "epilogue": "geglu",
         "workspace_limit": 18446744073709551615
       },
       "winner": {

--- a/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
@@ -170,8 +170,21 @@ fn launch_tactic_bf16(
                 output,
             )
             .map_err(Error::Cuda),
-        TacticBackend::CublasLt => unsafe {
+        TacticBackend::CublasLt | TacticBackend::CublasLtCustom => unsafe {
             ffi::check_cublas(ffi::apxinf_static_bf16_gemm(
+                activation.ptr(),
+                weight.ptr(),
+                output.ptr(),
+                key.m as i32,
+                key.n as i32,
+                key.k as i32,
+                1.0,
+                ctx.stream().handle(),
+            ))
+            .map_err(Error::Cuda)
+        },
+        TacticBackend::CublasLtCustomSplitSerial => unsafe {
+            ffi::check_cublas(ffi::apxinf_static_bf16_gemm_split(
                 activation.ptr(),
                 weight.ptr(),
                 output.ptr(),
@@ -191,6 +204,18 @@ fn launch_tactic_bf16(
 
 fn prepare_tactic_bf16(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
     super::providers::prepare(key, tactic)
+}
+
+fn resolve_bf16_plan(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    activation: &CudaBuffer,
+    weight: &CudaBuffer,
+) -> Result<super::PreparedGemmPlan> {
+    ctx.gemm_plans()
+        .resolve_or_tune(ctx, key, super::plan::default_bf16_tactic(), |preferred| {
+            autotune_request_bf16(ctx, key, activation, weight, preferred)
+        })
 }
 
 fn autotune_request_bf16(
@@ -234,14 +259,7 @@ fn autotune_request_bf16(
     let events = CudaEventPair::new()?;
     let mut evictor = ColdL2Evictor::new(ctx)?;
     let engine = AutoTuneEngine::new(AutoTuneConfig::default())?;
-    let candidates = super::providers::candidates(key, 64)
-        .into_iter()
-        .filter(|candidate| {
-            matches!(
-                candidate.tactic.backend,
-                TacticBackend::Vendor | TacticBackend::CublasLt
-            )
-        });
+    let candidates = super::providers::candidates(key, 64).into_iter();
     engine.tune_with_preferred(key, preferred, candidates, |candidate, config| {
         prepare_tactic_bf16(key, candidate.tactic)?;
         launch_tactic_bf16(ctx, key, activation, weight, &output, candidate.tactic)?;
@@ -386,12 +404,7 @@ pub fn gemm_bf16(ctx: &CudaContext, activation: &Tensor, weight: &Tensor) -> Res
     let activation = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
     let weight = CudaBuffer::from_tensor(weight).map_err(Error::Cuda)?;
     let key = tuning_key(ctx, m, n, k);
-    let plan = ctx.gemm_plans().resolve_or_tune(
-        ctx,
-        &key,
-        super::plan::default_bf16_tactic(),
-        |preferred| autotune_request_bf16(ctx, &key, &activation, &weight, preferred),
-    )?;
+    let plan = resolve_bf16_plan(ctx, &key, &activation, &weight)?;
     let use_split_serial = plan.tactic.backend == TacticBackend::CublasLtCustomSplitSerial;
     let use_persisted_cublaslt = matches!(
         plan.tactic.backend,
@@ -456,9 +469,22 @@ pub fn gemm_bf16(ctx: &CudaContext, activation: &Tensor, weight: &Tensor) -> Res
     Ok(output.into_tensor(Shape::new(vec![m, n]), DType::BF16))
 }
 
-/// Run the configured cuBLASLt BF16 gate + native SM100 CUTLASS up/GeGLU EVT.
-/// Returns `None` unless the exact physical record selects BF16 fused GeGLU;
-/// selected but unsupported records fail closed instead of falling back.
+fn geglu_tuning_key(ctx: &CudaContext, m: usize, full_n: usize, k: usize) -> GemmTuningKey {
+    let mut key = tuning_key(ctx, m, full_n, k);
+    key.epilogue = Epilogue::GeGlu;
+    key
+}
+
+const fn decomposed_geglu_tactic() -> TacticId {
+    TacticId {
+        backend: TacticBackend::GemmThenGeGlu,
+        value: 0,
+    }
+}
+
+/// Resolve and execute the complete BF16 gate/up projection plus GeGLU
+/// operator. The selected tactic may be fused or a prepared GEMM followed by
+/// the standalone activation kernel.
 pub fn gemm_bf16_geglu_fused(
     ctx: &CudaContext,
     activation: &Tensor,
@@ -492,237 +518,477 @@ pub fn gemm_bf16_geglu_fused(
             },
         });
     }
+    super::observe_bf16(activation, packed_weight)?;
+
     let (m, k, full_n) = (a[0], a[1], b[1]);
-    let key = tuning_key(ctx, m, full_n, k);
-    // Do not cache Bucket/Default from this optional fused probe. On an exact
-    // miss the caller falls back to the plain GEMM API, which must retain the
-    // opportunity to run AUTO_TUNE for this physical key.
-    let Some(exact_tactic) = ctx.tuning().lookup_gemm_exact(&key) else {
-        return Ok(None);
+    let n = full_n / 2;
+    let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
+    let primary_weight = CudaBuffer::from_tensor(packed_weight).map_err(Error::Cuda)?;
+    let automatic_interleaved = bf16_dual_geglu_auto_interleaved
+        .map(CudaBuffer::from_tensor)
+        .transpose()
+        .map_err(Error::Cuda)?;
+    let sm89_interleaved = bf16_sm89_geglu_interleaved
+        .map(CudaBuffer::from_tensor)
+        .transpose()
+        .map_err(Error::Cuda)?;
+    let (plain_weight, dual_weight) = if bf16_dual_geglu_interleaved {
+        (None, Some(&primary_weight))
+    } else {
+        (Some(&primary_weight), automatic_interleaved.as_ref())
     };
-    let fused_backend = matches!(
-        exact_tactic.backend,
-        TacticBackend::CublasLtCustomSplitGeGluCutlassBf16
-            | TacticBackend::CutlassBf16DualGeGluM522
-            | TacticBackend::CutlassBf16DualGeGluM533
-    );
-    if !fused_backend {
-        return Ok(None);
-    }
+
+    let plain_key = tuning_key(ctx, m, full_n, k);
+    let plain_plan = plain_weight
+        .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
+        .transpose()?;
+    let key = geglu_tuning_key(ctx, m, full_n, k);
+    let default = default_bf16_geglu_tactic(
+        ctx,
+        &key,
+        plain_plan.is_some(),
+        dual_weight.is_some(),
+        sm89_interleaved.is_some(),
+    )?;
     let plan = ctx
         .gemm_plans()
-        .resolve(ctx, &key, super::plan::default_bf16_tactic())?;
-    let fused_tactic = (plan.source == super::plan::PlanSource::Exact).then_some(plan.tactic);
-    let bf16_split_evt = fused_tactic
-        .is_some_and(|tactic| tactic.backend == TacticBackend::CublasLtCustomSplitGeGluCutlassBf16);
-    let bf16_dual_geglu_expected_m = fused_tactic.and_then(|tactic| match tactic.backend {
-        TacticBackend::CutlassBf16DualGeGluM522 => Some(522),
-        TacticBackend::CutlassBf16DualGeGluM533 => Some(533),
-        _ => None,
-    });
-    let bf16_dual_geglu = bf16_dual_geglu_expected_m.is_some();
-    let weight_route = bf16_dual_geglu_weight_route(
-        bf16_dual_geglu_mode()?,
-        bf16_dual_geglu,
-        bf16_dual_geglu_interleaved,
-        bf16_dual_geglu_auto_interleaved.is_some(),
+        .resolve_or_tune(ctx, &key, default, |preferred| {
+            autotune_request_bf16_geglu(
+                ctx,
+                &key,
+                &plain_key,
+                plain_plan.as_ref(),
+                &activation_buffer,
+                plain_weight,
+                dual_weight,
+                sm89_interleaved.as_ref(),
+                preferred,
+            )
+        })?;
+
+    let gate = output_buffer(
+        ctx,
+        m.checked_mul(full_n)
+            .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
+            .ok_or_else(|| Error::Other("BF16 GeGLU gate size overflow".into()))?,
     )?;
-    let selected_weight = match weight_route {
-        Bf16DualGeGluWeightRoute::Plain | Bf16DualGeGluWeightRoute::InterleavedPrimary => {
-            packed_weight
-        }
-        Bf16DualGeGluWeightRoute::InterleavedAuto => bf16_dual_geglu_auto_interleaved.unwrap(),
-    };
-    if selected_weight.dtype() != DType::BF16 || selected_weight.shape().dims() != b {
-        return Err(Error::Other(format!(
-            "BF16 dual GeGLU selected weight must be BF16 {b:?}, got {} {:?}",
-            selected_weight.dtype(),
-            selected_weight.shape().dims()
-        )));
+    let output = output_buffer(
+        ctx,
+        m.checked_mul(n)
+            .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
+            .ok_or_else(|| Error::Other("BF16 GeGLU output size overflow".into()))?,
+    )?;
+    if crate::workspace::may_prepare_native_resources() {
+        prepare_bf16_geglu_tactic(&key, &plain_key, plain_plan.as_ref(), plan.tactic)?;
     }
-    if selected_weight.device() != expected_device {
-        return Err(Error::DeviceMismatch {
-            expected: expected_device,
-            got: selected_weight.device(),
+    if let Err(error) = launch_bf16_geglu_tactic(
+        ctx,
+        &key,
+        plain_plan.as_ref(),
+        &activation_buffer,
+        plain_weight,
+        dual_weight,
+        sm89_interleaved.as_ref(),
+        &gate,
+        &output,
+        plan.tactic,
+    ) {
+        if plan.tactic == default || plain_plan.is_none() {
+            return Err(error);
+        }
+        eprintln!(
+            "[apxinf] BF16 GeGLU tactic {:?} failed for {key:?}: {error}; using decomposed fallback",
+            plan.tactic
+        );
+        ctx.gemm_plans()
+            .fallback_to(ctx, &key, decomposed_geglu_tactic())?;
+        prepare_bf16_geglu_tactic(
+            &key,
+            &plain_key,
+            plain_plan.as_ref(),
+            decomposed_geglu_tactic(),
+        )?;
+        launch_bf16_geglu_tactic(
+            ctx,
+            &key,
+            plain_plan.as_ref(),
+            &activation_buffer,
+            plain_weight,
+            dual_weight,
+            sm89_interleaved.as_ref(),
+            &gate,
+            &output,
+            decomposed_geglu_tactic(),
+        )?;
+    }
+    Ok(Some(
+        output.into_tensor(Shape::new(vec![m, n]), DType::BF16),
+    ))
+}
+
+fn default_bf16_geglu_tactic(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    has_plain_weight: bool,
+    has_dual_weight: bool,
+    has_sm89_weight: bool,
+) -> Result<TacticId> {
+    if has_plain_weight {
+        return Ok(decomposed_geglu_tactic());
+    }
+    if ctx.caps().sm == 110 && has_dual_weight {
+        let backend = match key.m {
+            522 => TacticBackend::CutlassBf16DualGeGluM522,
+            533 => TacticBackend::CutlassBf16DualGeGluM533,
+            _ => {
+                return Err(Error::Other(format!(
+                    "BF16 interleaved-only GeGLU has no implementation for {key:?}"
+                )))
+            }
+        };
+        return Ok(TacticId { backend, value: 0 });
+    }
+    if ctx.caps().sm == 89 && has_sm89_weight {
+        return Ok(TacticId {
+            backend: TacticBackend::CutlassBf16GeGluSm89,
+            value: 0,
         });
     }
-    if ctx.caps().sm == 89 && ((full_n, k) == (8192, 1024) || (full_n, k) == (32768, 2048)) {
-        let Some(sm89_weight) = bf16_sm89_geglu_interleaved else {
-            return Ok(None);
-        };
-        if sm89_weight.dtype() != DType::BF16 || sm89_weight.shape().dims() != b {
-            return Err(Error::Other(format!(
-                "BF16 SM89 GeGLU selected weight must be BF16 {b:?}, got {} {:?}",
-                sm89_weight.dtype(),
-                sm89_weight.shape().dims()
-            )));
-        }
-        if sm89_weight.device() != expected_device {
-            return Err(Error::DeviceMismatch {
-                expected: expected_device,
-                got: sm89_weight.device(),
-            });
-        }
+    Err(Error::Other(format!(
+        "BF16 GeGLU has no safe implementation for {key:?}"
+    )))
+}
 
-        #[cfg(not(apxinf_cutlass_bf16_sm89))]
-        return Err(Error::Other(
-            "BF16 SM89 fused GeGLU requires the SM89 CUTLASS adapter build".into(),
-        ));
+fn prepare_bf16_geglu_tactic(
+    key: &GemmTuningKey,
+    plain_key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    tactic: TacticId,
+) -> Result<()> {
+    if tactic.backend == TacticBackend::GemmThenGeGlu {
+        let plan = plain_plan.ok_or_else(|| {
+            Error::Other("decomposed BF16 GeGLU has no plain-weight GEMM plan".into())
+        })?;
+        return super::providers::prepare(plain_key, plan.tactic);
+    }
+    super::providers::prepare(key, tactic)
+}
 
-        #[cfg(apxinf_cutlass_bf16_sm89)]
-        {
-            super::observe_bf16(activation, packed_weight)?;
-            let n = full_n / 2;
-            let output = output_buffer(
+#[allow(clippy::too_many_arguments)]
+fn launch_bf16_geglu_tactic(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    activation: &CudaBuffer,
+    plain_weight: Option<&CudaBuffer>,
+    dual_weight: Option<&CudaBuffer>,
+    sm89_weight: Option<&CudaBuffer>,
+    gate: &CudaBuffer,
+    output: &CudaBuffer,
+    tactic: TacticId,
+) -> Result<()> {
+    let n = key.n / 2;
+    match tactic.backend {
+        TacticBackend::GemmThenGeGlu => {
+            let plain_plan = plain_plan.ok_or_else(|| {
+                Error::Other("decomposed BF16 GeGLU has no prepared GEMM plan".into())
+            })?;
+            let plain_weight = plain_weight.ok_or_else(|| {
+                Error::Other("decomposed BF16 GeGLU has no plain-layout weight".into())
+            })?;
+            launch_tactic_bf16(
                 ctx,
-                m.checked_mul(n)
-                    .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
-                    .ok_or_else(|| {
-                        Error::Other("BF16 SM89 fused GeGLU output size overflow".into())
-                    })?,
+                &plain_plan.key,
+                activation,
+                plain_weight,
+                gate,
+                plain_plan.tactic,
             )?;
-            let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
-            let weight_buffer = CudaBuffer::from_tensor(sm89_weight).map_err(Error::Cuda)?;
-            let status = unsafe {
-                ffi::apxinf_static_cutlass_bf16_interleaved_geglu_sm89(
-                    activation_buffer.ptr(),
-                    weight_buffer.ptr(),
+            unsafe {
+                ffi::check_cuda(ffi::apxinf_static_geglu_bf16(
+                    gate.ptr(),
                     output.ptr(),
-                    m as i32,
+                    key.m as i32,
                     n as i32,
-                    k as i32,
-                    full_n as i32,
-                    0,
                     ctx.stream().handle(),
-                )
+                ))
+                .map_err(Error::Cuda)
+            }
+        }
+        TacticBackend::CutlassBf16DualGeGluM522 | TacticBackend::CutlassBf16DualGeGluM533 => {
+            let expected_m = if tactic.backend == TacticBackend::CutlassBf16DualGeGluM522 {
+                522
+            } else {
+                533
             };
-            if status != 0 {
-                return Err(Error::Cuda(format!(
-                    "BF16 SM89 interleaved GeGLU rejected [{m},{n},{k}] ({status})"
+            validate_bf16_dual_geglu_shape(key.m, key.n, key.k, expected_m)?;
+            let weight = dual_weight.ok_or_else(|| {
+                Error::Other("BF16 dual-GEMM GeGLU has no interleaved weight".into())
+            })?;
+            #[cfg(apxinf_cutlass_gemm)]
+            {
+                let status = unsafe {
+                    ffi::apxinf_static_cutlass_bf16_dual_gemm_geglu(
+                        activation.ptr(),
+                        weight.ptr(),
+                        output.ptr(),
+                        key.m as i32,
+                        n as i32,
+                        key.k as i32,
+                        key.n as i32,
+                        ctx.stream().handle(),
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::Cuda(format!(
+                        "BF16 dual-GEMM GeGLU rejected [{},{},{}] ({status})",
+                        key.m, n, key.k
+                    )))
+                }
+            }
+            #[cfg(not(apxinf_cutlass_gemm))]
+            {
+                let _ = weight;
+                Err(Error::Other(
+                    "BF16 dual GeGLU requires the SM100-family CUTLASS build".into(),
+                ))
+            }
+        }
+        TacticBackend::CutlassBf16GeGluSm89 => {
+            let weight = sm89_weight
+                .ok_or_else(|| Error::Other("BF16 SM89 GeGLU has no interleaved weight".into()))?;
+            #[cfg(apxinf_cutlass_bf16_sm89)]
+            {
+                let status = unsafe {
+                    ffi::apxinf_static_cutlass_bf16_interleaved_geglu_sm89(
+                        activation.ptr(),
+                        weight.ptr(),
+                        output.ptr(),
+                        key.m as i32,
+                        n as i32,
+                        key.k as i32,
+                        key.n as i32,
+                        tactic.value,
+                        ctx.stream().handle(),
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::Cuda(format!(
+                        "BF16 SM89 GeGLU rejected [{},{},{}] ({status})",
+                        key.m, n, key.k
+                    )))
+                }
+            }
+            #[cfg(not(apxinf_cutlass_bf16_sm89))]
+            {
+                let _ = weight;
+                Err(Error::Other(
+                    "BF16 SM89 GeGLU requires the SM89 CUTLASS build".into(),
+                ))
+            }
+        }
+        TacticBackend::CublasLtCustomSplitGeGluCutlassBf16 => {
+            let weight = plain_weight.ok_or_else(|| {
+                Error::Other("split BF16 GeGLU has no plain-layout weight".into())
+            })?;
+            if (key.m, key.n, key.k) != (789, 32768, 2048) {
+                return Err(Error::Other(format!(
+                    "split BF16 GeGLU tactic requires [789,2048] @ [2048,32768], got [{},{}] @ [{},{}]",
+                    key.m, key.k, key.k, key.n
                 )));
             }
-            return Ok(Some(
-                output.into_tensor(Shape::new(vec![m, n]), DType::BF16),
-            ));
-        }
-    }
-
-    if !bf16_split_evt && !bf16_dual_geglu {
-        return Ok(None);
-    }
-    if let Some(expected_m) = bf16_dual_geglu_expected_m {
-        validate_bf16_dual_geglu_shape(m, full_n, k, expected_m)?;
-        #[cfg(not(apxinf_cutlass_gemm))]
-        return Err(Error::Other(
-            "BF16 dual GeGLU requires the SM100-family CUTLASS build".into(),
-        ));
-        #[cfg(apxinf_cutlass_gemm)]
-        {
-            super::observe_bf16(activation, packed_weight)?;
-            let n = full_n / 2;
-            let output = output_buffer(
-                ctx,
-                m.checked_mul(n)
-                    .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
-                    .ok_or_else(|| Error::Other("BF16 dual GeGLU output size overflow".into()))?,
-            )?;
-            let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
-            let weight_buffer = CudaBuffer::from_tensor(selected_weight).map_err(Error::Cuda)?;
-            let status = unsafe {
-                ffi::apxinf_static_cutlass_bf16_dual_gemm_geglu(
-                    activation_buffer.ptr(),
-                    weight_buffer.ptr(),
-                    output.ptr(),
-                    m as i32,
-                    n as i32,
-                    k as i32,
-                    full_n as i32,
-                    ctx.stream().handle(),
-                )
-            };
-            if status != 0 {
-                return Err(Error::Cuda(format!(
-                    "BF16 dual-GEMM GeGLU rejected [{m},{n},{k}] ({status})"
-                )));
+            #[cfg(apxinf_cutlass_gemm)]
+            {
+                unsafe {
+                    ffi::check_cublas(ffi::apxinf_static_bf16_gemm_split_first(
+                        activation.ptr(),
+                        weight.ptr(),
+                        gate.ptr(),
+                        key.m as i32,
+                        key.n as i32,
+                        key.k as i32,
+                        1.0,
+                        ctx.stream().handle(),
+                    ))
+                    .map_err(Error::Cuda)?;
+                }
+                let status = unsafe {
+                    ffi::apxinf_static_cutlass_bf16_gemm_geglu(
+                        activation.ptr(),
+                        weight.ptr(),
+                        gate.ptr(),
+                        output.ptr(),
+                        key.m as i32,
+                        n as i32,
+                        key.k as i32,
+                        key.n as i32,
+                        0,
+                        ctx.stream().handle(),
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::Cuda(format!(
+                        "split BF16 GeGLU tactic {:?} rejected {:?} ({status})",
+                        tactic, key
+                    )))
+                }
             }
-            return Ok(Some(
-                output.into_tensor(Shape::new(vec![m, n]), DType::BF16),
-            ));
+            #[cfg(not(apxinf_cutlass_gemm))]
+            {
+                let _ = weight;
+                Err(Error::Other(
+                    "split BF16 GeGLU requires the SM100-family CUTLASS build".into(),
+                ))
+            }
         }
-    }
-    if (m, full_n, k) != (789, 32768, 2048) {
-        return Err(Error::Other(format!(
-            "fused BF16 GeGLU is tuned only for [789,2048] @ [2048,32768], got [{m},{k}] @ [{k},{full_n}]"
-        )));
-    }
-
-    #[cfg(not(apxinf_cutlass_gemm))]
-    {
-        let _ = ctx;
-        return Err(Error::Other(
-            "BF16 fused GeGLU requires the SM100-family CUTLASS build".into(),
-        ));
-    }
-
-    #[cfg(apxinf_cutlass_gemm)]
-    {
-        super::observe_bf16(activation, packed_weight)?;
-        let n = full_n / 2;
-        let gate = output_buffer(
-            ctx,
-            m.checked_mul(full_n)
-                .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
-                .ok_or_else(|| Error::Other("BF16 fused GeGLU gate size overflow".into()))?,
-        )?;
-        let output = output_buffer(
-            ctx,
-            m.checked_mul(n)
-                .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
-                .ok_or_else(|| Error::Other("BF16 fused GeGLU output size overflow".into()))?,
-        )?;
-        let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
-        let weight_buffer = CudaBuffer::from_tensor(selected_weight).map_err(Error::Cuda)?;
-        unsafe {
-            ffi::check_cublas(ffi::apxinf_static_bf16_gemm_split_first(
-                activation_buffer.ptr(),
-                weight_buffer.ptr(),
-                gate.ptr(),
-                m as i32,
-                full_n as i32,
-                k as i32,
-                1.0,
-                ctx.stream().handle(),
-            ))
-            .map_err(Error::Cuda)?;
-        }
-        // Tactic 0 is the bitwise-exact 128x256x64, c1x2, explicit-1SM winner
-        // selected by the five-run alternating direct comparison.
-        let cutlass_tactic = 0;
-        let status = unsafe {
-            ffi::apxinf_static_cutlass_bf16_gemm_geglu(
-                activation_buffer.ptr(),
-                weight_buffer.ptr(),
-                gate.ptr(),
-                output.ptr(),
-                m as i32,
-                n as i32,
-                k as i32,
-                full_n as i32,
-                cutlass_tactic,
-                ctx.stream().handle(),
-            )
-        };
-        if status != 0 {
-            return Err(Error::Cuda(format!(
-                "BF16 fused GeGLU CUTLASS fused GeGLU rejected [{m},{n},{k}] ({status})"
-            )));
-        }
-        Ok(Some(
-            output.into_tensor(Shape::new(vec![m, n]), DType::BF16),
-        ))
+        _ => Err(Error::Other(format!(
+            "BF16 GeGLU online autotune cannot execute {tactic:?}"
+        ))),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn autotune_request_bf16_geglu(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    plain_key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    activation: &CudaBuffer,
+    plain_weight: Option<&CudaBuffer>,
+    dual_weight: Option<&CudaBuffer>,
+    sm89_weight: Option<&CudaBuffer>,
+    preferred: Option<TacticId>,
+) -> Result<TuningOutcome> {
+    let output_elements = key
+        .m
+        .checked_mul(key.n / 2)
+        .ok_or_else(|| Error::Other("BF16 GeGLU autotune output size overflow".into()))?;
+    let gate = CudaBuffer::alloc_zeros(
+        key.m
+            .checked_mul(key.n)
+            .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
+            .ok_or_else(|| Error::Other("BF16 GeGLU autotune gate size overflow".into()))?,
+        ctx.device_id(),
+    )
+    .map_err(Error::Cuda)?;
+    let bytes = output_elements
+        .checked_mul(DType::BF16.size_in_bytes())
+        .ok_or_else(|| Error::Other("BF16 GeGLU autotune output size overflow".into()))?;
+    let reference_output = CudaBuffer::alloc_zeros(bytes, ctx.device_id()).map_err(Error::Cuda)?;
+    let candidate_output = CudaBuffer::alloc_zeros(bytes, ctx.device_id()).map_err(Error::Cuda)?;
+    let reference_tactic = default_bf16_geglu_tactic(
+        ctx,
+        key,
+        plain_plan.is_some() && plain_weight.is_some(),
+        dual_weight.is_some(),
+        sm89_weight.is_some(),
+    )?;
+    prepare_bf16_geglu_tactic(key, plain_key, plain_plan, reference_tactic)?;
+    launch_bf16_geglu_tactic(
+        ctx,
+        key,
+        plain_plan,
+        activation,
+        plain_weight,
+        dual_weight,
+        sm89_weight,
+        &gate,
+        &reference_output,
+        reference_tactic,
+    )?;
+    ctx.synchronize().map_err(Error::Cuda)?;
+    let reference = copy_bf16_output(&reference_output, output_elements)?;
+
+    let candidates = super::providers::geglu_candidates(key)
+        .into_iter()
+        .filter(|candidate| {
+            candidate.tactic.backend != TacticBackend::GemmThenGeGlu
+                || (plain_plan.is_some() && plain_weight.is_some())
+        })
+        .filter(|candidate| {
+            !matches!(
+                candidate.tactic.backend,
+                TacticBackend::CutlassBf16DualGeGluM522 | TacticBackend::CutlassBf16DualGeGluM533
+            ) || dual_weight.is_some()
+        })
+        .filter(|candidate| {
+            candidate.tactic.backend != TacticBackend::CutlassBf16GeGluSm89 || sm89_weight.is_some()
+        });
+    let events = CudaEventPair::new()?;
+    let mut evictor = ColdL2Evictor::new(ctx)?;
+    let engine = AutoTuneEngine::new(AutoTuneConfig::default())?;
+    engine.tune_with_preferred(key, preferred, candidates, |candidate, config| {
+        prepare_bf16_geglu_tactic(key, plain_key, plain_plan, candidate.tactic)?;
+        launch_bf16_geglu_tactic(
+            ctx,
+            key,
+            plain_plan,
+            activation,
+            plain_weight,
+            dual_weight,
+            sm89_weight,
+            &gate,
+            &candidate_output,
+            candidate.tactic,
+        )?;
+        ctx.synchronize().map_err(Error::Cuda)?;
+        let actual = copy_bf16_output(&candidate_output, output_elements)?;
+        let correct = crate::tuning::outputs_are_close(&reference, &actual, 0.01, 0.9999);
+        if !correct {
+            return Ok(CandidateMeasurement {
+                tactic: candidate.tactic,
+                milliseconds: None,
+                correct: false,
+            });
+        }
+        for _ in 0..config.warmup_iterations {
+            evictor.evict(ctx)?;
+            launch_bf16_geglu_tactic(
+                ctx,
+                key,
+                plain_plan,
+                activation,
+                plain_weight,
+                dual_weight,
+                sm89_weight,
+                &gate,
+                &candidate_output,
+                candidate.tactic,
+            )?;
+        }
+        ctx.synchronize().map_err(Error::Cuda)?;
+        let mut milliseconds = 0.0;
+        for _ in 0..config.benchmark_iterations {
+            milliseconds += events.measure(ctx, &mut evictor, || {
+                launch_bf16_geglu_tactic(
+                    ctx,
+                    key,
+                    plain_plan,
+                    activation,
+                    plain_weight,
+                    dual_weight,
+                    sm89_weight,
+                    &gate,
+                    &candidate_output,
+                    candidate.tactic,
+                )
+            })?;
+        }
+        Ok(CandidateMeasurement {
+            tactic: candidate.tactic,
+            milliseconds: Some(milliseconds / config.benchmark_iterations as f64),
+            correct: true,
+        })
+    })
+}
+
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Bf16DualGeGluMode {
     Auto,
@@ -730,6 +996,7 @@ enum Bf16DualGeGluMode {
     On,
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Bf16DualGeGluWeightRoute {
     Plain,
@@ -737,6 +1004,7 @@ enum Bf16DualGeGluWeightRoute {
     InterleavedAuto,
 }
 
+#[cfg(test)]
 fn parse_bf16_dual_geglu_mode(value: Option<&str>) -> Result<Bf16DualGeGluMode> {
     match value {
         None | Some("auto") => Ok(Bf16DualGeGluMode::Auto),
@@ -748,17 +1016,7 @@ fn parse_bf16_dual_geglu_mode(value: Option<&str>) -> Result<Bf16DualGeGluMode> 
     }
 }
 
-fn bf16_dual_geglu_mode() -> Result<Bf16DualGeGluMode> {
-    const NAME: &str = "APXINF_PI05_BF16_DUAL_GEGLU";
-    match std::env::var(NAME) {
-        Err(std::env::VarError::NotPresent) => parse_bf16_dual_geglu_mode(None),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            Err(Error::Other(format!("{NAME} must be valid Unicode")))
-        }
-        Ok(value) => parse_bf16_dual_geglu_mode(Some(&value)),
-    }
-}
-
+#[cfg(test)]
 fn bf16_dual_geglu_weight_route(
     mode: Bf16DualGeGluMode,
     dual: bool,

--- a/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
@@ -492,7 +492,7 @@ pub fn gemm_bf16_geglu_fused(
     bf16_dual_geglu_interleaved: bool,
     bf16_dual_geglu_auto_interleaved: Option<&Tensor>,
     bf16_sm89_geglu_interleaved: Option<&Tensor>,
-) -> Result<Option<Tensor>> {
+) -> Result<Tensor> {
     if activation.dtype() != DType::BF16 || packed_weight.dtype() != DType::BF16 {
         return Err(Error::Other(format!(
             "BF16 fused GeGLU expects BF16 operands, got {} and {}",
@@ -539,20 +539,21 @@ pub fn gemm_bf16_geglu_fused(
     };
 
     let plain_key = tuning_key(ctx, m, full_n, k);
-    let plain_plan = plain_weight
-        .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
-        .transpose()?;
+    let mut plain_plan = None;
     let key = geglu_tuning_key(ctx, m, full_n, k);
     let default = default_bf16_geglu_tactic(
         ctx,
         &key,
-        plain_plan.is_some(),
+        plain_weight.is_some(),
         dual_weight.is_some(),
         sm89_interleaved.is_some(),
     )?;
     let plan = ctx
         .gemm_plans()
         .resolve_or_tune(ctx, &key, default, |preferred| {
+            plain_plan = plain_weight
+                .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
+                .transpose()?;
             autotune_request_bf16_geglu(
                 ctx,
                 &key,
@@ -566,12 +567,16 @@ pub fn gemm_bf16_geglu_fused(
             )
         })?;
 
-    let gate = output_buffer(
-        ctx,
-        m.checked_mul(full_n)
-            .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
-            .ok_or_else(|| Error::Other("BF16 GeGLU gate size overflow".into()))?,
-    )?;
+    if plan.tactic.backend == TacticBackend::GemmThenGeGlu && plain_plan.is_none() {
+        plain_plan = plain_weight
+            .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
+            .transpose()?;
+    }
+    let mut gate = if bf16_geglu_tactic_uses_gate(plan.tactic) {
+        Some(output_buffer(ctx, bf16_geglu_gate_bytes(m, full_n)?)?)
+    } else {
+        None
+    };
     let output = output_buffer(
         ctx,
         m.checked_mul(n)
@@ -589,11 +594,11 @@ pub fn gemm_bf16_geglu_fused(
         plain_weight,
         dual_weight,
         sm89_interleaved.as_ref(),
-        &gate,
+        gate.as_ref(),
         &output,
         plan.tactic,
     ) {
-        if plan.tactic == default || plain_plan.is_none() {
+        if plan.tactic == default || plain_weight.is_none() {
             return Err(error);
         }
         eprintln!(
@@ -602,6 +607,14 @@ pub fn gemm_bf16_geglu_fused(
         );
         ctx.gemm_plans()
             .fallback_to(ctx, &key, decomposed_geglu_tactic())?;
+        if plain_plan.is_none() {
+            plain_plan = plain_weight
+                .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
+                .transpose()?;
+        }
+        if gate.is_none() {
+            gate = Some(output_buffer(ctx, bf16_geglu_gate_bytes(m, full_n)?)?);
+        }
         prepare_bf16_geglu_tactic(
             &key,
             &plain_key,
@@ -616,14 +629,25 @@ pub fn gemm_bf16_geglu_fused(
             plain_weight,
             dual_weight,
             sm89_interleaved.as_ref(),
-            &gate,
+            gate.as_ref(),
             &output,
             decomposed_geglu_tactic(),
         )?;
     }
-    Ok(Some(
-        output.into_tensor(Shape::new(vec![m, n]), DType::BF16),
-    ))
+    Ok(output.into_tensor(Shape::new(vec![m, n]), DType::BF16))
+}
+
+fn bf16_geglu_tactic_uses_gate(tactic: TacticId) -> bool {
+    matches!(
+        tactic.backend,
+        TacticBackend::GemmThenGeGlu | TacticBackend::CublasLtCustomSplitGeGluCutlassBf16
+    )
+}
+
+fn bf16_geglu_gate_bytes(m: usize, full_n: usize) -> Result<usize> {
+    m.checked_mul(full_n)
+        .and_then(|elements| elements.checked_mul(DType::BF16.size_in_bytes()))
+        .ok_or_else(|| Error::Other("BF16 GeGLU gate size overflow".into()))
 }
 
 fn default_bf16_geglu_tactic(
@@ -683,13 +707,15 @@ fn launch_bf16_geglu_tactic(
     plain_weight: Option<&CudaBuffer>,
     dual_weight: Option<&CudaBuffer>,
     sm89_weight: Option<&CudaBuffer>,
-    gate: &CudaBuffer,
+    gate: Option<&CudaBuffer>,
     output: &CudaBuffer,
     tactic: TacticId,
 ) -> Result<()> {
     let n = key.n / 2;
     match tactic.backend {
         TacticBackend::GemmThenGeGlu => {
+            let gate = gate
+                .ok_or_else(|| Error::Other("decomposed BF16 GeGLU has no gate buffer".into()))?;
             let plain_plan = plain_plan.ok_or_else(|| {
                 Error::Other("decomposed BF16 GeGLU has no prepared GEMM plan".into())
             })?;
@@ -792,6 +818,8 @@ fn launch_bf16_geglu_tactic(
             }
         }
         TacticBackend::CublasLtCustomSplitGeGluCutlassBf16 => {
+            let gate =
+                gate.ok_or_else(|| Error::Other("split BF16 GeGLU has no gate buffer".into()))?;
             let weight = plain_weight.ok_or_else(|| {
                 Error::Other("split BF16 GeGLU has no plain-layout weight".into())
             })?;
@@ -898,7 +926,7 @@ fn autotune_request_bf16_geglu(
         plain_weight,
         dual_weight,
         sm89_weight,
-        &gate,
+        Some(&gate),
         &reference_output,
         reference_tactic,
     )?;
@@ -933,7 +961,7 @@ fn autotune_request_bf16_geglu(
             plain_weight,
             dual_weight,
             sm89_weight,
-            &gate,
+            Some(&gate),
             &candidate_output,
             candidate.tactic,
         )?;
@@ -957,7 +985,7 @@ fn autotune_request_bf16_geglu(
                 plain_weight,
                 dual_weight,
                 sm89_weight,
-                &gate,
+                Some(&gate),
                 &candidate_output,
                 candidate.tactic,
             )?;
@@ -974,7 +1002,7 @@ fn autotune_request_bf16_geglu(
                     plain_weight,
                     dual_weight,
                     sm89_weight,
-                    &gate,
+                    Some(&gate),
                     &candidate_output,
                     candidate.tactic,
                 )
@@ -986,58 +1014,6 @@ fn autotune_request_bf16_geglu(
             correct: true,
         })
     })
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Bf16DualGeGluMode {
-    Auto,
-    Off,
-    On,
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Bf16DualGeGluWeightRoute {
-    Plain,
-    InterleavedPrimary,
-    InterleavedAuto,
-}
-
-#[cfg(test)]
-fn parse_bf16_dual_geglu_mode(value: Option<&str>) -> Result<Bf16DualGeGluMode> {
-    match value {
-        None | Some("auto") => Ok(Bf16DualGeGluMode::Auto),
-        Some("0" | "off") => Ok(Bf16DualGeGluMode::Off),
-        Some("1" | "on") => Ok(Bf16DualGeGluMode::On),
-        Some(value) => Err(Error::Other(format!(
-            "APXINF_PI05_BF16_DUAL_GEGLU must be auto, 0/off, or 1/on; got {value}"
-        ))),
-    }
-}
-
-#[cfg(test)]
-fn bf16_dual_geglu_weight_route(
-    mode: Bf16DualGeGluMode,
-    dual: bool,
-    primary_interleaved: bool,
-    auto_interleaved_available: bool,
-) -> Result<Bf16DualGeGluWeightRoute> {
-    match (
-        mode,
-        dual,
-        primary_interleaved,
-        auto_interleaved_available,
-    ) {
-        (Bf16DualGeGluMode::Off, false, false, false) => Ok(Bf16DualGeGluWeightRoute::Plain),
-        (Bf16DualGeGluMode::On, true, true, false) => Ok(Bf16DualGeGluWeightRoute::InterleavedPrimary),
-        (Bf16DualGeGluMode::Auto, false, false, false) => Ok(Bf16DualGeGluWeightRoute::Plain),
-        (Bf16DualGeGluMode::Auto, false, false, true) => Ok(Bf16DualGeGluWeightRoute::Plain),
-        (Bf16DualGeGluMode::Auto, true, false, true) => Ok(Bf16DualGeGluWeightRoute::InterleavedAuto),
-        _ => Err(Error::Other(format!(
-            "BF16 dual GeGLU config/layout mismatch: mode={mode:?}, backend_dual={dual}, primary_interleaved={primary_interleaved}, auto_interleaved={auto_interleaved_available}"
-        ))),
-    }
 }
 
 fn validate_bf16_dual_geglu_shape(
@@ -1060,71 +1036,12 @@ mod bf16_dual_geglu_tests {
     use super::*;
 
     #[test]
-    fn bf16_dual_geglu_mode_parser_is_strict_and_defaults_auto() {
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(None).unwrap(),
-            Bf16DualGeGluMode::Auto
-        );
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(Some("auto")).unwrap(),
-            Bf16DualGeGluMode::Auto
-        );
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(Some("0")).unwrap(),
-            Bf16DualGeGluMode::Off
-        );
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(Some("off")).unwrap(),
-            Bf16DualGeGluMode::Off
-        );
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(Some("1")).unwrap(),
-            Bf16DualGeGluMode::On
-        );
-        assert_eq!(
-            parse_bf16_dual_geglu_mode(Some("on")).unwrap(),
-            Bf16DualGeGluMode::On
-        );
-        assert!(parse_bf16_dual_geglu_mode(Some("invalid")).is_err());
-    }
-
-    #[test]
-    fn bf16_dual_geglu_route_truth_table_covers_all_twenty_four_states() {
-        for mode in [
-            Bf16DualGeGluMode::Auto,
-            Bf16DualGeGluMode::Off,
-            Bf16DualGeGluMode::On,
-        ] {
-            for dual in [false, true] {
-                for primary in [false, true] {
-                    for automatic in [false, true] {
-                        let expected = match (mode, dual, primary, automatic) {
-                            (Bf16DualGeGluMode::Off, false, false, false) => {
-                                Some(Bf16DualGeGluWeightRoute::Plain)
-                            }
-                            (Bf16DualGeGluMode::On, true, true, false) => {
-                                Some(Bf16DualGeGluWeightRoute::InterleavedPrimary)
-                            }
-                            (Bf16DualGeGluMode::Auto, false, false, false) => {
-                                Some(Bf16DualGeGluWeightRoute::Plain)
-                            }
-                            (Bf16DualGeGluMode::Auto, false, false, true) => {
-                                Some(Bf16DualGeGluWeightRoute::Plain)
-                            }
-                            (Bf16DualGeGluMode::Auto, true, false, true) => {
-                                Some(Bf16DualGeGluWeightRoute::InterleavedAuto)
-                            }
-                            _ => None,
-                        };
-                        let actual = bf16_dual_geglu_weight_route(mode, dual, primary, automatic);
-                        match expected {
-                            Some(route) => assert_eq!(actual.unwrap(), route),
-                            None => assert!(actual.is_err()),
-                        }
-                    }
-                }
-            }
-        }
+    fn dual_fused_tactic_does_not_require_gate_buffer() {
+        assert!(!bf16_geglu_tactic_uses_gate(TacticId {
+            backend: TacticBackend::CutlassBf16DualGeGluM522,
+            value: 0,
+        }));
+        assert!(bf16_geglu_tactic_uses_gate(decomposed_geglu_tactic()));
     }
 
     #[test]

--- a/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/bf16.rs
@@ -518,6 +518,24 @@ pub fn gemm_bf16_geglu_fused(
             },
         });
     }
+    if let Some(weight) = bf16_dual_geglu_auto_interleaved {
+        super::validate_geglu_weight(
+            "BF16 dual GeGLU auto-interleaved weight",
+            weight,
+            DType::BF16,
+            b,
+            expected_device,
+        )?;
+    }
+    if let Some(weight) = bf16_sm89_geglu_interleaved {
+        super::validate_geglu_weight(
+            "BF16 SM89 GeGLU interleaved weight",
+            weight,
+            DType::BF16,
+            b,
+            expected_device,
+        )?;
+    }
     super::observe_bf16(activation, packed_weight)?;
 
     let (m, k, full_n) = (a[0], a[1], b[1]);
@@ -538,9 +556,18 @@ pub fn gemm_bf16_geglu_fused(
         (Some(&primary_weight), automatic_interleaved.as_ref())
     };
 
-    let plain_key = tuning_key(ctx, m, full_n, k);
-    let mut plain_plan = None;
     let key = geglu_tuning_key(ctx, m, full_n, k);
+    let plain_key = tuning_key(ctx, m, full_n, k);
+    // A cold GeGLU key may tune both the complete operator and its decomposed
+    // GEMM candidate. Resolve that dependency before the outer tuning session
+    // takes its non-reentrant lock.
+    let mut plain_plan = if ctx.tuning().lookup_gemm_exact(&key).is_none() {
+        plain_weight
+            .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
+            .transpose()?
+    } else {
+        None
+    };
     let default = default_bf16_geglu_tactic(
         ctx,
         &key,
@@ -551,9 +578,6 @@ pub fn gemm_bf16_geglu_fused(
     let plan = ctx
         .gemm_plans()
         .resolve_or_tune(ctx, &key, default, |preferred| {
-            plain_plan = plain_weight
-                .map(|weight| resolve_bf16_plan(ctx, &plain_key, &activation_buffer, weight))
-                .transpose()?;
             autotune_request_bf16_geglu(
                 ctx,
                 &key,

--- a/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
@@ -158,7 +158,6 @@ impl Drop for CudaEventPair {
     }
 }
 
-#[cfg(test)]
 fn validate_fp8_dual_geglu_record(
     op: GemmOp,
     m: usize,
@@ -211,53 +210,6 @@ pub struct DynamicFp8WeightView<'a> {
     pub values_e4m3: &'a Tensor,
     /// FP32 scale for each output channel, shape `[N]`.
     pub channel_scales: &'a Tensor,
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Fp8DualGeGluMode {
-    Auto,
-    Off,
-    On,
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Fp8DualGeGluWeightRoute {
-    Plain,
-    InterleavedPrimary,
-    InterleavedAuto,
-}
-
-#[cfg(test)]
-fn parse_fp8_dual_geglu_mode(value: Option<&str>) -> Result<Fp8DualGeGluMode> {
-    match value {
-        None | Some("auto") => Ok(Fp8DualGeGluMode::Auto),
-        Some("0" | "off") => Ok(Fp8DualGeGluMode::Off),
-        Some("1" | "on") => Ok(Fp8DualGeGluMode::On),
-        Some(value) => Err(Error::Other(format!(
-            "APXINF_PI05_FP8_DUAL_GEGLU must be auto, 0/off, or 1/on; got {value}"
-        ))),
-    }
-}
-
-#[cfg(test)]
-fn fp8_dual_geglu_weight_route(
-    mode: Fp8DualGeGluMode,
-    dual_mega: bool,
-    primary_interleaved: bool,
-    auto_interleaved_available: bool,
-) -> Result<Fp8DualGeGluWeightRoute> {
-    match (mode, dual_mega, primary_interleaved, auto_interleaved_available) {
-        (Fp8DualGeGluMode::Off, false, false, false) => Ok(Fp8DualGeGluWeightRoute::Plain),
-        (Fp8DualGeGluMode::On, true, true, false) => Ok(Fp8DualGeGluWeightRoute::InterleavedPrimary),
-        (Fp8DualGeGluMode::Auto, false, false, false) => Ok(Fp8DualGeGluWeightRoute::Plain),
-        (Fp8DualGeGluMode::Auto, false, false, true) => Ok(Fp8DualGeGluWeightRoute::Plain),
-        (Fp8DualGeGluMode::Auto, true, false, true) => Ok(Fp8DualGeGluWeightRoute::InterleavedAuto),
-        _ => Err(Error::Other(format!(
-            "FP8 dual GeGLU config/layout mismatch: mode={mode:?}, backend_dual={dual_mega}, primary_interleaved={primary_interleaved}, auto_interleaved={auto_interleaved_available}"
-        ))),
-    }
 }
 
 fn tuning_key(ctx: &CudaContext, m: usize, n: usize, k: usize) -> GemmTuningKey {
@@ -477,6 +429,20 @@ pub fn gemm_fp8(
     Ok(output.into_tensor(Shape::new(vec![m, n]), DType::F16))
 }
 
+fn geglu_tuning_key(ctx: &CudaContext, m: usize, full_n: usize, k: usize) -> GemmTuningKey {
+    let mut key = tuning_key(ctx, m, full_n, k);
+    key.output_dtype = TuningDType::F8E4M3;
+    key.epilogue = Epilogue::GeGlu;
+    key
+}
+
+const fn decomposed_geglu_tactic() -> TacticId {
+    TacticId {
+        backend: TacticBackend::GemmThenGeGlu,
+        value: 0,
+    }
+}
+
 /// Dynamic FP8 GEMM with one activation scale per row and one weight scale
 /// per output channel. The native backend applies both vectors and an optional
 /// BF16 bias before returning the final BF16 matrix.
@@ -612,23 +578,6 @@ pub fn gemm_fp8_dynamic_bf16(
     }
 }
 
-/// Run the configured cuBLASLt gate + CUTLASS up/GeGLU/E4M3 fused tactic.
-/// Returns `None` unless the exact physical GEMM record selects this backend;
-/// a selected but unsupported record fails closed instead of falling back.
-fn geglu_tuning_key(ctx: &CudaContext, m: usize, full_n: usize, k: usize) -> GemmTuningKey {
-    let mut key = tuning_key(ctx, m, full_n, k);
-    key.output_dtype = TuningDType::F8E4M3;
-    key.epilogue = Epilogue::GeGlu;
-    key
-}
-
-const fn decomposed_geglu_tactic() -> TacticId {
-    TacticId {
-        backend: TacticBackend::GemmThenGeGlu,
-        value: 0,
-    }
-}
-
 /// Resolve and execute the complete FP8 gate/up projection plus GeGLU
 /// operator. A tactic may be one fused kernel or a prepared GEMM followed by
 /// the standalone GeGLU kernel; all candidates have identical final output.
@@ -699,21 +648,20 @@ pub fn gemm_fp8_geglu_fused(
     };
 
     let plain_key = tuning_key(ctx, m, full_n, k);
-    let plain_plan = plain_weight
-        .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
-        .transpose()?;
+    let mut plain_plan = None;
     let key = geglu_tuning_key(ctx, m, full_n, k);
-    let default = if plain_plan.is_some() {
-        decomposed_geglu_tactic()
-    } else {
-        TacticId {
-            backend: TacticBackend::CutlassFp8DualGeGlu,
-            value: 0,
-        }
-    };
+    let default = default_fp8_geglu_tactic(
+        ctx,
+        &key,
+        plain_weight.is_some(),
+        interleaved_weight.is_some(),
+    )?;
     let plan = ctx
         .gemm_plans()
         .resolve_or_tune(ctx, &key, default, |preferred| {
+            plain_plan = plain_weight
+                .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
+                .transpose()?;
             autotune_request_fp8_geglu(
                 ctx,
                 &key,
@@ -728,12 +676,19 @@ pub fn gemm_fp8_geglu_fused(
             )
         })?;
 
-    let gate = crate::workspace::output_buffer(
-        ctx,
-        m.checked_mul(full_n)
-            .and_then(|elements| elements.checked_mul(DType::F16.size_in_bytes()))
-            .ok_or_else(|| Error::Other("FP8 GeGLU gate size overflow".into()))?,
-    )?;
+    if plan.tactic.backend == TacticBackend::GemmThenGeGlu && plain_plan.is_none() {
+        plain_plan = plain_weight
+            .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
+            .transpose()?;
+    }
+    let mut gate = if fp8_geglu_tactic_uses_gate(plan.tactic) {
+        Some(crate::workspace::output_buffer(
+            ctx,
+            fp8_geglu_gate_bytes(m, full_n)?,
+        )?)
+    } else {
+        None
+    };
     let output = crate::workspace::output_buffer(
         ctx,
         m.checked_mul(n)
@@ -750,13 +705,13 @@ pub fn gemm_fp8_geglu_fused(
         &activation_buffer,
         plain_weight,
         interleaved_weight,
-        &gate,
+        gate.as_ref(),
         &output,
         alpha,
         output_scale,
         plan.tactic,
     ) {
-        if plan.tactic == default || plain_plan.is_none() {
+        if plan.tactic == default || plain_weight.is_none() {
             return Err(error);
         }
         eprintln!(
@@ -765,6 +720,17 @@ pub fn gemm_fp8_geglu_fused(
         );
         ctx.gemm_plans()
             .fallback_to(ctx, &key, decomposed_geglu_tactic())?;
+        if plain_plan.is_none() {
+            plain_plan = plain_weight
+                .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
+                .transpose()?;
+        }
+        if gate.is_none() {
+            gate = Some(crate::workspace::output_buffer(
+                ctx,
+                fp8_geglu_gate_bytes(m, full_n)?,
+            )?);
+        }
         prepare_fp8_geglu_tactic(
             &key,
             &plain_key,
@@ -778,7 +744,7 @@ pub fn gemm_fp8_geglu_fused(
             &activation_buffer,
             plain_weight,
             interleaved_weight,
-            &gate,
+            gate.as_ref(),
             &output,
             alpha,
             output_scale,
@@ -788,6 +754,61 @@ pub fn gemm_fp8_geglu_fused(
     Ok(Some(
         output.into_tensor(Shape::new(vec![m, n]), DType::F8E4M3),
     ))
+}
+
+fn fp8_geglu_tactic_uses_gate(tactic: TacticId) -> bool {
+    matches!(
+        tactic.backend,
+        TacticBackend::GemmThenGeGlu
+            | TacticBackend::CublasLtCustomSplitGeGluCutlass
+            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
+            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
+            | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
+    )
+}
+
+fn fp8_geglu_gate_bytes(m: usize, full_n: usize) -> Result<usize> {
+    m.checked_mul(full_n)
+        .and_then(|elements| elements.checked_mul(DType::F16.size_in_bytes()))
+        .ok_or_else(|| Error::Other("FP8 GeGLU gate size overflow".into()))
+}
+
+fn default_fp8_geglu_tactic(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    has_plain_weight: bool,
+    has_interleaved_weight: bool,
+) -> Result<TacticId> {
+    if has_plain_weight {
+        return Ok(decomposed_geglu_tactic());
+    }
+    validate_fp8_interleaved_default(ctx.caps().sm, key, has_interleaved_weight)?;
+    #[cfg(apxinf_cutlass_gemm)]
+    {
+        Ok(TacticId {
+            backend: TacticBackend::CutlassFp8DualGeGlu,
+            value: 0,
+        })
+    }
+    #[cfg(not(apxinf_cutlass_gemm))]
+    {
+        Err(Error::Other(
+            "FP8 interleaved-only GeGLU requires the SM100-family CUTLASS build".into(),
+        ))
+    }
+}
+
+fn validate_fp8_interleaved_default(
+    sm: u32,
+    key: &GemmTuningKey,
+    has_interleaved_weight: bool,
+) -> Result<()> {
+    if sm != 110 || !has_interleaved_weight {
+        return Err(Error::Other(format!(
+            "FP8 interleaved-only GeGLU requires an SM110 dual-GEMM weight and kernel for {key:?}"
+        )));
+    }
+    validate_fp8_dual_geglu_record(key.op, key.m, key.n, key.k, 0)
 }
 
 fn prepare_fp8_geglu_tactic(
@@ -813,7 +834,7 @@ fn launch_fp8_geglu_tactic(
     activation: &CudaBuffer,
     plain_weight: Option<&CudaBuffer>,
     interleaved_weight: Option<&CudaBuffer>,
-    gate: &CudaBuffer,
+    gate: Option<&CudaBuffer>,
     output: &CudaBuffer,
     alpha: f32,
     output_scale: f32,
@@ -822,6 +843,8 @@ fn launch_fp8_geglu_tactic(
     let n = key.n / 2;
     match tactic.backend {
         TacticBackend::GemmThenGeGlu => {
+            let gate =
+                gate.ok_or_else(|| Error::Other("decomposed FP8 GeGLU has no gate buffer".into()))?;
             let plain_plan = plain_plan.ok_or_else(|| {
                 Error::Other("decomposed FP8 GeGLU has no prepared GEMM plan".into())
             })?;
@@ -890,6 +913,8 @@ fn launch_fp8_geglu_tactic(
         | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
         | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
         | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm => {
+            let gate =
+                gate.ok_or_else(|| Error::Other("split FP8 GeGLU has no gate buffer".into()))?;
             let weight = plain_weight
                 .ok_or_else(|| Error::Other("split FP8 GeGLU has no plain-layout weight".into()))?;
             let (cutlass_tactic, expected_m) = match tactic.backend {
@@ -1000,7 +1025,7 @@ fn autotune_request_fp8_geglu(
         activation,
         plain_weight,
         interleaved_weight,
-        &gate,
+        Some(&gate),
         &reference_output,
         alpha,
         output_scale,
@@ -1038,7 +1063,7 @@ fn autotune_request_fp8_geglu(
             activation,
             plain_weight,
             interleaved_weight,
-            &gate,
+            Some(&gate),
             &candidate_output,
             alpha,
             output_scale,
@@ -1070,7 +1095,7 @@ fn autotune_request_fp8_geglu(
                 activation,
                 plain_weight,
                 interleaved_weight,
-                &gate,
+                Some(&gate),
                 &candidate_output,
                 alpha,
                 output_scale,
@@ -1088,7 +1113,7 @@ fn autotune_request_fp8_geglu(
                     activation,
                     plain_weight,
                     interleaved_weight,
-                    &gate,
+                    Some(&gate),
                     &candidate_output,
                     alpha,
                     output_scale,
@@ -1709,60 +1734,24 @@ pub fn cublaslt_fp8_gemm_split_first_f16(
 mod fp8_dual_geglu_tests {
     use super::*;
 
-    #[test]
-    fn mode_parser_is_tri_state_and_defaults_auto() {
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(None).unwrap(),
-            Fp8DualGeGluMode::Auto
-        );
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(Some("auto")).unwrap(),
-            Fp8DualGeGluMode::Auto
-        );
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(Some("0")).unwrap(),
-            Fp8DualGeGluMode::Off
-        );
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(Some("off")).unwrap(),
-            Fp8DualGeGluMode::Off
-        );
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(Some("1")).unwrap(),
-            Fp8DualGeGluMode::On
-        );
-        assert_eq!(
-            parse_fp8_dual_geglu_mode(Some("on")).unwrap(),
-            Fp8DualGeGluMode::On
-        );
-        assert!(parse_fp8_dual_geglu_mode(Some("invalid")).is_err());
-    }
-
-    #[test]
-    fn auto_routes_dual_to_copy_and_other_backends_to_plain() {
-        assert_eq!(
-            fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Auto, true, false, true).unwrap(),
-            Fp8DualGeGluWeightRoute::InterleavedAuto
-        );
-        assert_eq!(
-            fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Auto, false, false, true).unwrap(),
-            Fp8DualGeGluWeightRoute::Plain
-        );
-        assert_eq!(
-            fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Auto, false, false, false).unwrap(),
-            Fp8DualGeGluWeightRoute::Plain
-        );
-        assert_eq!(
-            fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Off, false, false, false).unwrap(),
-            Fp8DualGeGluWeightRoute::Plain
-        );
-        assert_eq!(
-            fp8_dual_geglu_weight_route(Fp8DualGeGluMode::On, true, true, false).unwrap(),
-            Fp8DualGeGluWeightRoute::InterleavedPrimary
-        );
-        assert!(fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Off, true, false, false).is_err());
-        assert!(fp8_dual_geglu_weight_route(Fp8DualGeGluMode::On, false, true, false).is_err());
-        assert!(fp8_dual_geglu_weight_route(Fp8DualGeGluMode::Auto, true, false, false).is_err());
+    fn geglu_key(sm: u32, m: usize) -> GemmTuningKey {
+        GemmTuningKey {
+            op: GemmOp::Fp8F16,
+            device: DeviceFingerprint {
+                sm,
+                multiprocessor_count: 20,
+            },
+            m,
+            n: 32768,
+            k: 2048,
+            activation_dtype: TuningDType::F8E4M3,
+            weight_dtype: TuningDType::F8E4M3,
+            output_dtype: TuningDType::F8E4M3,
+            layout: GemmLayout::RowMajor,
+            scale_mode: ScaleMode::PerTensor,
+            epilogue: Epilogue::GeGlu,
+            workspace_limit: usize::MAX,
+        }
     }
 
     #[test]
@@ -1781,6 +1770,23 @@ mod fp8_dual_geglu_tests {
         ] {
             assert!(validate_fp8_dual_geglu_record(op, m, n, k, tactic).is_err());
         }
+    }
+
+    #[test]
+    fn interleaved_only_default_requires_sm110_and_exact_shape() {
+        assert!(validate_fp8_interleaved_default(110, &geglu_key(110, 522), true).is_ok());
+        assert!(validate_fp8_interleaved_default(89, &geglu_key(89, 522), true).is_err());
+        assert!(validate_fp8_interleaved_default(110, &geglu_key(110, 522), false).is_err());
+        assert!(validate_fp8_interleaved_default(110, &geglu_key(110, 778), true).is_err());
+    }
+
+    #[test]
+    fn dual_fused_tactic_does_not_require_gate_buffer() {
+        assert!(!fp8_geglu_tactic_uses_gate(TacticId {
+            backend: TacticBackend::CutlassFp8DualGeGlu,
+            value: 0,
+        }));
+        assert!(fp8_geglu_tactic_uses_gate(decomposed_geglu_tactic()));
     }
 
     #[test]

--- a/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
@@ -213,6 +213,7 @@ pub struct DynamicFp8WeightView<'a> {
     pub channel_scales: &'a Tensor,
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Fp8DualGeGluMode {
     Auto,
@@ -220,6 +221,7 @@ enum Fp8DualGeGluMode {
     On,
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Fp8DualGeGluWeightRoute {
     Plain,
@@ -227,6 +229,7 @@ enum Fp8DualGeGluWeightRoute {
     InterleavedAuto,
 }
 
+#[cfg(test)]
 fn parse_fp8_dual_geglu_mode(value: Option<&str>) -> Result<Fp8DualGeGluMode> {
     match value {
         None | Some("auto") => Ok(Fp8DualGeGluMode::Auto),
@@ -238,17 +241,7 @@ fn parse_fp8_dual_geglu_mode(value: Option<&str>) -> Result<Fp8DualGeGluMode> {
     }
 }
 
-fn fp8_dual_geglu_mode() -> Result<Fp8DualGeGluMode> {
-    const NAME: &str = "APXINF_PI05_FP8_DUAL_GEGLU";
-    match std::env::var(NAME) {
-        Err(std::env::VarError::NotPresent) => parse_fp8_dual_geglu_mode(None),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            Err(Error::Other(format!("{NAME} must be valid Unicode")))
-        }
-        Ok(value) => parse_fp8_dual_geglu_mode(Some(&value)),
-    }
-}
-
+#[cfg(test)]
 fn fp8_dual_geglu_weight_route(
     mode: Fp8DualGeGluMode,
     dual_mega: bool,
@@ -294,6 +287,21 @@ pub fn exact_fp8_tactic(
         .lookup_gemm(&tuning_key(ctx, m, n, k))
         .filter(|resolved| resolved.source == crate::tuning::TacticMatch::Exact)
         .map(|resolved| resolved.tactic)
+}
+
+fn resolve_fp8_plan(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    activation: &CudaBuffer,
+    weight: &CudaBuffer,
+    alpha: f32,
+) -> Result<super::PreparedGemmPlan> {
+    ctx.gemm_plans().resolve_or_tune(
+        ctx,
+        key,
+        super::plan::default_fp8_tactic(key.m, key.n, key.k),
+        |preferred| autotune_request_fp8(ctx, key, activation, weight, alpha, preferred),
+    )
 }
 
 /// Physical static FP8 GEMM with FP16 output.
@@ -385,21 +393,7 @@ pub fn gemm_fp8(
 
     let key = tuning_key(ctx, m, n, k);
     let alpha = activation_scale * weight.scale;
-    let plan = ctx.gemm_plans().resolve_or_tune(
-        ctx,
-        &key,
-        super::plan::default_fp8_tactic(m, n, k),
-        |preferred| {
-            autotune_request_fp8(
-                ctx,
-                &key,
-                &activation_buffer,
-                &weight_buffer,
-                alpha,
-                preferred,
-            )
-        },
-    )?;
+    let plan = resolve_fp8_plan(ctx, &key, &activation_buffer, &weight_buffer, alpha)?;
     let selected_tactic = plan.tactic;
     let use_split_serial = matches!(
         selected_tactic.backend,
@@ -621,6 +615,23 @@ pub fn gemm_fp8_dynamic_bf16(
 /// Run the configured cuBLASLt gate + CUTLASS up/GeGLU/E4M3 fused tactic.
 /// Returns `None` unless the exact physical GEMM record selects this backend;
 /// a selected but unsupported record fails closed instead of falling back.
+fn geglu_tuning_key(ctx: &CudaContext, m: usize, full_n: usize, k: usize) -> GemmTuningKey {
+    let mut key = tuning_key(ctx, m, full_n, k);
+    key.output_dtype = TuningDType::F8E4M3;
+    key.epilogue = Epilogue::GeGlu;
+    key
+}
+
+const fn decomposed_geglu_tactic() -> TacticId {
+    TacticId {
+        backend: TacticBackend::GemmThenGeGlu,
+        value: 0,
+    }
+}
+
+/// Resolve and execute the complete FP8 gate/up projection plus GeGLU
+/// operator. A tactic may be one fused kernel or a prepared GEMM followed by
+/// the standalone GeGLU kernel; all candidates have identical final output.
 pub fn gemm_fp8_geglu_fused(
     ctx: &CudaContext,
     activation: &Tensor,
@@ -668,160 +679,429 @@ pub fn gemm_fp8_geglu_fused(
         });
     }
 
-    let (m, k, full_n) = (a[0], a[1], b[1]);
-    let key = tuning_key(ctx, m, full_n, k);
-    // A missing/non-fused record must reach the plain GEMM path without
-    // caching a Bucket/Default plan first; otherwise AUTO_TUNE would observe
-    // that cached plan and skip this exact key.
-    let Some(exact_tactic) = ctx.tuning().lookup_gemm_exact(&key) else {
-        return Ok(None);
-    };
-    let fused_backend = matches!(
-        exact_tactic.backend,
-        TacticBackend::CublasLtCustomSplitGeGluCutlass
-            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
-            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
-            | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
-            | TacticBackend::CutlassFp8DualGeGlu
-    );
-    if !fused_backend {
-        return Ok(None);
-    }
-    let plan =
-        ctx.gemm_plans()
-            .resolve(ctx, &key, super::plan::default_fp8_tactic(m, full_n, k))?;
-    let fused_tactic = (plan.source == super::plan::PlanSource::Exact).then_some(plan.tactic);
-    let (cutlass_geglu_tactic, tuned_m, dual_mega) = match fused_tactic.map(|tactic| tactic.backend)
-    {
-        Some(TacticBackend::CublasLtCustomSplitGeGluCutlass) => (0, 778, false),
-        Some(TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto) => (1, 778, false),
-        Some(TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3) => (2, 778, false),
-        Some(TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm) => (3, 522, false),
-        Some(TacticBackend::CutlassFp8DualGeGlu) => (0, m, true),
-        _ => return Ok(None),
-    };
-    if (m, full_n, k) != (tuned_m, 32768, 2048) {
-        return Err(Error::Other(format!(
-            "fused FP8 GeGLU backend is tuned only for [{tuned_m},2048] @ [2048,32768], got [{m},{k}] @ [{k},{full_n}]"
-        )));
-    }
     if crate::workspace::fp8_emulation_required(ctx)? {
-        return Err(Error::Other(
-            "FP8 fused GeGLU requires native FP8 Tensor Cores".into(),
-        ));
+        return Ok(None);
     }
-    let weight_route = fp8_dual_geglu_weight_route(
-        fp8_dual_geglu_mode()?,
-        dual_mega,
-        packed_weight.dual_geglu_interleaved,
-        packed_weight.dual_geglu_auto_interleaved.is_some(),
-    )?;
-    let selected_weight = match weight_route {
-        Fp8DualGeGluWeightRoute::Plain | Fp8DualGeGluWeightRoute::InterleavedPrimary => {
-            packed_weight.values_e4m3
-        }
-        Fp8DualGeGluWeightRoute::InterleavedAuto => {
-            packed_weight.dual_geglu_auto_interleaved.unwrap()
+    let (m, k, full_n) = (a[0], a[1], b[1]);
+    let n = full_n / 2;
+    let alpha = activation_scale * packed_weight.scale;
+    let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
+    let primary_weight = CudaBuffer::from_tensor(packed_weight.values_e4m3).map_err(Error::Cuda)?;
+    let automatic_interleaved = packed_weight
+        .dual_geglu_auto_interleaved
+        .map(CudaBuffer::from_tensor)
+        .transpose()
+        .map_err(Error::Cuda)?;
+    let (plain_weight, interleaved_weight) = if packed_weight.dual_geglu_interleaved {
+        (None, Some(&primary_weight))
+    } else {
+        (Some(&primary_weight), automatic_interleaved.as_ref())
+    };
+
+    let plain_key = tuning_key(ctx, m, full_n, k);
+    let plain_plan = plain_weight
+        .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
+        .transpose()?;
+    let key = geglu_tuning_key(ctx, m, full_n, k);
+    let default = if plain_plan.is_some() {
+        decomposed_geglu_tactic()
+    } else {
+        TacticId {
+            backend: TacticBackend::CutlassFp8DualGeGlu,
+            value: 0,
         }
     };
-    if selected_weight.dtype() != DType::F8E4M3 || selected_weight.shape().dims() != b {
-        return Err(Error::Other(format!(
-            "FP8 dual GeGLU selected weight must be E4M3 {b:?}, got {} {:?}",
-            selected_weight.dtype(),
-            selected_weight.shape().dims()
-        )));
-    }
-    if selected_weight.device() != expected_device {
-        return Err(Error::DeviceMismatch {
-            expected: expected_device,
-            got: selected_weight.device(),
-        });
-    }
+    let plan = ctx
+        .gemm_plans()
+        .resolve_or_tune(ctx, &key, default, |preferred| {
+            autotune_request_fp8_geglu(
+                ctx,
+                &key,
+                &plain_key,
+                plain_plan.as_ref(),
+                &activation_buffer,
+                plain_weight,
+                interleaved_weight,
+                alpha,
+                output_scale,
+                preferred,
+            )
+        })?;
 
-    #[cfg(not(apxinf_cutlass_gemm))]
-    {
-        let _ = (ctx, activation_scale, output_scale);
-        return Err(Error::Other(
-            "FP8 fused GeGLU requires the SM100-family CUTLASS build".into(),
-        ));
+    let gate = crate::workspace::output_buffer(
+        ctx,
+        m.checked_mul(full_n)
+            .and_then(|elements| elements.checked_mul(DType::F16.size_in_bytes()))
+            .ok_or_else(|| Error::Other("FP8 GeGLU gate size overflow".into()))?,
+    )?;
+    let output = crate::workspace::output_buffer(
+        ctx,
+        m.checked_mul(n)
+            .and_then(|elements| elements.checked_mul(DType::F8E4M3.size_in_bytes()))
+            .ok_or_else(|| Error::Other("FP8 GeGLU output size overflow".into()))?,
+    )?;
+    if crate::workspace::may_prepare_native_resources() {
+        prepare_fp8_geglu_tactic(&key, &plain_key, plain_plan.as_ref(), plan.tactic)?;
     }
-
-    #[cfg(apxinf_cutlass_gemm)]
-    {
-        let n = full_n / 2;
-        let output = crate::workspace::output_buffer(
-            ctx,
-            m.checked_mul(n)
-                .and_then(|elements| elements.checked_mul(DType::F8E4M3.size_in_bytes()))
-                .ok_or_else(|| Error::Other("FP8 fused GeGLU output size overflow".into()))?,
+    if let Err(error) = launch_fp8_geglu_tactic(
+        ctx,
+        &key,
+        plain_plan.as_ref(),
+        &activation_buffer,
+        plain_weight,
+        interleaved_weight,
+        &gate,
+        &output,
+        alpha,
+        output_scale,
+        plan.tactic,
+    ) {
+        if plan.tactic == default || plain_plan.is_none() {
+            return Err(error);
+        }
+        eprintln!(
+            "[apxinf] FP8 GeGLU tactic {:?} failed for {key:?}: {error}; using decomposed fallback",
+            plan.tactic
+        );
+        ctx.gemm_plans()
+            .fallback_to(ctx, &key, decomposed_geglu_tactic())?;
+        prepare_fp8_geglu_tactic(
+            &key,
+            &plain_key,
+            plain_plan.as_ref(),
+            decomposed_geglu_tactic(),
         )?;
-        let activation_buffer = CudaBuffer::from_tensor(activation).map_err(Error::Cuda)?;
-        let weight_buffer = CudaBuffer::from_tensor(selected_weight).map_err(Error::Cuda)?;
-        if dual_mega {
-            let status = unsafe {
-                ffi::apxinf_static_cutlass_fp8_dual_gemm_geglu_e4m3(
-                    activation_buffer.ptr(),
-                    weight_buffer.ptr(),
+        launch_fp8_geglu_tactic(
+            ctx,
+            &key,
+            plain_plan.as_ref(),
+            &activation_buffer,
+            plain_weight,
+            interleaved_weight,
+            &gate,
+            &output,
+            alpha,
+            output_scale,
+            decomposed_geglu_tactic(),
+        )?;
+    }
+    Ok(Some(
+        output.into_tensor(Shape::new(vec![m, n]), DType::F8E4M3),
+    ))
+}
+
+fn prepare_fp8_geglu_tactic(
+    key: &GemmTuningKey,
+    plain_key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    tactic: TacticId,
+) -> Result<()> {
+    if tactic.backend == TacticBackend::GemmThenGeGlu {
+        let plan = plain_plan.ok_or_else(|| {
+            Error::Other("decomposed FP8 GeGLU has no plain-weight GEMM plan".into())
+        })?;
+        return super::providers::prepare(plain_key, plan.tactic);
+    }
+    super::providers::prepare(key, tactic)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_fp8_geglu_tactic(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    activation: &CudaBuffer,
+    plain_weight: Option<&CudaBuffer>,
+    interleaved_weight: Option<&CudaBuffer>,
+    gate: &CudaBuffer,
+    output: &CudaBuffer,
+    alpha: f32,
+    output_scale: f32,
+    tactic: TacticId,
+) -> Result<()> {
+    let n = key.n / 2;
+    match tactic.backend {
+        TacticBackend::GemmThenGeGlu => {
+            let plain_plan = plain_plan.ok_or_else(|| {
+                Error::Other("decomposed FP8 GeGLU has no prepared GEMM plan".into())
+            })?;
+            let plain_weight = plain_weight.ok_or_else(|| {
+                Error::Other("decomposed FP8 GeGLU has no plain-layout weight".into())
+            })?;
+            launch_tactic_fp8(
+                ctx,
+                &plain_plan.key,
+                activation,
+                plain_weight,
+                gate,
+                alpha,
+                plain_plan.tactic,
+            )?;
+            unsafe {
+                ffi::check_cuda(ffi::apxinf_static_geglu_quant_f16_e4m3(
+                    gate.ptr(),
                     output.ptr(),
-                    m as i32,
+                    key.m as i32,
                     n as i32,
-                    k as i32,
-                    full_n as i32,
-                    activation_scale * packed_weight.scale,
                     output_scale,
                     ctx.stream().handle(),
-                )
+                ))
+                .map_err(Error::Cuda)
+            }
+        }
+        TacticBackend::CutlassFp8DualGeGlu => {
+            let weight = interleaved_weight.ok_or_else(|| {
+                Error::Other("FP8 dual-GEMM GeGLU has no interleaved weight".into())
+            })?;
+            #[cfg(apxinf_cutlass_gemm)]
+            {
+                let status = unsafe {
+                    ffi::apxinf_static_cutlass_fp8_dual_gemm_geglu_e4m3(
+                        activation.ptr(),
+                        weight.ptr(),
+                        output.ptr(),
+                        key.m as i32,
+                        n as i32,
+                        key.k as i32,
+                        key.n as i32,
+                        alpha,
+                        output_scale,
+                        ctx.stream().handle(),
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::Cuda(format!(
+                        "FP8 dual-GEMM GeGLU rejected [{},{},{}] ({status})",
+                        key.m, n, key.k
+                    )))
+                }
+            }
+            #[cfg(not(apxinf_cutlass_gemm))]
+            {
+                let _ = weight;
+                Err(Error::Other(
+                    "FP8 dual-GEMM GeGLU requires the SM100-family CUTLASS build".into(),
+                ))
+            }
+        }
+        TacticBackend::CublasLtCustomSplitGeGluCutlass
+        | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
+        | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
+        | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm => {
+            let weight = plain_weight
+                .ok_or_else(|| Error::Other("split FP8 GeGLU has no plain-layout weight".into()))?;
+            let (cutlass_tactic, expected_m) = match tactic.backend {
+                TacticBackend::CublasLtCustomSplitGeGluCutlass => (0, 778),
+                TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto => (1, 778),
+                TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3 => (2, 778),
+                TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm => (3, 522),
+                _ => unreachable!(),
             };
-            if status != 0 {
-                return Err(Error::Cuda(format!(
-                    "FP8 dual-GEMM GeGLU rejected [{m},{n},{k}] ({status})"
+            if (key.m, key.n, key.k) != (expected_m, 32768, 2048) {
+                return Err(Error::Other(format!(
+                    "split FP8 GeGLU tactic requires [{expected_m},2048] @ [2048,32768], got [{},{}] @ [{},{}]",
+                    key.m, key.k, key.k, key.n
                 )));
             }
-            return Ok(Some(
-                output.into_tensor(Shape::new(vec![m, n]), DType::F8E4M3),
-            ));
+            #[cfg(apxinf_cutlass_gemm)]
+            {
+                cublaslt_fp8_gemm_split_first_f16(
+                    ctx, activation, weight, gate, key.m, key.n, key.k, alpha,
+                )?;
+                let status = unsafe {
+                    ffi::apxinf_static_cutlass_fp8_gemm_geglu_e4m3(
+                        activation.ptr(),
+                        weight.ptr(),
+                        gate.ptr(),
+                        output.ptr(),
+                        key.m as i32,
+                        n as i32,
+                        key.k as i32,
+                        key.n as i32,
+                        alpha,
+                        output_scale,
+                        cutlass_tactic,
+                        ctx.stream().handle(),
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::Cuda(format!(
+                        "split FP8 GeGLU tactic {:?} rejected {:?} ({status})",
+                        tactic, key
+                    )))
+                }
+            }
+            #[cfg(not(apxinf_cutlass_gemm))]
+            {
+                let _ = (weight, cutlass_tactic);
+                Err(Error::Other(
+                    "split FP8 GeGLU requires the SM100-family CUTLASS build".into(),
+                ))
+            }
         }
-        let gate = crate::workspace::output_buffer(
-            ctx,
-            m.checked_mul(full_n)
-                .and_then(|elements| elements.checked_mul(DType::F16.size_in_bytes()))
-                .ok_or_else(|| Error::Other("FP8 fused GeGLU gate size overflow".into()))?,
-        )?;
-        cublaslt_fp8_gemm_split_first_f16(
-            ctx,
-            &activation_buffer,
-            &weight_buffer,
-            &gate,
-            m,
-            full_n,
-            k,
-            activation_scale * packed_weight.scale,
-        )?;
-        let status = unsafe {
-            ffi::apxinf_static_cutlass_fp8_gemm_geglu_e4m3(
-                activation_buffer.ptr(),
-                weight_buffer.ptr(),
-                gate.ptr(),
-                output.ptr(),
-                m as i32,
-                n as i32,
-                k as i32,
-                full_n as i32,
-                activation_scale * packed_weight.scale,
-                output_scale,
-                cutlass_geglu_tactic,
-                ctx.stream().handle(),
-            )
-        };
-        if status != 0 {
-            return Err(Error::Cuda(format!(
-                "FP8 fused GeGLU CUTLASS fused GeGLU rejected [{m},{n},{k}] ({status})"
-            )));
-        }
-        Ok(Some(
-            output.into_tensor(Shape::new(vec![m, n]), DType::F8E4M3),
-        ))
+        _ => Err(Error::Other(format!(
+            "FP8 GeGLU online autotune cannot execute {tactic:?}"
+        ))),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn autotune_request_fp8_geglu(
+    ctx: &CudaContext,
+    key: &GemmTuningKey,
+    plain_key: &GemmTuningKey,
+    plain_plan: Option<&super::PreparedGemmPlan>,
+    activation: &CudaBuffer,
+    plain_weight: Option<&CudaBuffer>,
+    interleaved_weight: Option<&CudaBuffer>,
+    alpha: f32,
+    output_scale: f32,
+    preferred: Option<TacticId>,
+) -> Result<TuningOutcome> {
+    let output_elements = key
+        .m
+        .checked_mul(key.n / 2)
+        .ok_or_else(|| Error::Other("FP8 GeGLU autotune output size overflow".into()))?;
+    let gate = CudaBuffer::alloc_zeros(
+        key.m
+            .checked_mul(key.n)
+            .and_then(|elements| elements.checked_mul(DType::F16.size_in_bytes()))
+            .ok_or_else(|| Error::Other("FP8 GeGLU autotune gate size overflow".into()))?,
+        ctx.device_id(),
+    )
+    .map_err(Error::Cuda)?;
+    let reference_output =
+        CudaBuffer::alloc_zeros(output_elements, ctx.device_id()).map_err(Error::Cuda)?;
+    let candidate_output =
+        CudaBuffer::alloc_zeros(output_elements, ctx.device_id()).map_err(Error::Cuda)?;
+    let decoded_output = CudaBuffer::alloc_zeros(
+        output_elements * DType::F16.size_in_bytes(),
+        ctx.device_id(),
+    )
+    .map_err(Error::Cuda)?;
+
+    let reference_tactic = if plain_plan.is_some() && plain_weight.is_some() {
+        decomposed_geglu_tactic()
+    } else {
+        TacticId {
+            backend: TacticBackend::CutlassFp8DualGeGlu,
+            value: 0,
+        }
+    };
+    prepare_fp8_geglu_tactic(key, plain_key, plain_plan, reference_tactic)?;
+    launch_fp8_geglu_tactic(
+        ctx,
+        key,
+        plain_plan,
+        activation,
+        plain_weight,
+        interleaved_weight,
+        &gate,
+        &reference_output,
+        alpha,
+        output_scale,
+        reference_tactic,
+    )?;
+    ctx.synchronize().map_err(Error::Cuda)?;
+    let reference = copy_fused_output(
+        ctx,
+        &reference_output,
+        Some(&decoded_output),
+        output_elements,
+        DType::F8E4M3,
+        output_scale,
+    )?;
+
+    let candidates = super::providers::geglu_candidates(key)
+        .into_iter()
+        .filter(|candidate| {
+            candidate.tactic.backend != TacticBackend::GemmThenGeGlu
+                || (plain_plan.is_some() && plain_weight.is_some())
+        })
+        .filter(|candidate| {
+            candidate.tactic.backend != TacticBackend::CutlassFp8DualGeGlu
+                || interleaved_weight.is_some()
+        });
+    let events = CudaEventPair::new()?;
+    let mut evictor = ColdL2Evictor::new(ctx)?;
+    let engine = AutoTuneEngine::new(AutoTuneConfig::default())?;
+    engine.tune_with_preferred(key, preferred, candidates, |candidate, config| {
+        prepare_fp8_geglu_tactic(key, plain_key, plain_plan, candidate.tactic)?;
+        launch_fp8_geglu_tactic(
+            ctx,
+            key,
+            plain_plan,
+            activation,
+            plain_weight,
+            interleaved_weight,
+            &gate,
+            &candidate_output,
+            alpha,
+            output_scale,
+            candidate.tactic,
+        )?;
+        ctx.synchronize().map_err(Error::Cuda)?;
+        let actual = copy_fused_output(
+            ctx,
+            &candidate_output,
+            Some(&decoded_output),
+            output_elements,
+            DType::F8E4M3,
+            output_scale,
+        )?;
+        let correct = crate::tuning::outputs_are_close(&reference, &actual, 0.03, 0.998);
+        if !correct {
+            return Ok(CandidateMeasurement {
+                tactic: candidate.tactic,
+                milliseconds: None,
+                correct: false,
+            });
+        }
+        for _ in 0..config.warmup_iterations {
+            evictor.evict(ctx)?;
+            launch_fp8_geglu_tactic(
+                ctx,
+                key,
+                plain_plan,
+                activation,
+                plain_weight,
+                interleaved_weight,
+                &gate,
+                &candidate_output,
+                alpha,
+                output_scale,
+                candidate.tactic,
+            )?;
+        }
+        ctx.synchronize().map_err(Error::Cuda)?;
+        let mut milliseconds = 0.0;
+        for _ in 0..config.benchmark_iterations {
+            milliseconds += events.measure(ctx, &mut evictor, || {
+                launch_fp8_geglu_tactic(
+                    ctx,
+                    key,
+                    plain_plan,
+                    activation,
+                    plain_weight,
+                    interleaved_weight,
+                    &gate,
+                    &candidate_output,
+                    alpha,
+                    output_scale,
+                    candidate.tactic,
+                )
+            })?;
+        }
+        Ok(CandidateMeasurement {
+            tactic: candidate.tactic,
+            milliseconds: Some(milliseconds / config.benchmark_iterations as f64),
+            correct: true,
+        })
+    })
 }
 
 pub fn native_fp8_gemm_supported_for_device(device: usize) -> Result<bool> {
@@ -1009,8 +1289,11 @@ fn launch_tactic_fp8(
     tactic: TacticId,
 ) -> Result<()> {
     match tactic.backend {
-        TacticBackend::Vendor | TacticBackend::CublasLt => {
+        TacticBackend::Vendor | TacticBackend::CublasLt | TacticBackend::CublasLtCustom => {
             cublaslt_fp8_gemm_f16(ctx, activation, weight, output, key.m, key.n, key.k, alpha)
+        }
+        TacticBackend::CublasLtCustomSplitSerial => {
+            cublaslt_fp8_gemm_split_f16(ctx, activation, weight, output, key.m, key.n, key.k, alpha)
         }
         TacticBackend::Cutlass => {
             #[cfg(apxinf_cutlass_gemm)]
@@ -1258,8 +1541,8 @@ fn fused_epilogue_id(epilogue: Epilogue) -> Result<i32> {
         Epilogue::Bias => Ok(1),
         Epilogue::BiasGelu => Ok(2),
         Epilogue::BiasResidual => Ok(3),
-        Epilogue::None => Err(Error::Other(
-            "plain GEMM cannot use a fused cuBLASLt epilogue configuration".into(),
+        Epilogue::None | Epilogue::GeGlu => Err(Error::Other(
+            "this operator cannot use a fused cuBLASLt bias epilogue configuration".into(),
         )),
     }
 }

--- a/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/fp8.rs
@@ -627,6 +627,15 @@ pub fn gemm_fp8_geglu_fused(
             },
         });
     }
+    if let Some(weight) = packed_weight.dual_geglu_auto_interleaved {
+        super::validate_geglu_weight(
+            "FP8 dual GeGLU auto-interleaved weight",
+            weight,
+            DType::F8E4M3,
+            b,
+            expected_device,
+        )?;
+    }
 
     if crate::workspace::fp8_emulation_required(ctx)? {
         return Ok(None);
@@ -647,9 +656,17 @@ pub fn gemm_fp8_geglu_fused(
         (Some(&primary_weight), automatic_interleaved.as_ref())
     };
 
-    let plain_key = tuning_key(ctx, m, full_n, k);
-    let mut plain_plan = None;
     let key = geglu_tuning_key(ctx, m, full_n, k);
+    let plain_key = tuning_key(ctx, m, full_n, k);
+    // Resolve a cold key's decomposed GEMM dependency before GeGLU tuning
+    // acquires the session-wide, non-reentrant tuning lock.
+    let mut plain_plan = if ctx.tuning().lookup_gemm_exact(&key).is_none() {
+        plain_weight
+            .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
+            .transpose()?
+    } else {
+        None
+    };
     let default = default_fp8_geglu_tactic(
         ctx,
         &key,
@@ -659,9 +676,6 @@ pub fn gemm_fp8_geglu_fused(
     let plan = ctx
         .gemm_plans()
         .resolve_or_tune(ctx, &key, default, |preferred| {
-            plain_plan = plain_weight
-                .map(|weight| resolve_fp8_plan(ctx, &plain_key, &activation_buffer, weight, alpha))
-                .transpose()?;
             autotune_request_fp8_geglu(
                 ctx,
                 &key,

--- a/crates/apxinf-cuda/src/kernels/gemm/mod.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/mod.rs
@@ -100,6 +100,29 @@ pub(super) fn observe_bf16(activation: &Tensor, weight: &Tensor) -> Result<()> {
     })
 }
 
+pub(super) fn validate_geglu_weight(
+    name: &str,
+    weight: &Tensor,
+    expected_dtype: DType,
+    expected_shape: &[usize],
+    expected_device: Device,
+) -> Result<()> {
+    if weight.dtype() != expected_dtype || weight.shape().dims() != expected_shape {
+        return Err(Error::Other(format!(
+            "{name} must be {expected_dtype} {expected_shape:?}, got {} {:?}",
+            weight.dtype(),
+            weight.shape().dims()
+        )));
+    }
+    if weight.device() != expected_device {
+        return Err(Error::DeviceMismatch {
+            expected: expected_device,
+            got: weight.device(),
+        });
+    }
+    Ok(())
+}
+
 pub fn matmul(ctx: &CudaContext, activation: &Tensor, weight: &Tensor) -> Result<Tensor> {
     if activation.dtype() != weight.dtype() {
         return Err(Error::DTypeMismatch {
@@ -235,4 +258,34 @@ pub fn write_ex(
             dtype, trans_a, trans_b, m, n, k, alpha, a, lda, b, ldb, beta, output, ldc,
         )
         .map_err(apxinf_core::Error::Cuda)
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+
+    #[test]
+    fn geglu_weight_contract_checks_dtype_shape_and_device() {
+        let weight = Tensor::zeros(vec![2, 4], DType::BF16);
+        assert!(
+            validate_geglu_weight("test weight", &weight, DType::BF16, &[2, 4], Device::Cpu,)
+                .is_ok()
+        );
+        assert!(
+            validate_geglu_weight("test weight", &weight, DType::F8E4M3, &[2, 4], Device::Cpu,)
+                .is_err()
+        );
+        assert!(
+            validate_geglu_weight("test weight", &weight, DType::BF16, &[4, 2], Device::Cpu,)
+                .is_err()
+        );
+        assert!(validate_geglu_weight(
+            "test weight",
+            &weight,
+            DType::BF16,
+            &[2, 4],
+            Device::Cuda(0),
+        )
+        .is_err());
+    }
 }

--- a/crates/apxinf-cuda/src/kernels/gemm/plan.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/plan.rs
@@ -34,6 +34,7 @@ pub struct GemmPlanCache {
 }
 
 impl GemmPlanCache {
+    #[cfg(test)]
     pub fn resolve(
         &self,
         ctx: &CudaContext,
@@ -162,11 +163,23 @@ impl GemmPlanCache {
     /// Replace a rejected prepared tactic with the provider-independent safe
     /// route so subsequent calls do not retry the failing launch.
     pub fn fallback(&self, ctx: &CudaContext, key: &GemmTuningKey) -> Result<PreparedGemmPlan> {
+        self.fallback_to(
+            ctx,
+            key,
+            TacticId {
+                backend: TacticBackend::Vendor,
+                value: 0,
+            },
+        )
+    }
+
+    pub(crate) fn fallback_to(
+        &self,
+        ctx: &CudaContext,
+        key: &GemmTuningKey,
+        tactic: TacticId,
+    ) -> Result<PreparedGemmPlan> {
         ensure_native_prepare_allowed(crate::workspace::may_prepare_native_resources())?;
-        let tactic = TacticId {
-            backend: TacticBackend::Vendor,
-            value: 0,
-        };
         providers::prepare(key, tactic)?;
         let plan = PreparedGemmPlan {
             key: key.clone(),

--- a/crates/apxinf-cuda/src/kernels/gemm/providers/cublaslt.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/providers/cublaslt.rs
@@ -6,15 +6,16 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
     use super::super::{bf16, fp8};
 
     match (key.op, tactic.backend) {
-        (GemmOp::Bf16, TacticBackend::CublasLt) => {
+        (GemmOp::Bf16, TacticBackend::CublasLt) if key.epilogue == Epilogue::None => {
             bf16::set_cublaslt_gemm_heuristic(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, false)
         }
-        (GemmOp::Fp8F16, TacticBackend::CublasLt) => {
-            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) {
+        (GemmOp::Fp8F16, TacticBackend::CublasLt) => match key.epilogue {
+            Epilogue::None => {
                 fp8::set_cublaslt_gemm_heuristic(key.m, key.n, key.k, tactic.value)?;
                 fp8::prepare_cublaslt_fp8_gemm(key.m, key.n, key.k)
-            } else {
+            }
+            Epilogue::Bias | Epilogue::BiasGelu | Epilogue::BiasResidual => {
                 fp8::set_cublaslt_fused_gemm_heuristic(
                     key.m,
                     key.n,
@@ -23,14 +24,15 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
                     tactic.value,
                 )
             }
-        }
-        (GemmOp::Bf16, TacticBackend::CublasLtCustom) => {
+            Epilogue::GeGlu => Err(Error::Other(format!(
+                "cuBLASLt provider rejected {tactic:?} for {key:?}"
+            ))),
+        },
+        (GemmOp::Bf16, TacticBackend::CublasLtCustom) if key.epilogue == Epilogue::None => {
             bf16::set_cublaslt_gemm_custom(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, false)
         }
-        (GemmOp::Fp8F16, TacticBackend::CublasLtCustom)
-            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
-        {
+        (GemmOp::Fp8F16, TacticBackend::CublasLtCustom) if key.epilogue == Epilogue::None => {
             fp8::set_cublaslt_gemm_custom(key.m, key.n, key.k, tactic.value)?;
             fp8::prepare_cublaslt_fp8_gemm(key.m, key.n, key.k)
         }
@@ -40,13 +42,13 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
             fp8::set_cublaslt_gemm_bias_custom(key.m, key.n, key.k, key.epilogue, tactic.value)
         }
         (GemmOp::Bf16, TacticBackend::CublasLtCustomSplitSerial)
-            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
+            if key.epilogue == Epilogue::None =>
         {
             bf16::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, true)
         }
         (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitSerial)
-            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
+            if key.epilogue == Epilogue::None =>
         {
             fp8::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
             fp8::prepare_cublaslt_fp8_gemm_split(key.m, key.n, key.k)
@@ -178,5 +180,21 @@ mod tests {
         assert!(candidates.iter().any(|candidate| {
             candidate.backend == TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
         }));
+    }
+
+    #[test]
+    fn plain_cublaslt_backends_reject_geglu_keys_before_native_prepare() {
+        for backend in [
+            TacticBackend::CublasLt,
+            TacticBackend::CublasLtCustom,
+            TacticBackend::CublasLtCustomSplitSerial,
+        ] {
+            let value = if backend == TacticBackend::CublasLt {
+                0
+            } else {
+                18_377_904
+            };
+            assert!(prepare(&key(Epilogue::GeGlu), TacticId { backend, value }).is_err());
+        }
     }
 }

--- a/crates/apxinf-cuda/src/kernels/gemm/providers/cublaslt.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/providers/cublaslt.rs
@@ -11,7 +11,7 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, false)
         }
         (GemmOp::Fp8F16, TacticBackend::CublasLt) => {
-            if key.epilogue == Epilogue::None {
+            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) {
                 fp8::set_cublaslt_gemm_heuristic(key.m, key.n, key.k, tactic.value)?;
                 fp8::prepare_cublaslt_fp8_gemm(key.m, key.n, key.k)
             } else {
@@ -28,7 +28,9 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
             bf16::set_cublaslt_gemm_custom(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, false)
         }
-        (GemmOp::Fp8F16, TacticBackend::CublasLtCustom) if key.epilogue == Epilogue::None => {
+        (GemmOp::Fp8F16, TacticBackend::CublasLtCustom)
+            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
+        {
             fp8::set_cublaslt_gemm_custom(key.m, key.n, key.k, tactic.value)?;
             fp8::prepare_cublaslt_fp8_gemm(key.m, key.n, key.k)
         }
@@ -38,23 +40,28 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
             fp8::set_cublaslt_gemm_bias_custom(key.m, key.n, key.k, key.epilogue, tactic.value)
         }
         (GemmOp::Bf16, TacticBackend::CublasLtCustomSplitSerial)
-            if key.epilogue == Epilogue::None =>
+            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
         {
             bf16::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, true)
         }
         (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitSerial)
-        | (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitGeGluCutlass)
+            if matches!(key.epilogue, Epilogue::None | Epilogue::GeGlu) =>
+        {
+            fp8::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
+            fp8::prepare_cublaslt_fp8_gemm_split(key.m, key.n, key.k)
+        }
+        (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitGeGluCutlass)
         | (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto)
         | (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3)
         | (GemmOp::Fp8F16, TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm)
-            if key.epilogue == Epilogue::None =>
+            if key.epilogue == Epilogue::GeGlu =>
         {
             fp8::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
             fp8::prepare_cublaslt_fp8_gemm_split(key.m, key.n, key.k)
         }
         (GemmOp::Bf16, TacticBackend::CublasLtCustomSplitGeGluCutlassBf16)
-            if key.epilogue == Epilogue::None =>
+            if key.epilogue == Epilogue::GeGlu =>
         {
             bf16::set_cublaslt_gemm_split_custom(key.m, key.n, key.k, tactic.value)?;
             bf16::prepare_cublaslt_gemm(key.m, key.n, key.k, true)
@@ -68,11 +75,108 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
 /// cuBLASLt discovers the actually supported algorithms through
 /// `cublasLtMatmulAlgoGetHeuristic`; these IDs only bound the requested result
 /// count passed to the native provider.
-pub(super) fn candidates(max_algorithms: usize) -> Vec<TacticId> {
-    (0..max_algorithms.min(64))
+pub(super) fn candidates(key: &GemmTuningKey, max_algorithms: usize) -> Vec<TacticId> {
+    let mut candidates = (0..max_algorithms.min(64))
         .map(|value| TacticId {
             backend: TacticBackend::CublasLt,
             value: value as i32,
         })
+        .collect::<Vec<_>>();
+    if key.device.sm != 110 {
+        return candidates;
+    }
+    let custom_backend = match (key.op, key.epilogue) {
+        (GemmOp::Bf16 | GemmOp::Fp8F16, Epilogue::None) => Some(TacticBackend::CublasLtCustom),
+        (GemmOp::Fp8F16, Epilogue::Bias | Epilogue::BiasResidual) => {
+            Some(TacticBackend::CublasLtCustomBias)
+        }
+        _ => None,
+    };
+    if let Some(backend) = custom_backend {
+        candidates.extend(custom_config_ids().map(|value| TacticId { backend, value }));
+    }
+    if key.epilogue == Epilogue::None && matches!(key.op, GemmOp::Bf16 | GemmOp::Fp8F16) {
+        candidates.extend(custom_config_ids().map(|value| TacticId {
+            backend: TacticBackend::CublasLtCustomSplitSerial,
+            value,
+        }));
+    }
+    candidates
+}
+
+pub(super) fn geglu_candidates(key: &GemmTuningKey) -> Vec<TacticId> {
+    if key.device.sm != 110 || key.epilogue != Epilogue::GeGlu {
+        return Vec::new();
+    }
+    let backends: &[TacticBackend] = match (key.op, key.m, key.n, key.k) {
+        (GemmOp::Fp8F16, 778, 32768, 2048) => &[
+            TacticBackend::CublasLtCustomSplitGeGluCutlass,
+            TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto,
+            TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3,
+        ],
+        (GemmOp::Fp8F16, 522, 32768, 2048) => {
+            &[TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm]
+        }
+        (GemmOp::Bf16, 789, 32768, 2048) => &[TacticBackend::CublasLtCustomSplitGeGluCutlassBf16],
+        _ => &[],
+    };
+    backends
+        .iter()
+        .flat_map(|&backend| custom_config_ids().map(move |value| TacticId { backend, value }))
         .collect()
+}
+
+/// Provider-owned CUDA 13 / SM110 algorithm configurations. These are
+/// physical cuBLASLt configurations, not model shapes; every exact workload
+/// validates them with cublasLtMatmulAlgoCheck before benchmarking.
+fn custom_config_ids() -> impl Iterator<Item = i32> {
+    [
+        18_377_904, 18_902_425, 18_923_959, 18_924_573, 18_924_956, 18_926_998, 18_927_004,
+    ]
+    .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tuning::{DeviceFingerprint, GemmLayout, ScaleMode, TuningDType};
+
+    fn key(epilogue: Epilogue) -> GemmTuningKey {
+        GemmTuningKey {
+            op: GemmOp::Fp8F16,
+            device: DeviceFingerprint {
+                sm: 110,
+                multiprocessor_count: 20,
+            },
+            m: 522,
+            n: 32768,
+            k: 2048,
+            activation_dtype: TuningDType::F8E4M3,
+            weight_dtype: TuningDType::F8E4M3,
+            output_dtype: TuningDType::F8E4M3,
+            layout: GemmLayout::RowMajor,
+            scale_mode: ScaleMode::PerTensor,
+            epilogue,
+            workspace_limit: usize::MAX,
+        }
+    }
+
+    #[test]
+    fn plain_fp8_candidates_include_custom_and_split_families() {
+        let candidates = candidates(&key(Epilogue::None), 2);
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.backend == TacticBackend::CublasLtCustom));
+        assert!(candidates
+            .iter()
+            .any(|candidate| { candidate.backend == TacticBackend::CublasLtCustomSplitSerial }));
+    }
+
+    #[test]
+    fn geglu_candidates_are_shape_specific() {
+        let candidates = geglu_candidates(&key(Epilogue::GeGlu));
+        assert!(candidates.iter().any(|candidate| {
+            candidate.backend == TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
+        }));
+    }
 }

--- a/crates/apxinf-cuda/src/kernels/gemm/providers/cutlass.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/providers/cutlass.rs
@@ -3,7 +3,16 @@ use apxinf_core::{Error, Result};
 use crate::tuning::{Epilogue, GemmOp, GemmTuningKey, TacticBackend, TacticId};
 
 pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
-    if key.epilogue != Epilogue::None {
+    let plain = key.epilogue == Epilogue::None && tactic.backend == TacticBackend::Cutlass;
+    let geglu = key.epilogue == Epilogue::GeGlu
+        && matches!(
+            tactic.backend,
+            TacticBackend::CutlassFp8DualGeGlu
+                | TacticBackend::CutlassBf16DualGeGluM522
+                | TacticBackend::CutlassBf16DualGeGluM533
+                | TacticBackend::CutlassBf16GeGluSm89
+        );
+    if !plain && !geglu {
         return Err(Error::Other(format!(
             "CUTLASS provider does not implement {:?} for {key:?}",
             key.epilogue
@@ -25,6 +34,12 @@ pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
         }
         TacticBackend::CutlassBf16DualGeGluM533 => {
             key.op == GemmOp::Bf16 && (key.m, key.n, key.k, tactic.value) == (533, 32768, 2048, 0)
+        }
+        TacticBackend::CutlassBf16GeGluSm89 => {
+            key.op == GemmOp::Bf16
+                && key.device.sm == 89
+                && matches!((key.n, key.k), (8192, 1024) | (32768, 2048))
+                && tactic.value == 0
         }
         _ => false,
     };
@@ -56,6 +71,39 @@ pub(super) fn candidates(key: &GemmTuningKey) -> Vec<TacticId> {
         });
     }
     candidates
+}
+
+pub(super) fn geglu_candidates(key: &GemmTuningKey) -> Vec<TacticId> {
+    if key.epilogue != Epilogue::GeGlu {
+        return Vec::new();
+    }
+    if key.op == GemmOp::Bf16
+        && key.device.sm == 89
+        && matches!((key.n, key.k), (8192, 1024) | (32768, 2048))
+    {
+        return vec![TacticId {
+            backend: TacticBackend::CutlassBf16GeGluSm89,
+            value: 0,
+        }];
+    }
+    if (key.n, key.k) != (32768, 2048) {
+        return Vec::new();
+    }
+    match (key.op, key.m) {
+        (GemmOp::Fp8F16, 522 | 533) => vec![TacticId {
+            backend: TacticBackend::CutlassFp8DualGeGlu,
+            value: 0,
+        }],
+        (GemmOp::Bf16, 522) => vec![TacticId {
+            backend: TacticBackend::CutlassBf16DualGeGluM522,
+            value: 0,
+        }],
+        (GemmOp::Bf16, 533) => vec![TacticId {
+            backend: TacticBackend::CutlassBf16DualGeGluM533,
+            value: 0,
+        }],
+        _ => Vec::new(),
+    }
 }
 
 fn fp8_supported(key: &GemmTuningKey, tactic: i32) -> bool {

--- a/crates/apxinf-cuda/src/kernels/gemm/providers/mod.rs
+++ b/crates/apxinf-cuda/src/kernels/gemm/providers/mod.rs
@@ -9,10 +9,17 @@ use crate::tuning::{Epilogue, GemmOp, GemmTuningKey, TacticBackend, TacticCandid
 
 pub(super) fn prepare(key: &GemmTuningKey, tactic: TacticId) -> Result<()> {
     match tactic.backend {
+        TacticBackend::GemmThenGeGlu if key.epilogue == Epilogue::GeGlu && tactic.value == 0 => {
+            Ok(())
+        }
+        TacticBackend::GemmThenGeGlu => Err(Error::Other(format!(
+            "invalid decomposed GeGLU tactic {tactic:?} for {key:?}"
+        ))),
         TacticBackend::Cutlass
         | TacticBackend::CutlassFp8DualGeGlu
         | TacticBackend::CutlassBf16DualGeGluM522
-        | TacticBackend::CutlassBf16DualGeGluM533 => cutlass::prepare(key, tactic),
+        | TacticBackend::CutlassBf16DualGeGluM533
+        | TacticBackend::CutlassBf16GeGluSm89 => cutlass::prepare(key, tactic),
         TacticBackend::CublasLt
         | TacticBackend::CublasLtCustom
         | TacticBackend::CublasLtCustomBias
@@ -56,7 +63,7 @@ pub(super) fn candidates(
     });
     if matches!(key.op, GemmOp::Bf16 | GemmOp::Fp8F16) {
         tactics.extend(
-            cublaslt::candidates(max_cublaslt_algorithms)
+            cublaslt::candidates(key, max_cublaslt_algorithms)
                 .into_iter()
                 .map(|tactic| TacticCandidate { tactic }),
         );
@@ -68,5 +75,25 @@ pub(super) fn candidates(
                 .map(|tactic| TacticCandidate { tactic }),
         );
     }
+    tactics
+}
+
+/// Complete implementations of a gate/up projection followed by GeGLU.
+/// `GemmThenGeGlu` delegates to the separately tuned plain GEMM plan; the
+/// remaining candidates implement the same final output with fused kernels.
+pub(super) fn geglu_candidates(key: &GemmTuningKey) -> Vec<TacticCandidate> {
+    debug_assert_eq!(key.epilogue, Epilogue::GeGlu);
+    let mut tactics = vec![TacticCandidate {
+        tactic: TacticId {
+            backend: TacticBackend::GemmThenGeGlu,
+            value: 0,
+        },
+    }];
+    tactics.extend(
+        cublaslt::geglu_candidates(key)
+            .into_iter()
+            .chain(cutlass::geglu_candidates(key))
+            .map(|tactic| TacticCandidate { tactic }),
+    );
     tactics
 }

--- a/crates/apxinf-cuda/src/tests/bf16.rs
+++ b/crates/apxinf-cuda/src/tests/bf16.rs
@@ -31,9 +31,7 @@ fn bf16_geglu_fallback_observes_activation_once() {
         .to_device(&Tensor::from_bf16(vec![M, K], &vec![bf16::ZERO; M * K]).unwrap())
         .unwrap();
     let weight = backend
-        .to_device(
-            &Tensor::from_bf16(vec![K, FULL_N], &vec![bf16::ZERO; K * FULL_N]).unwrap(),
-        )
+        .to_device(&Tensor::from_bf16(vec![K, FULL_N], &vec![bf16::ZERO; K * FULL_N]).unwrap())
         .unwrap();
     let observer = Rc::new(CountingObserver(Cell::new(0)));
     let _guard = crate::kernels::gemm::install_bf16_observer(observer.clone()).unwrap();
@@ -47,11 +45,12 @@ fn bf16_geglu_fallback_observes_activation_once() {
         None,
     )
     .unwrap();
-    assert!(fused.is_none());
-    assert_eq!(observer.0.get(), 0, "a rejected fused probe must not observe");
-
-    crate::kernels::gemm::bf16(backend.context(), &activation, &weight).unwrap();
-    assert_eq!(observer.0.get(), 1, "the fallback must observe exactly once");
+    assert_eq!(fused.shape().dims(), [M, FULL_N / 2]);
+    assert_eq!(
+        observer.0.get(),
+        1,
+        "the decomposed GeGLU path must observe exactly once"
+    );
 }
 
 #[test]

--- a/crates/apxinf-cuda/src/tests/bf16.rs
+++ b/crates/apxinf-cuda/src/tests/bf16.rs
@@ -21,12 +21,19 @@ impl crate::kernels::gemm::Bf16ActivationObserver for CountingObserver {
 }
 
 #[test]
-fn bf16_geglu_fallback_observes_activation_once() {
+fn bf16_geglu_cold_autotune_resolves_dependencies_without_reentering_tune_lock() {
     const M: usize = 3;
     const K: usize = 5;
     const FULL_N: usize = 14;
 
     let backend = CudaBackend::new(0).unwrap();
+    crate::kernels::gemm::configure_tuning(
+        backend.context(),
+        crate::tuning::TuningMode::AutoTune,
+        &[],
+        None,
+    )
+    .unwrap();
     let activation = backend
         .to_device(&Tensor::from_bf16(vec![M, K], &vec![bf16::ZERO; M * K]).unwrap())
         .unwrap();
@@ -51,6 +58,23 @@ fn bf16_geglu_fallback_observes_activation_once() {
         1,
         "the decomposed GeGLU path must observe exactly once"
     );
+    for epilogue in [Epilogue::None, Epilogue::GeGlu] {
+        let key = GemmTuningKey {
+            op: GemmOp::Bf16,
+            device: DeviceFingerprint::from(backend.context().caps()),
+            m: M,
+            n: FULL_N,
+            k: K,
+            activation_dtype: TuningDType::Bf16,
+            weight_dtype: TuningDType::Bf16,
+            output_dtype: TuningDType::Bf16,
+            layout: GemmLayout::RowMajor,
+            scale_mode: ScaleMode::None,
+            epilogue,
+            workspace_limit: usize::MAX,
+        };
+        assert!(backend.context().tuning().lookup_gemm_exact(&key).is_some());
+    }
 }
 
 #[test]

--- a/crates/apxinf-cuda/src/tuning/db.rs
+++ b/crates/apxinf-cuda/src/tuning/db.rs
@@ -962,6 +962,31 @@ mod tests {
     }
 
     #[test]
+    fn migrates_pre_geglu_bf16_fused_record_to_complete_operator_key() {
+        assert_eq!(
+            normalize_legacy_geglu_key(
+                TacticBackend::CutlassBf16DualGeGluM522,
+                Epilogue::None,
+                TuningDType::Bf16,
+            ),
+            (Epilogue::GeGlu, TuningDType::Bf16)
+        );
+    }
+
+    #[test]
+    fn parses_legacy_map_geglu_backend_as_complete_operator() {
+        let db = TuningDb::from_json_str(
+            r#"{"device":"Thor sm_110","tactics":{"fp8_f16_m522_n32768_k2048":{"backend":"cutlass_fp8_dual_geglu","tactic":0}}}"#,
+        )
+        .unwrap();
+        let store = db.build_store(&caps(110), &versions()).unwrap();
+        let record = store.gemm_records().next().unwrap();
+        assert_eq!(record.key.epilogue, Epilogue::GeGlu);
+        assert_eq!(record.key.output_dtype, TuningDType::F8E4M3);
+        assert_eq!(record.tactic.backend, TacticBackend::CutlassFp8DualGeGlu);
+    }
+
+    #[test]
     fn parses_explicit_geglu_operator_key() {
         let db = TuningDb::from_json_str(
             r#"{

--- a/crates/apxinf-cuda/src/tuning/db.rs
+++ b/crates/apxinf-cuda/src/tuning/db.rs
@@ -233,10 +233,12 @@ impl TuningDb {
                         version == record.tactic.backend.implementation_version()
                     });
                 let library_compatible = match record.tactic.backend {
-                    TacticBackend::Cutlass
+                    TacticBackend::GemmThenGeGlu
+                    | TacticBackend::Cutlass
                     | TacticBackend::CutlassFp8DualGeGlu
                     | TacticBackend::CutlassBf16DualGeGluM522
-                    | TacticBackend::CutlassBf16DualGeGluM533 => cuda_compatible,
+                    | TacticBackend::CutlassBf16DualGeGluM533
+                    | TacticBackend::CutlassBf16GeGluSm89 => cuda_compatible,
                     TacticBackend::CublasLt
                     | TacticBackend::CublasLtCustom
                     | TacticBackend::CublasLtCustomBias
@@ -510,6 +512,7 @@ fn parse_v1_record(index: usize, value: &serde_json::Value) -> Result<ParsedGemm
         "bias" => Epilogue::Bias,
         "bias_gelu" => Epilogue::BiasGelu,
         "bias_residual" => Epilogue::BiasResidual,
+        "geglu" => Epilogue::GeGlu,
         value => return invalid_field(&label, "epilogue", value),
     };
     let device = key
@@ -518,6 +521,11 @@ fn parse_v1_record(index: usize, value: &serde_json::Value) -> Result<ParsedGemm
         .transpose()?;
     let (backend, tactic) = parse_v1_tactic(record, &label)?;
     validate_tactic(&label, backend, tactic)?;
+    // v1 databases written before GeGLU became an explicit operator contract
+    // stored fused winners under the corresponding plain GEMM key. Normalize
+    // those records while loading so existing production databases keep
+    // working without allowing a fused plan to shadow a plain GEMM.
+    let (epilogue, output_dtype) = normalize_legacy_geglu_key(backend, epilogue, output_dtype);
     Ok(ParsedGemmRecord {
         op,
         device,
@@ -576,7 +584,11 @@ fn parse_legacy_tactics(value: &serde_json::Value) -> Result<Vec<ParsedGemmRecor
             k,
             activation_dtype: TuningDType::F8E4M3,
             weight_dtype: TuningDType::F8E4M3,
-            output_dtype: TuningDType::F16,
+            output_dtype: if is_geglu_backend(backend) {
+                TuningDType::F8E4M3
+            } else {
+                TuningDType::F16
+            },
             layout: GemmLayout::RowMajor,
             scale_mode: ScaleMode::PerTensor,
             // The legacy custom-bias records were measured on PI0.5's
@@ -585,6 +597,8 @@ fn parse_legacy_tactics(value: &serde_json::Value) -> Result<Vec<ParsedGemmRecor
             // instead of letting the record shadow a plain GEMM.
             epilogue: if backend == TacticBackend::CublasLtCustomBias {
                 Epilogue::BiasResidual
+            } else if is_geglu_backend(backend) {
+                Epilogue::GeGlu
             } else {
                 Epilogue::None
             },
@@ -627,6 +641,7 @@ fn parse_v1_tactic(
 
 fn parse_backend(value: &str, label: &str) -> Result<TacticBackend> {
     match value {
+        "gemm_then_geglu" => Ok(TacticBackend::GemmThenGeGlu),
         "cutlass" => Ok(TacticBackend::Cutlass),
         "cublaslt" => Ok(TacticBackend::CublasLt),
         "cublaslt_custom" => Ok(TacticBackend::CublasLtCustom),
@@ -649,6 +664,7 @@ fn parse_backend(value: &str, label: &str) -> Result<TacticBackend> {
         | "cutlass_fp8_dual_geglu_m533" => Ok(TacticBackend::CutlassFp8DualGeGlu),
         "cutlass_bf16_dual_geglu_m522" => Ok(TacticBackend::CutlassBf16DualGeGluM522),
         "cutlass_bf16_dual_geglu_m533" => Ok(TacticBackend::CutlassBf16DualGeGluM533),
+        "cutlass_bf16_geglu_sm89" => Ok(TacticBackend::CutlassBf16GeGluSm89),
         "cublaslt_custom_split_geglu_cutlass_bf16" => {
             Ok(TacticBackend::CublasLtCustomSplitGeGluCutlassBf16)
         }
@@ -734,6 +750,7 @@ fn invalid_field<T>(label: &str, field: &str, value: &str) -> Result<T> {
 
 fn validate_tactic(key: &str, backend: TacticBackend, tactic: i32) -> Result<()> {
     let valid = match backend {
+        TacticBackend::GemmThenGeGlu => tactic == 0,
         TacticBackend::Cutlass => (0..=7).contains(&tactic),
         TacticBackend::CublasLt => (0..64).contains(&tactic),
         TacticBackend::CublasLtCustom
@@ -748,7 +765,8 @@ fn validate_tactic(key: &str, backend: TacticBackend, tactic: i32) -> Result<()>
         }
         TacticBackend::CutlassFp8DualGeGlu
         | TacticBackend::CutlassBf16DualGeGluM522
-        | TacticBackend::CutlassBf16DualGeGluM533 => tactic == 0,
+        | TacticBackend::CutlassBf16DualGeGluM533
+        | TacticBackend::CutlassBf16GeGluSm89 => tactic == 0,
         TacticBackend::Vendor => tactic == 0,
     };
     if valid {
@@ -758,6 +776,44 @@ fn validate_tactic(key: &str, backend: TacticBackend, tactic: i32) -> Result<()>
             "CUDA tactic {key} has invalid {backend:?} id {tactic}"
         )))
     }
+}
+
+fn is_geglu_backend(backend: TacticBackend) -> bool {
+    matches!(
+        backend,
+        TacticBackend::CublasLtCustomSplitGeGluCutlass
+            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
+            | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
+            | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
+            | TacticBackend::CutlassFp8DualGeGlu
+            | TacticBackend::CutlassBf16DualGeGluM522
+            | TacticBackend::CutlassBf16DualGeGluM533
+            | TacticBackend::CutlassBf16GeGluSm89
+            | TacticBackend::CublasLtCustomSplitGeGluCutlassBf16
+    )
+}
+
+fn normalize_legacy_geglu_key(
+    backend: TacticBackend,
+    epilogue: Epilogue,
+    output_dtype: TuningDType,
+) -> (Epilogue, TuningDType) {
+    if epilogue != Epilogue::None || !is_geglu_backend(backend) {
+        return (epilogue, output_dtype);
+    }
+    let output_dtype = if backend == TacticBackend::CutlassFp8DualGeGlu
+        || matches!(
+            backend,
+            TacticBackend::CublasLtCustomSplitGeGluCutlass
+                | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmAuto
+                | TacticBackend::CublasLtCustomSplitGeGluCutlass2SmStage3
+                | TacticBackend::CublasLtCustomSplitGeGluCutlassM522Explicit2Sm
+        ) {
+        TuningDType::F8E4M3
+    } else {
+        output_dtype
+    };
+    (Epilogue::GeGlu, output_dtype)
 }
 
 fn parse_sm(device: &str) -> Option<u32> {
@@ -872,6 +928,68 @@ mod tests {
                 TacticBackend::CutlassFp8DualGeGlu
             );
         }
+    }
+
+    #[test]
+    fn migrates_pre_geglu_v1_fused_record_to_complete_operator_key() {
+        let db = TuningDb::from_json_str(
+            r#"{
+                "schema":"apxinf.cuda.tuning.v1",
+                "device_name":"test",
+                "sm":110,
+                "cuda_version":"12.6",
+                "cublas_version":"12.6",
+                "records":[{
+                    "key":{
+                        "op":"fp8_f16",
+                        "m":522,"n":32768,"k":2048,
+                        "activation_dtype":"f8e4m3",
+                        "weight_dtype":"f8e4m3",
+                        "output_dtype":"f16",
+                        "layout":"row_major",
+                        "scale_mode":"per_tensor",
+                        "epilogue":"none"
+                    },
+                    "tactic":{"backend":"cutlass_fp8_dual_geglu","id":0}
+                }]
+            }"#,
+        )
+        .unwrap();
+        let store = db.build_store(&caps(110), &versions()).unwrap();
+        let record = store.gemm_records().next().unwrap();
+        assert_eq!(record.key.epilogue, Epilogue::GeGlu);
+        assert_eq!(record.key.output_dtype, TuningDType::F8E4M3);
+    }
+
+    #[test]
+    fn parses_explicit_geglu_operator_key() {
+        let db = TuningDb::from_json_str(
+            r#"{
+                "schema":"apxinf.cuda.tuning.v1",
+                "device_name":"test",
+                "sm":110,
+                "cuda_version":"12.6",
+                "cublas_version":"12.6",
+                "records":[{
+                    "key":{
+                        "op":"fp8_f16",
+                        "m":522,"n":32768,"k":2048,
+                        "activation_dtype":"f8e4m3",
+                        "weight_dtype":"f8e4m3",
+                        "output_dtype":"f8e4m3",
+                        "layout":"row_major",
+                        "scale_mode":"per_tensor",
+                        "epilogue":"geglu"
+                    },
+                    "tactic":{"backend":"gemm_then_geglu","id":0}
+                }]
+            }"#,
+        )
+        .unwrap();
+        let store = db.build_store(&caps(110), &versions()).unwrap();
+        let record = store.gemm_records().next().unwrap();
+        assert_eq!(record.key.epilogue, Epilogue::GeGlu);
+        assert_eq!(record.tactic.backend, TacticBackend::GemmThenGeGlu);
     }
 
     #[test]

--- a/crates/apxinf-cuda/src/tuning/key.rs
+++ b/crates/apxinf-cuda/src/tuning/key.rs
@@ -49,6 +49,10 @@ pub enum Epilogue {
     Bias,
     BiasGelu,
     BiasResidual,
+    /// Gate/up projection followed by GeGLU. Unlike a conventional GEMM
+    /// epilogue this halves the last dimension, but it is part of the same
+    /// operator contract from the caller's point of view.
+    GeGlu,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/apxinf-cuda/src/tuning/report.rs
+++ b/crates/apxinf-cuda/src/tuning/report.rs
@@ -177,3 +177,30 @@ fn dtype_name(dtype: super::TuningDType) -> &'static str {
         super::TuningDType::I32 => "i32",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_thor_geglu_report_uses_complete_operator_keys() {
+        let report: Value = serde_json::from_str(include_str!(
+            "../../../../configs/tuning/nvidia/thor-sm110/tuning_report.json"
+        ))
+        .unwrap();
+        for run in report["runs"].as_array().unwrap() {
+            let backend = run["winner"]["backend"].as_str().unwrap();
+            if !backend.contains("geglu") {
+                continue;
+            }
+            let key = &run["key"];
+            assert_eq!(key["epilogue"], "geglu", "{backend}");
+            let expected_output = match key["op"].as_str().unwrap() {
+                "bf16" => "bf16",
+                "fp8_f16" => "f8e4m3",
+                op => panic!("unexpected GeGLU report op {op}"),
+            };
+            assert_eq!(key["output_dtype"], expected_output, "{backend}");
+        }
+    }
+}

--- a/crates/apxinf-cuda/src/tuning/report.rs
+++ b/crates/apxinf-cuda/src/tuning/report.rs
@@ -123,6 +123,7 @@ pub(crate) fn key_json(key: &GemmTuningKey) -> Value {
             super::Epilogue::Bias => "bias",
             super::Epilogue::BiasGelu => "bias_gelu",
             super::Epilogue::BiasResidual => "bias_residual",
+            super::Epilogue::GeGlu => "geglu",
         },
         "workspace_limit": key.workspace_limit,
     })
@@ -139,6 +140,7 @@ pub(crate) fn tactic_json(backend: TacticBackend, id: i32, milliseconds: Option<
 
 pub(crate) fn backend_name(backend: TacticBackend) -> &'static str {
     match backend {
+        TacticBackend::GemmThenGeGlu => "gemm_then_geglu",
         TacticBackend::Cutlass => "cutlass",
         TacticBackend::CublasLt => "cublaslt",
         TacticBackend::CublasLtCustom => "cublaslt_custom",
@@ -157,6 +159,7 @@ pub(crate) fn backend_name(backend: TacticBackend) -> &'static str {
         TacticBackend::CutlassFp8DualGeGlu => "cutlass_fp8_dual_geglu",
         TacticBackend::CutlassBf16DualGeGluM522 => "cutlass_bf16_dual_geglu_m522",
         TacticBackend::CutlassBf16DualGeGluM533 => "cutlass_bf16_dual_geglu_m533",
+        TacticBackend::CutlassBf16GeGluSm89 => "cutlass_bf16_geglu_sm89",
         TacticBackend::CublasLtCustomSplitGeGluCutlassBf16 => {
             "cublaslt_custom_split_geglu_cutlass_bf16"
         }

--- a/crates/apxinf-cuda/src/tuning/store.rs
+++ b/crates/apxinf-cuda/src/tuning/store.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use apxinf_core::{Error, Result};
 
-use super::key::{GemmBucketKey, GemmTuningKey};
+use super::key::{Epilogue, GemmBucketKey, GemmTuningKey};
 use super::tactic::TacticId;
 
 #[cfg(test)]
@@ -44,7 +44,7 @@ impl TacticStore {
                 }
             }
             exact_gemm.insert(record.key.clone(), record.clone());
-            if !record.tactic.backend.bucket_eligible() {
+            if !bucket_eligible(&record) {
                 continue;
             }
             let bucket = record.key.bucket();
@@ -117,7 +117,7 @@ impl TacticStore {
     fn rebuild_buckets(&mut self) {
         self.bucket_gemm.clear();
         for record in self.exact_gemm.values() {
-            if !record.tactic.backend.bucket_eligible() {
+            if !bucket_eligible(record) {
                 continue;
             }
             let bucket = record.key.bucket();
@@ -129,6 +129,13 @@ impl TacticStore {
             }
         }
     }
+}
+
+fn bucket_eligible(record: &GemmTuningRecord) -> bool {
+    // GeGLU implementations are complete operators and several are pinned to
+    // an exact M. Never derive a bucket entry for them, even if a malformed or
+    // legacy database labels one with a shape-generic backend.
+    record.key.epilogue != Epilogue::GeGlu && record.tactic.backend.bucket_eligible()
 }
 
 fn is_faster(candidate: &GemmTuningRecord, current: &GemmTuningRecord) -> bool {
@@ -206,5 +213,22 @@ mod tests {
         assert_eq!(store.lookup_gemm_bucket(&key(11)).unwrap().value, 4);
         assert!(!store.upsert_gemm(record(10, 4, 0.02)));
         assert!(!store.upsert_gemm(record(10, 5, 0.04)));
+    }
+
+    #[test]
+    fn geglu_records_are_exact_only_even_for_generic_backends() {
+        let mut record = record(522, 0, 0.01);
+        record.key.epilogue = Epilogue::GeGlu;
+        let store = TacticStore::from_gemm_records([record]).unwrap();
+        assert!(store
+            .lookup_gemm_exact(&{
+                let mut key = key(522);
+                key.epilogue = Epilogue::GeGlu;
+                key
+            })
+            .is_some());
+        let mut other = key(789);
+        other.epilogue = Epilogue::GeGlu;
+        assert!(store.lookup_gemm_bucket(&other).is_none());
     }
 }

--- a/crates/apxinf-cuda/src/tuning/tactic.rs
+++ b/crates/apxinf-cuda/src/tuning/tactic.rs
@@ -3,6 +3,10 @@
 /// Physical implementation family selected for one GEMM problem.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TacticBackend {
+    /// Execute the already prepared plain GEMM winner followed by the
+    /// standalone GeGLU kernel. This is the safe composite implementation of
+    /// the GeGLU projection operator.
+    GemmThenGeGlu,
     Cutlass,
     CublasLt,
     /// Fully specified cuBLASLt algorithm configuration. Unlike a heuristic
@@ -17,6 +21,7 @@ pub enum TacticBackend {
     CutlassFp8DualGeGlu,
     CutlassBf16DualGeGluM522,
     CutlassBf16DualGeGluM533,
+    CutlassBf16GeGluSm89,
     CublasLtCustomSplitGeGluCutlassBf16,
     Vendor,
 }
@@ -47,6 +52,7 @@ impl TacticBackend {
     /// generated kernel changes; unrelated source edits keep all winners.
     pub const fn implementation_version(self) -> u32 {
         match self {
+            Self::GemmThenGeGlu => 1,
             Self::Cutlass => 1,
             Self::CublasLt => 1,
             Self::CublasLtCustom => 1,
@@ -59,6 +65,7 @@ impl TacticBackend {
             Self::CutlassFp8DualGeGlu => 1,
             Self::CutlassBf16DualGeGluM522 => 1,
             Self::CutlassBf16DualGeGluM533 => 1,
+            Self::CutlassBf16GeGluSm89 => 1,
             Self::CublasLtCustomSplitGeGluCutlassBf16 => 1,
             Self::Vendor => 1,
         }

--- a/crates/apxinf-model/src/pi05/bf16_executor.rs
+++ b/crates/apxinf-model/src/pi05/bf16_executor.rs
@@ -62,20 +62,14 @@ pub fn language_layer_bf16(
         &weights.post_attention_norm_scale,
         rms_eps,
     )?;
-    let activated = match gemm::bf16_geglu_fused(
+    let activated = gemm::bf16_geglu_fused(
         ctx,
         &fused.normalized,
         &weights.gate_up.weight,
         weights.gate_up.bf16_dual_geglu_interleaved,
         weights.gate_up.bf16_dual_geglu_auto_interleaved.as_ref(),
         weights.gate_up.bf16_sm89_geglu_interleaved.as_ref(),
-    )? {
-        Some(value) => value,
-        None => {
-            let gate_up = gemm::bf16(ctx, &fused.normalized, &weights.gate_up.weight)?;
-            activation::geglu_bf16(ctx, &gate_up)?
-        }
-    };
+    )?;
     let projected = gemm::bf16(ctx, &activated, &weights.down.weight)?;
     let hidden =
         fused::bias_residual_bf16(ctx, &projected, weights.down.bias.as_ref(), &fused.hidden)?;
@@ -140,20 +134,14 @@ pub fn action_layer_bf16(
         mlp_style,
         rms_eps,
     )?;
-    let activated = match gemm::bf16_geglu_fused(
+    let activated = gemm::bf16_geglu_fused(
         ctx,
         &fused.normalized,
         &weights.gate_up.weight,
         weights.gate_up.bf16_dual_geglu_interleaved,
         weights.gate_up.bf16_dual_geglu_auto_interleaved.as_ref(),
         weights.gate_up.bf16_sm89_geglu_interleaved.as_ref(),
-    )? {
-        Some(value) => value,
-        None => {
-            let gate_up = gemm::bf16(ctx, &fused.normalized, &weights.gate_up.weight)?;
-            activation::geglu_bf16(ctx, &gate_up)?
-        }
-    };
+    )?;
     let projected = gemm::bf16(ctx, &activated, &weights.down.weight)?;
     let fused = fused::adaptive_gate_residual_rms_bf16(
         ctx,


### PR DESCRIPTION
## Summary

Extend GEMM autotuning to cover complete GeGLU operators and specialized implementations.

## Changes

- Add `GeGlu` semantics to `GemmTuningKey`.
- Enumerate custom, split and dual-GEMM fused candidates.
- Validate and benchmark the final GeGLU output.
- Remove the requirement for an existing fused Exact tactic.
- Cache the winner as a `PreparedGemmPlan` before CUDA Graph capture.
- Migrate legacy fused tactic records to the new GeGLU key.
- Fall back safely to ordinary GEMM + GeGLU.

## Result

Thor FP8 PI0.5, starting from an empty tactic database:

- Autotune discovers fused/custom implementations.
- Restarted inference automatically reuses the generated tactics.
- P50: **41.416 ms**
- Production database P50: **41.607 ms**
- Eager and CUDA Graph outputs are bitwise equal.

## Validation

- 97 `apxinf-cuda` tests passed.
- 5 CUDA architecture tests passed.
- Rust formatting checks passed.