### PR TITLE
Add standalone policy adapters for LIBERO, robosuite, Isaac Lab, and Arena

### DIFF
--- a/scripts/connect_isaaclab.py
+++ b/scripts/connect_isaaclab.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Standalone Isaac Lab -> ApxInf policy adapter (PI0.5-LIBERO contract).
+
+Requires numpy, openpi-client, and the caller's Isaac Lab/torch installation.
+No other repository file is imported. ApxInfPolicy.get_action(env, observation)
+returns [N,7] torch actions on env.device. The caller supplies a ManagerBasedRLEnv
+with policy terms eef_pos, eef_quat (WXYZ), gripper_pos (two finger positions),
+and the two camera keys chosen explicitly. The state frame must be compatible
+with the trained policy; matching shapes alone does not establish equivalence.
+
+Requires arm_action relative-pose IK then gripper_action binary joint control.
+IK scale and gripper sign conversion are included below. Configure physical
+frames, cameras and frequency for your robot; arbitrary controllers are rejected.
+CLI requires --task, --prompt, --primary-camera and --wrist-camera; it does not
+select a default robot/scene or open a terminal prompt loop."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import importlib
+from collections import deque
+from typing import Any, Mapping
+
+import numpy as np
+
+POLICY_ACTION_DIM = 7
+POLICY_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+POLICY_STATE_KEY = "observation/state"
+POLICY_PROMPT_KEY = "prompt"
+
+
+def _scale_vector(value: Any) -> np.ndarray:
+    scale = np.asarray(value, dtype=np.float32)
+    if scale.shape == ():
+        scale = np.full(6, scale, dtype=np.float32)
+    if scale.shape != (6,) or not np.isfinite(scale).all() or (scale <= 0).any():
+        raise ValueError("relative IK scale must be a positive finite scalar or six-vector")
+    return scale
+
+
+def relative_ik_scale(env: Any) -> np.ndarray:
+    """Read the target environment contract; never guess from the robot name."""
+    arm = env.unwrapped.cfg.actions.arm_action
+    controller = getattr(arm, "controller", None)
+    if (getattr(controller, "command_type", None) != "pose"
+            or not getattr(controller, "use_relative_mode", False)):
+        raise ValueError("LIBERO adapter requires a relative pose IK arm_action controller")
+    return _scale_vector(arm.scale)
+
+
+def libero_action_to_relative_ik(
+    value: Any, *, controller_scale: Any, action_dim: int = 7,
+) -> np.ndarray:
+    """Match LIBERO's +/-5 cm, +/-0.5 rad OSC limits and gripper intent.
+
+    Input is the server's dataset-domain action, not a network-normalized latent.
+    Isaac applies its configured scale after this conversion. Extra mobile-base
+    channels stay zero. Coordinate frames and control frequency must still be
+    compatible with the chosen environment; this is not benchmark equivalence.
+    """
+    action = np.asarray(value, dtype=np.float32)
+    if action.shape != (7,):
+        raise ValueError(f"expected policy action (7,), got {action.shape}")
+    if not np.isfinite(action).all():
+        raise FloatingPointError("policy returned a non-finite action")
+    if action_dim < 7:
+        raise ValueError("target action dimension cannot be smaller than 7")
+    result = np.zeros(action_dim, dtype=np.float32)
+    physical_limits = np.array([0.05] * 3 + [0.5] * 3, dtype=np.float32)
+    result[:6] = np.clip(action[:6], -1, 1) * physical_limits / _scale_vector(controller_scale)
+    # LIBERO: positive closes. Isaac BinaryJointPositionAction: negative closes.
+    result[6] = -1.0 if action[6] >= 0.0 else 1.0
+    return result
+
+def _as_numpy(value: Any) -> np.ndarray:
+    detach = getattr(value, "detach", None)
+    if callable(detach):
+        value = detach()
+    cpu = getattr(value, "cpu", None)
+    if callable(cpu):
+        value = cpu()
+    return np.asarray(value)
+
+
+def _env_value(value: Any, env_index: int) -> np.ndarray:
+    array = _as_numpy(value)
+    if array.ndim == 0:
+        raise ValueError("expected an observation with an environment dimension")
+    if env_index >= array.shape[0]:
+        raise IndexError(f"environment {env_index} is outside observation shape {array.shape}")
+    return array[env_index]
+
+
+def _rgb_uint8(value: Any) -> np.ndarray:
+    image = _as_numpy(value)
+    if image.ndim != 3 or image.shape[-1] not in (3, 4):
+        raise ValueError(f"expected HWC RGB/RGBA image, got {image.shape}")
+    image = image[..., :3]
+    if not image.size or not np.isfinite(image).all():
+        raise ValueError("camera image must be non-empty and finite")
+    if image.dtype != np.uint8:
+        image = np.asarray(image, dtype=np.float32)
+        if image.size and float(np.nanmax(image)) <= 1.0:
+            image = image * 255.0
+        image = np.rint(np.clip(image, 0.0, 255.0)).astype(np.uint8)
+    return np.ascontiguousarray(image)
+
+
+def _quat_wxyz_to_axis_angle(value: Any) -> np.ndarray:
+    quat = np.asarray(value, dtype=np.float64).copy()
+    if quat.shape != (4,):
+        raise ValueError(f"expected quaternion (4,), got {quat.shape}")
+    norm = float(np.linalg.norm(quat))
+    if not np.isfinite(norm) or norm == 0.0:
+        raise ValueError("quaternion must be finite and non-zero")
+    quat /= norm
+    if quat[0] < 0.0:
+        quat = -quat
+    vector = quat[1:]
+    vector_norm = float(np.linalg.norm(vector))
+    if vector_norm < 1e-8:
+        return np.zeros(3, dtype=np.float32)
+    angle = 2.0 * np.arctan2(vector_norm, np.clip(quat[0], -1.0, 1.0))
+    return np.asarray(vector * (angle / vector_norm), dtype=np.float32)
+
+
+def build_policy_observation(
+    observation: Mapping[str, Any],
+    *,
+    env_index: int,
+    prompt: str,
+    primary_camera: str,
+    wrist_camera: str,
+) -> dict[str, Any]:
+    """Convert one Isaac Lab Franka environment observation to PI0.5 keys."""
+    policy = observation.get("policy", observation)
+    cameras = policy
+    if not isinstance(policy, Mapping):
+        raise TypeError("Arena observation['policy'] must be a mapping")
+    if not isinstance(cameras, Mapping):
+        raise KeyError("Arena observation has no 'camera_obs' group; pass --enable_cameras")
+
+    missing_state = [key for key in ("eef_pos", "eef_quat", "gripper_pos") if key not in policy]
+    missing_cameras = [key for key in (primary_camera, wrist_camera) if key not in cameras]
+    if missing_state:
+        raise KeyError(f"Arena policy observation is missing {missing_state}")
+    if missing_cameras:
+        raise KeyError(
+            f"Arena camera observation is missing {missing_cameras}; available={list(cameras)}"
+        )
+
+    eef_pos = np.asarray(_env_value(policy["eef_pos"], env_index), dtype=np.float32)
+    eef_quat = _env_value(policy["eef_quat"], env_index)
+    gripper = np.asarray(_env_value(policy["gripper_pos"], env_index), dtype=np.float32).reshape(-1)
+    if eef_pos.shape != (3,) or gripper.shape != (2,):
+        raise ValueError(
+            f"expected eef_pos (3,) and gripper_pos (2,), got {eef_pos.shape} and {gripper.shape}"
+        )
+    state = np.concatenate((eef_pos, _quat_wxyz_to_axis_angle(eef_quat), gripper))
+    if not np.isfinite(state).all():
+        raise ValueError("robot state must be finite")
+    return {
+        POLICY_IMAGE_KEYS[0]: _rgb_uint8(_env_value(cameras[primary_camera], env_index)),
+        POLICY_IMAGE_KEYS[1]: _rgb_uint8(_env_value(cameras[wrist_camera], env_index)),
+        POLICY_STATE_KEY: np.ascontiguousarray(state, dtype=np.float32),
+        POLICY_PROMPT_KEY: str(prompt),
+    }
+
+
+def validate_server_metadata(metadata: Mapping[str, Any]) -> None:
+    action_dim = metadata.get("action_dim")
+    if action_dim is not None and int(action_dim) != POLICY_ACTION_DIM:
+        raise RuntimeError(f"server action_dim is {action_dim}, expected {POLICY_ACTION_DIM}")
+    image_keys = metadata.get("image_keys")
+    if image_keys is not None and tuple(image_keys) != POLICY_IMAGE_KEYS:
+        raise RuntimeError(
+            f"server image_keys are {image_keys}, expected {list(POLICY_IMAGE_KEYS)}"
+        )
+    state_key = metadata.get("state_key")
+    if state_key is not None and state_key != POLICY_STATE_KEY:
+        raise RuntimeError(f"server state_key is {state_key!r}, expected {POLICY_STATE_KEY!r}")
+
+
+
+def connect(host: str, port: int):
+    """Create an OpenPI-compatible client; the simulator needs no ApxInf install."""
+    from openpi_client.websocket_client_policy import WebsocketClientPolicy
+
+    host = host.strip()
+    if not host:
+        raise ValueError("host must not be empty")
+    for key in ("NO_PROXY", "no_proxy"):
+        entries = [entry for entry in os.environ.get(key, "").split(",") if entry]
+        if host not in entries:
+            entries.append(host)
+        os.environ[key] = ",".join(entries)
+    return WebsocketClientPolicy(host, port)
+
+
+def close_client(client) -> None:
+    connection = getattr(client, "_ws", None)
+    if connection is not None:
+        connection.close()
+
+class ApxInfPolicy:
+    """Batch-aware adapter; the environment owner remains responsible for step/reset.
+
+    Requires relative pose IK as arm_action followed by a BinaryJointPosition
+    gripper_action. Set camera names explicitly to match the environment.
+    Call reset(terminated_env_ids) after environment auto-reset, or reset() after
+    resetting every environment. Inference is sequential across environments.
+    """
+
+    def __init__(self, *, primary_camera: str, wrist_camera: str, prompt: str | None = None,
+                 host: str = "127.0.0.1", port: int = 8000, replan_steps: int = 5,
+                 action_dim: int = 7, client=None):
+        if replan_steps <= 0 or action_dim < 7:
+            raise ValueError("replan_steps must be positive and action_dim must be at least 7")
+        self.prompt = prompt
+        self.task_description = None
+        self.primary_camera = primary_camera
+        self.wrist_camera = wrist_camera
+        self.replan_steps = replan_steps
+        self.action_dim = action_dim
+        self._plans = []
+        self._owns_client = client is None
+        self._client = connect(host, port) if client is None else client
+        try:
+            validate_server_metadata(self._client.get_server_metadata())
+        except Exception:
+            self.close()
+            raise
+
+    def set_prompt(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.reset()
+
+    def set_task_description(self, task_description: str | None) -> str:
+        self.task_description = task_description
+        self.reset()
+        return self._prompt()
+
+    def _prompt(self) -> str:
+        prompt = self.prompt if self.prompt is not None else self.task_description
+        if not prompt:
+            raise ValueError("supply a policy prompt or an environment task description")
+        return prompt
+
+    def reset(self, env_ids=None) -> None:
+        if env_ids is None:
+            for plan in self._plans:
+                plan.clear()
+            return
+        for index in np.asarray(_as_numpy(env_ids), dtype=np.int64).reshape(-1):
+            if self._plans:
+                self._plans[int(index)].clear()
+
+    def get_action(self, env, observation: Mapping[str, Any]):
+        import torch
+
+        target = env.unwrapped
+        scale = relative_ik_scale(env)
+        if target.action_manager.total_action_dim != self.action_dim:
+            raise ValueError("environment action dimension differs from configured action_dim")
+        if list(target.action_manager.active_terms[:2]) != ["arm_action", "gripper_action"]:
+            raise ValueError("requires arm_action then gripper_action in the target action layout")
+        gripper_type = target.cfg.actions.gripper_action.class_type
+        if gripper_type.__name__ != "BinaryJointPositionAction":
+            raise ValueError("requires BinaryJointPositionAction for the gripper")
+        policy_obs = observation.get("policy", observation)
+        positions = _as_numpy(policy_obs["eef_pos"])
+        if positions.ndim != 2 or positions.shape[1] != 3 or positions.shape[0] < 1:
+            raise ValueError("eef_pos must have shape [num_envs, 3]")
+        num_envs = positions.shape[0]
+        if not self._plans:
+            self._plans = [deque() for _ in range(num_envs)]
+        if len(self._plans) != num_envs:
+            raise ValueError("num_envs changed; create a new policy for the new environment")
+        for index, plan in enumerate(self._plans):
+            if plan:
+                continue
+            request = build_policy_observation(
+                observation, env_index=index, prompt=self._prompt(),
+                primary_camera=self.primary_camera, wrist_camera=self.wrist_camera,
+            )
+            response = self._client.infer(request)
+            actions = np.asarray(response["actions"], dtype=np.float32)
+            if actions.ndim != 2 or actions.shape[1] != 7:
+                raise ValueError(f"expected actions [H,7], got {actions.shape}")
+            if len(actions) < self.replan_steps:
+                raise ValueError("server horizon is shorter than replan_steps")
+            if not np.isfinite(actions).all():
+                raise FloatingPointError("policy returned non-finite actions")
+            plan.extend(libero_action_to_relative_ik(
+                row, controller_scale=scale, action_dim=self.action_dim,
+            ) for row in actions[:self.replan_steps])
+        batch = np.stack([plan.popleft() for plan in self._plans])
+        return torch.as_tensor(batch, device=target.device, dtype=torch.float32)
+
+    def close(self) -> None:
+        if self._owns_client:
+            close_client(self._client)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", required=True, help="registered Isaac Lab Gym task ID")
+    parser.add_argument("--task-module", help="optional installed module registering your task")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--primary-camera", required=True)
+    parser.add_argument("--wrist-camera", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--replan-steps", type=int, default=5)
+    parser.add_argument("--max-steps", type=int, default=520)
+    parser.add_argument("--num-envs", type=int, default=1)
+    from isaaclab.app import AppLauncher
+
+    AppLauncher.add_app_launcher_args(parser)
+    args = parser.parse_args()
+    if min(args.max_steps, args.replan_steps, args.num_envs) <= 0:
+        parser.error("max-steps, replan-steps and num-envs must be positive")
+    simulation_app = AppLauncher(args).app
+    env = policy = None
+    try:
+        import gymnasium as gym
+        import torch
+        import isaaclab_tasks  # noqa: F401 -- registers built-in task interfaces
+        from isaaclab_tasks.utils import parse_env_cfg
+
+        if args.task_module:
+            importlib.import_module(args.task_module)
+        cfg = parse_env_cfg(args.task, device=args.device, num_envs=args.num_envs)
+        env = gym.make(args.task, cfg=cfg)
+        observation, _ = env.reset()
+        policy = ApxInfPolicy(
+            prompt=args.prompt, primary_camera=args.primary_camera, wrist_camera=args.wrist_camera,
+            host=args.host, port=args.port, replan_steps=args.replan_steps,
+        )
+        steps = 0
+        while steps < args.max_steps and simulation_app.is_running():
+            with torch.inference_mode():
+                observation, _, terminated, truncated, _ = env.step(policy.get_action(env, observation))
+            steps += 1
+            # ManagerBasedRLEnv auto-resets done environments; discard their old chunks.
+            ids = (terminated | truncated).nonzero().flatten()
+            if len(ids):
+                policy.reset(ids)
+        print(f"Isaac Lab rollout completed: steps={steps}", flush=True)
+    finally:
+        if policy is not None:
+            policy.close()
+        if env is not None:
+            env.close()
+        simulation_app.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/connect_isaaclab_arena.py
+++ b/scripts/connect_isaaclab_arena.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Standalone Isaac Lab-Arena -> ApxInf policy adapter (PI0.5-LIBERO contract).
+
+Copy this file alone. Implements the PolicyBase public protocol consumed by
+Arena's native policy_runner without importing Arena/torch before AppLauncher.
+Targets Arena aad4f25 (feature/arena_v0.2_on_lab_2.3) and Isaac Lab 2.3.2.
+Requires numpy, openpi-client, and a working caller-installed Arena stack;
+this file does not install assets or patch third-party packages.
+
+Invoke this script with Arena's environment arguments plus --apxinf-primary-camera
+and --apxinf-wrist-camera. Arena owns scene/reset/step/metrics. No default task,
+LW-BenchHub placement, camera pose override, or interactive prompt UI is bundled.
+ApxInfPolicy can also be imported and used with a caller-created Arena environment.
+Policy state requires eef_pos/eef_quat (WXYZ)/gripper_pos; images come from
+camera_obs. Camera keys are explicit: no silent one-camera-to-two-view fallback.
+
+Only relative-pose IK arm_action followed by binary gripper_action is supported.
+Physical frame/frequency compatibility remains the caller's responsibility.
+Extra action channels are zero for a stationary base, not a general mobile policy."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from collections import deque
+from typing import Any, Mapping
+
+import numpy as np
+
+POLICY_ACTION_DIM = 7
+POLICY_IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+POLICY_STATE_KEY = "observation/state"
+POLICY_PROMPT_KEY = "prompt"
+
+
+def _scale_vector(value: Any) -> np.ndarray:
+    scale = np.asarray(value, dtype=np.float32)
+    if scale.shape == ():
+        scale = np.full(6, scale, dtype=np.float32)
+    if scale.shape != (6,) or not np.isfinite(scale).all() or (scale <= 0).any():
+        raise ValueError("relative IK scale must be a positive finite scalar or six-vector")
+    return scale
+
+
+def relative_ik_scale(env: Any) -> np.ndarray:
+    """Read the target environment contract; never guess from the robot name."""
+    arm = env.unwrapped.cfg.actions.arm_action
+    controller = getattr(arm, "controller", None)
+    if (getattr(controller, "command_type", None) != "pose"
+            or not getattr(controller, "use_relative_mode", False)):
+        raise ValueError("LIBERO adapter requires a relative pose IK arm_action controller")
+    return _scale_vector(arm.scale)
+
+
+def libero_action_to_relative_ik(
+    value: Any, *, controller_scale: Any, action_dim: int = 7,
+) -> np.ndarray:
+    """Match LIBERO's +/-5 cm, +/-0.5 rad OSC limits and gripper intent.
+
+    Input is the server's dataset-domain action, not a network-normalized latent.
+    Isaac applies its configured scale after this conversion. Extra mobile-base
+    channels stay zero. Coordinate frames and control frequency must still be
+    compatible with the chosen environment; this is not benchmark equivalence.
+    """
+    action = np.asarray(value, dtype=np.float32)
+    if action.shape != (7,):
+        raise ValueError(f"expected policy action (7,), got {action.shape}")
+    if not np.isfinite(action).all():
+        raise FloatingPointError("policy returned a non-finite action")
+    if action_dim < 7:
+        raise ValueError("target action dimension cannot be smaller than 7")
+    result = np.zeros(action_dim, dtype=np.float32)
+    physical_limits = np.array([0.05] * 3 + [0.5] * 3, dtype=np.float32)
+    result[:6] = np.clip(action[:6], -1, 1) * physical_limits / _scale_vector(controller_scale)
+    # LIBERO: positive closes. Isaac BinaryJointPositionAction: negative closes.
+    result[6] = -1.0 if action[6] >= 0.0 else 1.0
+    return result
+
+def _as_numpy(value: Any) -> np.ndarray:
+    detach = getattr(value, "detach", None)
+    if callable(detach):
+        value = detach()
+    cpu = getattr(value, "cpu", None)
+    if callable(cpu):
+        value = cpu()
+    return np.asarray(value)
+
+
+def _env_value(value: Any, env_index: int) -> np.ndarray:
+    array = _as_numpy(value)
+    if array.ndim == 0:
+        raise ValueError("expected an observation with an environment dimension")
+    if env_index >= array.shape[0]:
+        raise IndexError(f"environment {env_index} is outside observation shape {array.shape}")
+    return array[env_index]
+
+
+def _rgb_uint8(value: Any) -> np.ndarray:
+    image = _as_numpy(value)
+    if image.ndim != 3 or image.shape[-1] not in (3, 4):
+        raise ValueError(f"expected HWC RGB/RGBA image, got {image.shape}")
+    image = image[..., :3]
+    if not image.size or not np.isfinite(image).all():
+        raise ValueError("camera image must be non-empty and finite")
+    if image.dtype != np.uint8:
+        image = np.asarray(image, dtype=np.float32)
+        if image.size and float(np.nanmax(image)) <= 1.0:
+            image = image * 255.0
+        image = np.rint(np.clip(image, 0.0, 255.0)).astype(np.uint8)
+    return np.ascontiguousarray(image)
+
+
+def _quat_wxyz_to_axis_angle(value: Any) -> np.ndarray:
+    quat = np.asarray(value, dtype=np.float64).copy()
+    if quat.shape != (4,):
+        raise ValueError(f"expected quaternion (4,), got {quat.shape}")
+    norm = float(np.linalg.norm(quat))
+    if not np.isfinite(norm) or norm == 0.0:
+        raise ValueError("quaternion must be finite and non-zero")
+    quat /= norm
+    if quat[0] < 0.0:
+        quat = -quat
+    vector = quat[1:]
+    vector_norm = float(np.linalg.norm(vector))
+    if vector_norm < 1e-8:
+        return np.zeros(3, dtype=np.float32)
+    angle = 2.0 * np.arctan2(vector_norm, np.clip(quat[0], -1.0, 1.0))
+    return np.asarray(vector * (angle / vector_norm), dtype=np.float32)
+
+
+def build_policy_observation(
+    observation: Mapping[str, Any],
+    *,
+    env_index: int,
+    prompt: str,
+    primary_camera: str,
+    wrist_camera: str,
+) -> dict[str, Any]:
+    """Convert one Arena Franka environment observation to PI0.5 keys."""
+    policy = observation.get("policy", observation)
+    cameras = observation.get("camera_obs")
+    if not isinstance(policy, Mapping):
+        raise TypeError("Arena observation['policy'] must be a mapping")
+    if not isinstance(cameras, Mapping):
+        raise KeyError("Arena observation has no 'camera_obs' group; pass --enable_cameras")
+
+    missing_state = [key for key in ("eef_pos", "eef_quat", "gripper_pos") if key not in policy]
+    missing_cameras = [key for key in (primary_camera, wrist_camera) if key not in cameras]
+    if missing_state:
+        raise KeyError(f"Arena policy observation is missing {missing_state}")
+    if missing_cameras:
+        raise KeyError(
+            f"Arena camera observation is missing {missing_cameras}; available={list(cameras)}"
+        )
+
+    eef_pos = np.asarray(_env_value(policy["eef_pos"], env_index), dtype=np.float32)
+    eef_quat = _env_value(policy["eef_quat"], env_index)
+    gripper = np.asarray(_env_value(policy["gripper_pos"], env_index), dtype=np.float32).reshape(-1)
+    if eef_pos.shape != (3,) or gripper.shape != (2,):
+        raise ValueError(
+            f"expected eef_pos (3,) and gripper_pos (2,), got {eef_pos.shape} and {gripper.shape}"
+        )
+    state = np.concatenate((eef_pos, _quat_wxyz_to_axis_angle(eef_quat), gripper))
+    if not np.isfinite(state).all():
+        raise ValueError("robot state must be finite")
+    return {
+        POLICY_IMAGE_KEYS[0]: _rgb_uint8(_env_value(cameras[primary_camera], env_index)),
+        POLICY_IMAGE_KEYS[1]: _rgb_uint8(_env_value(cameras[wrist_camera], env_index)),
+        POLICY_STATE_KEY: np.ascontiguousarray(state, dtype=np.float32),
+        POLICY_PROMPT_KEY: str(prompt),
+    }
+
+
+def validate_server_metadata(metadata: Mapping[str, Any]) -> None:
+    action_dim = metadata.get("action_dim")
+    if action_dim is not None and int(action_dim) != POLICY_ACTION_DIM:
+        raise RuntimeError(f"server action_dim is {action_dim}, expected {POLICY_ACTION_DIM}")
+    image_keys = metadata.get("image_keys")
+    if image_keys is not None and tuple(image_keys) != POLICY_IMAGE_KEYS:
+        raise RuntimeError(
+            f"server image_keys are {image_keys}, expected {list(POLICY_IMAGE_KEYS)}"
+        )
+    state_key = metadata.get("state_key")
+    if state_key is not None and state_key != POLICY_STATE_KEY:
+        raise RuntimeError(f"server state_key is {state_key!r}, expected {POLICY_STATE_KEY!r}")
+
+
+
+def connect(host: str, port: int):
+    """Create an OpenPI-compatible client; the simulator needs no ApxInf install."""
+    from openpi_client.websocket_client_policy import WebsocketClientPolicy
+
+    host = host.strip()
+    if not host:
+        raise ValueError("host must not be empty")
+    for key in ("NO_PROXY", "no_proxy"):
+        entries = [entry for entry in os.environ.get(key, "").split(",") if entry]
+        if host not in entries:
+            entries.append(host)
+        os.environ[key] = ",".join(entries)
+    return WebsocketClientPolicy(host, port)
+
+
+def close_client(client) -> None:
+    connection = getattr(client, "_ws", None)
+    if connection is not None:
+        connection.close()
+
+class ApxInfPolicy:
+    """Batch-aware adapter; the environment owner remains responsible for step/reset.
+
+    Requires relative pose IK as arm_action followed by a BinaryJointPosition
+    gripper_action. Set camera names explicitly to match the environment.
+    Call reset(terminated_env_ids) after environment auto-reset, or reset() after
+    resetting every environment. Inference is sequential across environments.
+    """
+
+    def __init__(self, *, primary_camera: str, wrist_camera: str, prompt: str | None = None,
+                 host: str = "127.0.0.1", port: int = 8000, replan_steps: int = 5,
+                 action_dim: int = 7, client=None):
+        if replan_steps <= 0 or action_dim < 7:
+            raise ValueError("replan_steps must be positive and action_dim must be at least 7")
+        self.prompt = prompt
+        self.task_description = None
+        self.primary_camera = primary_camera
+        self.wrist_camera = wrist_camera
+        self.replan_steps = replan_steps
+        self.action_dim = action_dim
+        self._plans = []
+        self._owns_client = client is None
+        self._client = connect(host, port) if client is None else client
+        try:
+            validate_server_metadata(self._client.get_server_metadata())
+        except Exception:
+            self.close()
+            raise
+
+    def set_prompt(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.reset()
+
+    def set_task_description(self, task_description: str | None) -> str:
+        self.task_description = task_description
+        self.reset()
+        return self._prompt()
+
+    def _prompt(self) -> str:
+        prompt = self.prompt if self.prompt is not None else self.task_description
+        if not prompt:
+            raise ValueError("supply a policy prompt or an environment task description")
+        return prompt
+
+    def reset(self, env_ids=None) -> None:
+        if env_ids is None:
+            for plan in self._plans:
+                plan.clear()
+            return
+        for index in np.asarray(_as_numpy(env_ids), dtype=np.int64).reshape(-1):
+            if self._plans:
+                self._plans[int(index)].clear()
+
+    def get_action(self, env, observation: Mapping[str, Any]):
+        import torch
+
+        target = env.unwrapped
+        scale = relative_ik_scale(env)
+        if target.action_manager.total_action_dim != self.action_dim:
+            raise ValueError("environment action dimension differs from configured action_dim")
+        if list(target.action_manager.active_terms[:2]) != ["arm_action", "gripper_action"]:
+            raise ValueError("requires arm_action then gripper_action in the target action layout")
+        gripper_type = target.cfg.actions.gripper_action.class_type
+        if gripper_type.__name__ != "BinaryJointPositionAction":
+            raise ValueError("requires BinaryJointPositionAction for the gripper")
+        policy_obs = observation.get("policy", observation)
+        positions = _as_numpy(policy_obs["eef_pos"])
+        if positions.ndim != 2 or positions.shape[1] != 3 or positions.shape[0] < 1:
+            raise ValueError("eef_pos must have shape [num_envs, 3]")
+        num_envs = positions.shape[0]
+        if not self._plans:
+            self._plans = [deque() for _ in range(num_envs)]
+        if len(self._plans) != num_envs:
+            raise ValueError("num_envs changed; create a new policy for the new environment")
+        for index, plan in enumerate(self._plans):
+            if plan:
+                continue
+            request = build_policy_observation(
+                observation, env_index=index, prompt=self._prompt(),
+                primary_camera=self.primary_camera, wrist_camera=self.wrist_camera,
+            )
+            response = self._client.infer(request)
+            actions = np.asarray(response["actions"], dtype=np.float32)
+            if actions.ndim != 2 or actions.shape[1] != 7:
+                raise ValueError(f"expected actions [H,7], got {actions.shape}")
+            if len(actions) < self.replan_steps:
+                raise ValueError("server horizon is shorter than replan_steps")
+            if not np.isfinite(actions).all():
+                raise FloatingPointError("policy returned non-finite actions")
+            plan.extend(libero_action_to_relative_ik(
+                row, controller_scale=scale, action_dim=self.action_dim,
+            ) for row in actions[:self.replan_steps])
+        batch = np.stack([plan.popleft() for plan in self._plans])
+        return torch.as_tensor(batch, device=target.device, dtype=torch.float32)
+
+    def close(self) -> None:
+        if self._owns_client:
+            close_client(self._client)
+
+    # PolicyBase's public protocol, without importing Arena before AppLauncher.
+    @classmethod
+    def from_dict(cls, config: dict):
+        return cls(**config)
+
+    @staticmethod
+    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        group = parser.add_argument_group("ApxInf remote policy")
+        group.add_argument("--apxinf-host", default="127.0.0.1")
+        group.add_argument("--apxinf-port", type=int, default=8000)
+        group.add_argument("--apxinf-prompt", default=None)
+        group.add_argument("--apxinf-replan-steps", type=int, default=5)
+        group.add_argument("--apxinf-primary-camera", required=True)
+        group.add_argument("--apxinf-wrist-camera", required=True)
+        group.add_argument("--apxinf-action-dim", type=int, default=7)
+        group.add_argument("--remote_kill_on_exit", action="store_true",
+                           help="Arena compatibility only; never kills the shared server")
+        return parser
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace):
+        return cls(
+            host=args.apxinf_host, port=args.apxinf_port, prompt=args.apxinf_prompt,
+            replan_steps=args.apxinf_replan_steps, action_dim=args.apxinf_action_dim,
+            primary_camera=args.apxinf_primary_camera, wrist_camera=args.apxinf_wrist_camera,
+        )
+
+    def has_length(self) -> bool:
+        return False
+
+    def length(self):
+        return None
+
+    @property
+    def is_remote(self) -> bool:
+        return True
+
+    def shutdown_remote(self, kill_server: bool = False) -> None:
+        # Arena owns the rollout, not the shared inference server's lifecycle.
+        self.close()
+
+
+def main() -> None:
+    # Native Arena imports this module by dotted path only after AppLauncher.
+    script = Path(__file__).resolve()
+    sys.path.insert(0, str(script.parent))
+    if "--policy_type" not in sys.argv:
+        sys.argv[1:1] = ["--policy_type", f"{script.stem}.ApxInfPolicy"]
+    from isaaclab_arena.evaluation.policy_runner import main as arena_main
+
+    arena_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/connect_libero.py
+++ b/scripts/connect_libero.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Connect a caller-selected LIBERO ControlEnv to an ApxInf WebSocket policy.
+
+Copy this file alone; requires numpy, Pillow, openpi-client and your LIBERO
+installation. The Python interface is ApxInfPolicy.get_action(env, observation).
+For CLI use, --env-factory libero.libero.envs:OffScreenRenderEnv accepts
+--env-kwargs with the caller's bddl_file_name and camera settings.
+No suite/task layout is hardcoded. The caller supplies the prompt and any
+benchmark-specific initial state or settling protocol when using the interface.
+
+Supports the PI0.5-LIBERO Panda OSC_POSE contract only: raw agentview and wrist
+RGB, world-frame EEF position/XYZW quaternion, two raw finger joint positions,
+and 7D normalized OSC delta + gripper (-1 open, +1 close). Images are rotated
+180 degrees and resized/padded to 224. This is not an accuracy evaluator."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+from collections import deque
+from typing import Any, Mapping
+
+import numpy as np
+
+ACTION_DIM = 7
+IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+STATE_KEY = "observation/state"
+PROMPT_KEY = "prompt"
+
+
+def quat_xyzw_to_axis_angle(value: Any) -> np.ndarray:
+    """Convert robosuite's ``(x, y, z, w)`` quaternion to a rotation vector."""
+    quat = np.asarray(value, dtype=np.float64)
+    if quat.shape != (4,):
+        raise ValueError(f"expected quaternion (4,), got {quat.shape}")
+    norm = float(np.linalg.norm(quat))
+    if not math.isfinite(norm) or norm == 0.0:
+        raise ValueError("quaternion must be finite and non-zero")
+    quat = quat / norm
+    if quat[3] < 0.0:
+        quat = -quat
+    vector = quat[:3]
+    vector_norm = float(np.linalg.norm(vector))
+    if vector_norm < 1e-8:
+        return np.zeros(3, dtype=np.float32)
+    angle = 2.0 * math.atan2(vector_norm, float(np.clip(quat[3], -1.0, 1.0)))
+    return np.asarray(vector * (angle / vector_norm), dtype=np.float32)
+
+
+def _camera(value: Any) -> np.ndarray:
+    image = np.asarray(value)
+    if image.ndim != 3 or image.shape[-1] not in (3, 4):
+        raise ValueError(f"expected HWC RGB image, got {image.shape}")
+    image = image[..., :3]
+    if not image.size or not np.isfinite(image).all():
+        raise ValueError("camera image must be non-empty and finite")
+    if image.dtype != np.uint8:
+        if not np.issubdtype(image.dtype, np.floating):
+            raise ValueError(f"camera image must be uint8 or float, got {image.dtype}")
+        image = np.clip(image, 0.0, 1.0) * 255.0
+        image = image.astype(np.uint8)
+    # PI0.5-LIBERO training orientation: rotate both raw MuJoCo images by 180 degrees.
+    from PIL import Image
+
+    image = np.ascontiguousarray(image[::-1, ::-1])
+    height, width = image.shape[:2]
+    if height == 0 or width == 0:
+        raise ValueError("camera image must not be empty")
+    ratio = max(width / 224, height / 224)
+    resized_width, resized_height = max(1, int(width / ratio)), max(1, int(height / ratio))
+    resized = np.asarray(Image.fromarray(image).resize(
+        (resized_width, resized_height), resample=Image.Resampling.BILINEAR,
+    ))
+    canvas = np.zeros((224, 224, 3), dtype=np.uint8)
+    y, x = (224 - resized_height) // 2, (224 - resized_width) // 2
+    canvas[y:y + resized_height, x:x + resized_width] = resized
+    return canvas
+
+
+def build_policy_observation(observation: Mapping[str, Any], prompt: str) -> dict:
+    """Translate a Panda robosuite observation to the franka_libero wire contract."""
+    required = (
+        "agentview_image",
+        "robot0_eye_in_hand_image",
+        "robot0_eef_pos",
+        "robot0_eef_quat",
+        "robot0_gripper_qpos",
+    )
+    missing = [key for key in required if key not in observation]
+    if missing:
+        raise KeyError(f"robosuite observation is missing {missing}")
+    position = np.asarray(observation["robot0_eef_pos"], dtype=np.float32)
+    gripper = np.asarray(observation["robot0_gripper_qpos"], dtype=np.float32)
+    if position.shape != (3,) or gripper.shape != (2,):
+        raise ValueError(
+            f"expected eef_pos (3,) and gripper_qpos (2,), got "
+            f"{position.shape} and {gripper.shape}"
+        )
+    state = np.concatenate(
+        (
+            position,
+            quat_xyzw_to_axis_angle(observation["robot0_eef_quat"]),
+            gripper,
+        )
+    )
+    if not np.isfinite(state).all():
+        raise ValueError("robot state must be finite")
+    return {
+        IMAGE_KEYS[0]: _camera(observation["agentview_image"]),
+        IMAGE_KEYS[1]: _camera(observation["robot0_eye_in_hand_image"]),
+        STATE_KEY: np.ascontiguousarray(state, dtype=np.float32),
+        PROMPT_KEY: str(prompt),
+    }
+
+
+def validate_action_chunk(value: Any, replan_steps: int) -> np.ndarray:
+    actions = np.asarray(value, dtype=np.float32)
+    if actions.ndim != 2 or actions.shape[1] != ACTION_DIM:
+        raise ValueError(f"expected actions [H,{ACTION_DIM}], got {actions.shape}")
+    if actions.shape[0] < replan_steps:
+        raise ValueError(
+            f"server returned horizon {actions.shape[0]}, shorter than "
+            f"--replan-steps {replan_steps}"
+        )
+    if not np.isfinite(actions).all():
+        raise FloatingPointError("policy returned non-finite actions")
+    return actions
+
+
+def validate_server_metadata(metadata: Mapping[str, Any]) -> None:
+    action_dim = metadata.get("action_dim")
+    if action_dim is not None and int(action_dim) != ACTION_DIM:
+        raise RuntimeError(
+            f"server action_dim is {action_dim}, expected {ACTION_DIM}; "
+            "serve the checkpoint with --robot franka_libero"
+        )
+    image_keys = metadata.get("image_keys")
+    if image_keys is not None and tuple(image_keys) != IMAGE_KEYS:
+        raise RuntimeError(f"server image_keys are {image_keys}, expected {list(IMAGE_KEYS)}")
+    state_key = metadata.get("state_key")
+    if state_key is not None and state_key != STATE_KEY:
+        raise RuntimeError(f"server state_key is {state_key!r}, expected {STATE_KEY!r}")
+
+
+
+def connect(host: str, port: int):
+    """Create an OpenPI-compatible client; the simulator needs no ApxInf install."""
+    from openpi_client.websocket_client_policy import WebsocketClientPolicy
+
+    host = host.strip()
+    if not host:
+        raise ValueError("host must not be empty")
+    for key in ("NO_PROXY", "no_proxy"):
+        entries = [entry for entry in os.environ.get(key, "").split(",") if entry]
+        if host not in entries:
+            entries.append(host)
+        os.environ[key] = ",".join(entries)
+    return WebsocketClientPolicy(host, port)
+
+
+def close_client(client) -> None:
+    connection = getattr(client, "_ws", None)
+    if connection is not None:
+        connection.close()
+
+
+def validate_environment(env) -> None:
+    base = getattr(env, "env", env)
+    if getattr(base, "action_dim", None) != ACTION_DIM or len(base.robots) != 1:
+        raise ValueError("requires one Panda with 7D OSC_POSE + gripper actions")
+    robot = base.robots[0]
+    parts = getattr(robot, "part_controllers", {})
+    controller = parts.get("right") if parts else getattr(robot, "controller", None)
+    if getattr(controller, "name", None) != "OSC_POSE" or not controller.use_delta:
+        raise ValueError("requires a relative OSC_POSE controller, not joint/absolute control")
+    for key, expected in (
+        ("input_max", np.ones(6)), ("input_min", -np.ones(6)),
+        ("output_max", np.array([0.05] * 3 + [0.5] * 3)),
+        ("output_min", -np.array([0.05] * 3 + [0.5] * 3)),
+    ):
+        if not np.allclose(getattr(controller, key), expected):
+            raise ValueError(f"OSC controller {key} does not match PI0.5-LIBERO")
+
+
+class ApxInfPolicy:
+    """Adapt one compatible environment to PI0.5-LIBERO actions.
+
+    The caller owns reset/step/render and must call reset() at every episode
+    boundary. Injected clients remain caller-owned; close() only closes clients
+    created by this adapter. No environment or background input thread is created.
+    """
+
+    def __init__(self, *, prompt: str, host: str = "127.0.0.1", port: int = 8000,
+                 replan_steps: int = 5, client=None):
+        if replan_steps <= 0:
+            raise ValueError("replan_steps must be positive")
+        self.prompt = prompt
+        self.replan_steps = replan_steps
+        self._plan = deque()
+        self._owns_client = client is None
+        self._client = connect(host, port) if client is None else client
+        try:
+            validate_server_metadata(self._client.get_server_metadata())
+        except Exception:
+            self.close()
+            raise
+
+    def set_prompt(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.reset()
+
+    def reset(self) -> None:
+        self._plan.clear()
+
+    def get_action(self, env, observation: Mapping[str, Any]) -> np.ndarray:
+        validate_environment(env)
+        if not self._plan:
+            request = build_policy_observation(observation, self.prompt)
+            response = self._client.infer(request)
+            actions = validate_action_chunk(response["actions"], self.replan_steps)
+            self._plan.extend(row.copy() for row in actions[:self.replan_steps])
+        return self._plan.popleft()
+
+    def close(self) -> None:
+        if self._owns_client:
+            close_client(self._client)
+
+
+def run(env, policy: ApxInfPolicy, *, max_steps: int, render: bool = False) -> dict:
+    """Reset and run one episode; stop at done or the explicit step limit.
+
+    Does not close caller-owned env/policy. No grasp heuristic, hold steps,
+    prompt rewriting, default scene, or benchmark success-rate calculation.
+    """
+    if max_steps <= 0:
+        raise ValueError("max_steps must be positive")
+    observation = env.reset()
+    policy.reset()
+    done = False
+    for step in range(1, max_steps + 1):
+        action = policy.get_action(env, observation)
+        observation, _, done, _ = env.step(action)
+        if render:
+            getattr(env, "env", env).render()
+        if bool(done):
+            policy.reset()
+            break
+    return {"steps": step, "done": bool(done)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-factory", required=True,
+                        help="installed module:callable returning the configured environment")
+    parser.add_argument("--env-kwargs", default="{}", help="JSON keyword arguments for the factory")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--replan-steps", type=int, default=5)
+    parser.add_argument("--max-steps", type=int, default=520)
+    parser.add_argument("--render", action="store_true")
+    args = parser.parse_args()
+    if args.max_steps <= 0 or args.replan_steps <= 0:
+        parser.error("max-steps and replan-steps must be positive")
+    module_name, separator, callable_name = args.env_factory.partition(":")
+    if not separator or not module_name or not callable_name:
+        parser.error("--env-factory must have the form module:callable")
+    kwargs = json.loads(args.env_kwargs)
+    if not isinstance(kwargs, dict):
+        parser.error("--env-kwargs must be a JSON object")
+    factory = getattr(importlib.import_module(module_name), callable_name)
+    env = factory(**kwargs)
+    policy = None
+    try:
+        policy = ApxInfPolicy(prompt=args.prompt, host=args.host, port=args.port,
+                             replan_steps=args.replan_steps)
+        print(run(env, policy, max_steps=args.max_steps, render=args.render), flush=True)
+    finally:
+        if policy is not None:
+            policy.close()
+        env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/connect_robosuite.py
+++ b/scripts/connect_robosuite.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Connect a caller-selected robosuite environment to an ApxInf WebSocket policy.
+
+Copy this file alone; requires numpy, openpi-client and robosuite. Use
+ApxInfPolicy.get_action(env, observation) inside your existing rollout, or
+--env-factory robosuite:make --env-kwargs '<your environment configuration>'.
+The script does not create a default PickPlace scene or a prompt-input loop.
+
+Supports the PI0.5-LIBERO Panda OSC_POSE contract only: agentview_image,
+robot0_eye_in_hand_image, world-frame EEF position/XYZW quaternion, and two raw
+finger joint positions. Configure 7D OSC_POSE, input limits +/-1, translation
+limits +/-0.05 m, rotation limits +/-0.5 rad, and the standard Panda gripper
+(-1 open, +1 close). Joint/absolute controllers and arbitrary robots are not
+interchangeable with this contract. Both raw images are rotated 180 degrees
+to match LIBERO's training convention; configure the cameras accordingly."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+from collections import deque
+from typing import Any, Mapping
+
+import numpy as np
+
+ACTION_DIM = 7
+IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+STATE_KEY = "observation/state"
+PROMPT_KEY = "prompt"
+
+
+def quat_xyzw_to_axis_angle(value: Any) -> np.ndarray:
+    """Convert robosuite's ``(x, y, z, w)`` quaternion to a rotation vector."""
+    quat = np.asarray(value, dtype=np.float64)
+    if quat.shape != (4,):
+        raise ValueError(f"expected quaternion (4,), got {quat.shape}")
+    norm = float(np.linalg.norm(quat))
+    if not math.isfinite(norm) or norm == 0.0:
+        raise ValueError("quaternion must be finite and non-zero")
+    quat = quat / norm
+    if quat[3] < 0.0:
+        quat = -quat
+    vector = quat[:3]
+    vector_norm = float(np.linalg.norm(vector))
+    if vector_norm < 1e-8:
+        return np.zeros(3, dtype=np.float32)
+    angle = 2.0 * math.atan2(vector_norm, float(np.clip(quat[3], -1.0, 1.0)))
+    return np.asarray(vector * (angle / vector_norm), dtype=np.float32)
+
+
+def _camera(value: Any) -> np.ndarray:
+    image = np.asarray(value)
+    if image.ndim != 3 or image.shape[-1] not in (3, 4):
+        raise ValueError(f"expected HWC RGB image, got {image.shape}")
+    image = image[..., :3]
+    if not image.size or not np.isfinite(image).all():
+        raise ValueError("camera image must be non-empty and finite")
+    if image.dtype != np.uint8:
+        if not np.issubdtype(image.dtype, np.floating):
+            raise ValueError(f"camera image must be uint8 or float, got {image.dtype}")
+        image = np.clip(image, 0.0, 1.0) * 255.0
+        image = image.astype(np.uint8)
+    # PI0.5-LIBERO training orientation: rotate both raw MuJoCo images by 180 degrees.
+    return np.ascontiguousarray(image[::-1, ::-1])
+
+
+def build_policy_observation(observation: Mapping[str, Any], prompt: str) -> dict:
+    """Translate a Panda robosuite observation to the franka_libero wire contract."""
+    required = (
+        "agentview_image",
+        "robot0_eye_in_hand_image",
+        "robot0_eef_pos",
+        "robot0_eef_quat",
+        "robot0_gripper_qpos",
+    )
+    missing = [key for key in required if key not in observation]
+    if missing:
+        raise KeyError(f"robosuite observation is missing {missing}")
+    position = np.asarray(observation["robot0_eef_pos"], dtype=np.float32)
+    gripper = np.asarray(observation["robot0_gripper_qpos"], dtype=np.float32)
+    if position.shape != (3,) or gripper.shape != (2,):
+        raise ValueError(
+            f"expected eef_pos (3,) and gripper_qpos (2,), got "
+            f"{position.shape} and {gripper.shape}"
+        )
+    state = np.concatenate(
+        (
+            position,
+            quat_xyzw_to_axis_angle(observation["robot0_eef_quat"]),
+            gripper,
+        )
+    )
+    if not np.isfinite(state).all():
+        raise ValueError("robot state must be finite")
+    return {
+        IMAGE_KEYS[0]: _camera(observation["agentview_image"]),
+        IMAGE_KEYS[1]: _camera(observation["robot0_eye_in_hand_image"]),
+        STATE_KEY: np.ascontiguousarray(state, dtype=np.float32),
+        PROMPT_KEY: str(prompt),
+    }
+
+
+def validate_action_chunk(value: Any, replan_steps: int) -> np.ndarray:
+    actions = np.asarray(value, dtype=np.float32)
+    if actions.ndim != 2 or actions.shape[1] != ACTION_DIM:
+        raise ValueError(f"expected actions [H,{ACTION_DIM}], got {actions.shape}")
+    if actions.shape[0] < replan_steps:
+        raise ValueError(
+            f"server returned horizon {actions.shape[0]}, shorter than "
+            f"--replan-steps {replan_steps}"
+        )
+    if not np.isfinite(actions).all():
+        raise FloatingPointError("policy returned non-finite actions")
+    return actions
+
+
+def validate_server_metadata(metadata: Mapping[str, Any]) -> None:
+    action_dim = metadata.get("action_dim")
+    if action_dim is not None and int(action_dim) != ACTION_DIM:
+        raise RuntimeError(
+            f"server action_dim is {action_dim}, expected {ACTION_DIM}; "
+            "serve the checkpoint with --robot franka_libero"
+        )
+    image_keys = metadata.get("image_keys")
+    if image_keys is not None and tuple(image_keys) != IMAGE_KEYS:
+        raise RuntimeError(f"server image_keys are {image_keys}, expected {list(IMAGE_KEYS)}")
+    state_key = metadata.get("state_key")
+    if state_key is not None and state_key != STATE_KEY:
+        raise RuntimeError(f"server state_key is {state_key!r}, expected {STATE_KEY!r}")
+
+
+
+def connect(host: str, port: int):
+    """Create an OpenPI-compatible client; the simulator needs no ApxInf install."""
+    from openpi_client.websocket_client_policy import WebsocketClientPolicy
+
+    host = host.strip()
+    if not host:
+        raise ValueError("host must not be empty")
+    for key in ("NO_PROXY", "no_proxy"):
+        entries = [entry for entry in os.environ.get(key, "").split(",") if entry]
+        if host not in entries:
+            entries.append(host)
+        os.environ[key] = ",".join(entries)
+    return WebsocketClientPolicy(host, port)
+
+
+def close_client(client) -> None:
+    connection = getattr(client, "_ws", None)
+    if connection is not None:
+        connection.close()
+
+
+def validate_environment(env) -> None:
+    base = getattr(env, "env", env)
+    if getattr(base, "action_dim", None) != ACTION_DIM or len(base.robots) != 1:
+        raise ValueError("requires one Panda with 7D OSC_POSE + gripper actions")
+    robot = base.robots[0]
+    parts = getattr(robot, "part_controllers", {})
+    controller = parts.get("right") if parts else getattr(robot, "controller", None)
+    if getattr(controller, "name", None) != "OSC_POSE" or not controller.use_delta:
+        raise ValueError("requires a relative OSC_POSE controller, not joint/absolute control")
+    for key, expected in (
+        ("input_max", np.ones(6)), ("input_min", -np.ones(6)),
+        ("output_max", np.array([0.05] * 3 + [0.5] * 3)),
+        ("output_min", -np.array([0.05] * 3 + [0.5] * 3)),
+    ):
+        if not np.allclose(getattr(controller, key), expected):
+            raise ValueError(f"OSC controller {key} does not match PI0.5-LIBERO")
+
+
+class ApxInfPolicy:
+    """Adapt one compatible environment to PI0.5-LIBERO actions.
+
+    The caller owns reset/step/render and must call reset() at every episode
+    boundary. Injected clients remain caller-owned; close() only closes clients
+    created by this adapter. No environment or background input thread is created.
+    """
+
+    def __init__(self, *, prompt: str, host: str = "127.0.0.1", port: int = 8000,
+                 replan_steps: int = 5, client=None):
+        if replan_steps <= 0:
+            raise ValueError("replan_steps must be positive")
+        self.prompt = prompt
+        self.replan_steps = replan_steps
+        self._plan = deque()
+        self._owns_client = client is None
+        self._client = connect(host, port) if client is None else client
+        try:
+            validate_server_metadata(self._client.get_server_metadata())
+        except Exception:
+            self.close()
+            raise
+
+    def set_prompt(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.reset()
+
+    def reset(self) -> None:
+        self._plan.clear()
+
+    def get_action(self, env, observation: Mapping[str, Any]) -> np.ndarray:
+        validate_environment(env)
+        if not self._plan:
+            request = build_policy_observation(observation, self.prompt)
+            response = self._client.infer(request)
+            actions = validate_action_chunk(response["actions"], self.replan_steps)
+            self._plan.extend(row.copy() for row in actions[:self.replan_steps])
+        return self._plan.popleft()
+
+    def close(self) -> None:
+        if self._owns_client:
+            close_client(self._client)
+
+
+def run(env, policy: ApxInfPolicy, *, max_steps: int, render: bool = False) -> dict:
+    """Reset and run one episode; stop at done or the explicit step limit.
+
+    Does not close caller-owned env/policy. No grasp heuristic, hold steps,
+    prompt rewriting, default scene, or benchmark success-rate calculation.
+    """
+    if max_steps <= 0:
+        raise ValueError("max_steps must be positive")
+    observation = env.reset()
+    policy.reset()
+    done = False
+    for step in range(1, max_steps + 1):
+        action = policy.get_action(env, observation)
+        observation, _, done, _ = env.step(action)
+        if render:
+            getattr(env, "env", env).render()
+        if bool(done):
+            policy.reset()
+            break
+    return {"steps": step, "done": bool(done)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-factory", required=True,
+                        help="installed module:callable returning the configured environment")
+    parser.add_argument("--env-kwargs", default="{}", help="JSON keyword arguments for the factory")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--replan-steps", type=int, default=5)
+    parser.add_argument("--max-steps", type=int, default=520)
+    parser.add_argument("--render", action="store_true")
+    args = parser.parse_args()
+    if args.max_steps <= 0 or args.replan_steps <= 0:
+        parser.error("max-steps and replan-steps must be positive")
+    module_name, separator, callable_name = args.env_factory.partition(":")
+    if not separator or not module_name or not callable_name:
+        parser.error("--env-factory must have the form module:callable")
+    kwargs = json.loads(args.env_kwargs)
+    if not isinstance(kwargs, dict):
+        parser.error("--env-kwargs must be a JSON object")
+    factory = getattr(importlib.import_module(module_name), callable_name)
+    env = factory(**kwargs)
+    policy = None
+    try:
+        policy = ApxInfPolicy(prompt=args.prompt, host=args.host, port=args.port,
+                             replan_steps=args.replan_steps)
+        print(run(env, policy, max_steps=args.max_steps, render=args.render), flush=True)
+    finally:
+        if policy is not None:
+            policy.close()
+        env.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add four standalone OpenPI-compatible ApxInf policy adapters:

- `scripts/connect_libero.py`
- `scripts/connect_robosuite.py`
- `scripts/connect_isaaclab.py`
- `scripts/connect_isaaclab_arena.py`

Each file can be copied independently and includes its own observation conversion, WebSocket connection, action validation, chunk cache, and reset handling. No shared repository helper modules are required.

LIBERO and robosuite accept a caller-selected environment factory/configuration. Isaac Lab requires an explicit registered task and camera keys. Arena implements the policy protocol consumed by its native runner, which remains responsible for scene construction, stepping, episode reset, and metrics.

The Isaac paths read the target relative-IK scale and translate LIBERO gripper commands into Isaac's opposite sign convention. Batch reset discards only the terminated environments' queued actions. There is no bundled scene layout, interactive terminal prompt loop, remote GUI launcher, or third-party installation patch.

## Scope and limitations

- Exactly four added files and one commit relative to `main`; excludes the original development branch's prerequisite commits, demo scripts, documentation, launchers, and helper modules.
- Targets the PI0.5-LIBERO observation/action contract with compatible Panda/Franka controllers; this is not a generic adapter for arbitrary robots, coordinate frames, or action spaces.
- Requires the caller's simulator/framework installation and `openpi-client` (plus NumPy; Pillow for LIBERO). Targets the tested Arena `aad4f25` / Isaac Lab 2.3.2 interface.
- Frame, camera, controller-frequency, and training-distribution compatibility remain the caller's responsibility. Short smoke runs do not demonstrate task success or benchmark accuracy.

## Validation

- 45 local regression checks passed: isolated single-file imports without repository helpers, observation mapping, chunk replanning, prompt/reset handling, controller scaling and gripper direction, metadata rejection/connection cleanup, and episode/step limits. The test harness is intentionally not included in this four-file-only PR.
- One-step end-to-end smoke checks completed through a running ApxInf WebSocket server for all four paths: LIBERO and robosuite/MuJoCo on macOS; Isaac Lab and native Arena on Windows. Windows checks used a directory without the old repository helper modules.
- The Arena smoke check explicitly selected its single wrist camera for both input keys; this is a connectivity check, not a two-view accuracy evaluation.
- `git diff --check` passed; the four files match the previously validated commit byte-for-byte after cherry-picking onto current upstream `main`.
