### PR TITLE
docs: build Python wheels without auditwheel repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ It works from the same guides a human would follow:
 git clone <repo-url> && cd ApxInf
 python3 -m venv .venv && source .venv/bin/activate
 pip install maturin
-maturin develop --release --features cuda -m crates/apxinf-py/Cargo.toml
+CARGO_TARGET_DIR=target/wheel maturin build --release --features cuda --auditwheel skip -m crates/apxinf-py/Cargo.toml
+pip install --force-reinstall target/wheel/wheels/apxinf_py-*.whl
 pip install -e "python/apxinf[tokenizer,serving]"
 # For WallOSS checkpoints, use its processor extra instead:
 # pip install -e "python/apxinf[walloss,serving]"
 ```
 
-`maturin develop` compiles the binding into the *active* environment, so a venv
-or conda env has to be activated first. The extras keep model-specific processor
+Activate a venv or conda env before installing. The extras keep model-specific processor
 dependencies opt-in: PI0.5 uses `tokenizer`, while WallOSS uses `walloss`; both
 can add `serving` for msgpack/websockets.
 
@@ -155,11 +155,6 @@ The build queries the visible GPU for its compute capability and compiles the
 kernels for exactly that architecture, so build on the machine you deploy to;
 cross-compiling fails unless `APXINF_CUDA_ARCH` names the target (`sm_87` Orin,
 `sm_101` Thor-U, `sm_110` Thor).
-
-To ship a wheel instead of installing in place, build it with
-`maturin build --release --features cuda --auditwheel skip`. The skip matters on
-Jetson: the default `auditwheel` repair vendors a `libcuda` stub into the wheel,
-and the installed binding then fails at runtime with CUDA error 304.
 
 Confirm the binding imports and reaches the GPU:
 

--- a/crates/apxinf-py/README.md
+++ b/crates/apxinf-py/README.md
@@ -28,7 +28,8 @@ shape contract, but model loading errors.
 ```sh
 # In this crate directory. --features cuda is additive to pyproject's
 # extension-module feature.
-maturin develop --release --features cuda
+CARGO_TARGET_DIR=../../target/wheel maturin build --release --features cuda --auditwheel skip
+pip install --force-reinstall ../../target/wheel/wheels/apxinf_py-*.whl
 ```
 
 On Thor set the usual environment (see repo memory): `APXINF_CUDA_ARCH=sm_110`,

--- a/python/apxinf/examples/README.md
+++ b/python/apxinf/examples/README.md
@@ -25,7 +25,7 @@ model-specific example only when it demonstrates a genuinely distinct workflow.
 ## Dependencies
 
 - The `*_infer.py` examples and servers need the **`apxinf_py` CUDA
-  binding** (`maturin develop --features cuda` in [`crates/apxinf-py`](../../../crates/apxinf-py))
+  binding** (see [Build ApxInf](../../../README.md#build-apxinf))
   and a compatible checkpoint directory.
 - Using a WallOSS checkpoint additionally needs `pip install -e "python/apxinf[walloss]"`
   for its Qwen2.5-VL tokenizer/image processor and serialized normalizers.


### PR DESCRIPTION
The default Python build instructions now use `maturin build --auditwheel skip` followed by wheel installation. A separate wheel target avoids reusing artifacts modified by `maturin develop`. The crate README and examples link follow the same workflow.

Validated on Linux aarch64 with maturin 1.15.0 using a minimal PyO3 extension linked to a shared library: `develop` added an absolute RPATH and prevented `LD_LIBRARY_PATH` from selecting an alternative library; build with auditwheel skipped produced no RPATH/RUNPATH and allowed the override. Cargo, wheel, and installed extension bytes matched. `git diff --check` passes. Full ApxInf compilation was stopped in favor of this focused experiment.
