### PR TITLE
fix: expose LIBERO normalization stats override

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,15 @@ arbitrary π0.5 checkpoint might not reproduce it.
 ```bash
 pip install -U "huggingface_hub[cli]"
 huggingface-cli download lerobot/pi05_libero_base --local-dir <path-to-model>
+curl -fL https://storage.googleapis.com/openpi-assets/checkpoints/pi05_libero/assets/physical-intelligence/libero/norm_stats.json \
+  -o <path-to-model>/norm_stats.json
 ```
+
+Download OpenPI's LIBERO `norm_stats.json` as shown above and pass `--norm-stats`
+explicitly to restore state/action scaling. This overrides checkpoint
+normalization, including LeRobot processor metadata; placing the file beside
+the weights alone does not ensure it is used. For a different or custom
+checkpoint, use its matching training statistics.
 
 ### Run
 
@@ -379,6 +387,7 @@ pip install -e <path-to-openpi>/packages/openpi-client
 
 ```bash
 python scripts/eval_libero.py --backend in-process --model-dir <path-to-model> \
+  --norm-stats <path-to-model>/norm_stats.json \
   --precision bf16 --action-horizon 10 \
   --suite libero_10 --tasks all --trials-per-task 50 \
   --results-jsonl <out-dir>/results.jsonl --summary-json <out-dir>/summary.json
@@ -392,13 +401,15 @@ That is the published protocol: all 10 LIBERO-10 tasks x 50 episodes at seed 7
 - `--suite` picks the task suite, `--tasks` a comma list within it, and
   `--trials-per-task` the episode count; a smoke run is
   `--tasks 0 --trials-per-task 1`.
-- The model flags — `--model-type`, `--action-horizon`, `--action-dim`,
+- The model flags — `--model-type`, `--norm-stats`, `--action-horizon`, `--action-dim`,
   `--discrete-state`, FP8 `--calibration` — belong to `--backend in-process`
   alone.
 - `--backend websocket --host <h> --port <p>` evaluates a running
   [server](#openpi-compatible-serving) instead, on this machine or another. The
   model flags belong to the server there, and `--precision` only asserts what
   the server reports, so a mismatch fails at connect instead of skewing a run.
+  Pass `--norm-stats <path-to-model>/norm_stats.json` to
+  `scripts/pi05_openpi_websocket_server.py` when serving this checkpoint.
 - Runs are resumable: completed task/trial rows in the JSONL ledger are skipped,
   and the summary reports success rate alongside per-segment latency.
 

--- a/README.md
+++ b/README.md
@@ -349,11 +349,10 @@ curl -fL https://storage.googleapis.com/openpi-assets/checkpoints/pi05_libero/as
   -o <path-to-model>/norm_stats.json
 ```
 
-Download OpenPI's LIBERO `norm_stats.json` as shown above and pass `--norm-stats`
-explicitly to restore state/action scaling. This overrides checkpoint
-normalization, including LeRobot processor metadata; placing the file beside
-the weights alone does not ensure it is used. For a different or custom
-checkpoint, use its matching training statistics.
+The `lerobot/pi05_libero_base` checkpoint lost its normalization statistics
+during repository updates. To reproduce the officially reported performance,
+download OpenPI's LIBERO `norm_stats.json` separately as shown above and pass it
+explicitly with `--norm-stats`.
 
 ### Run
 

--- a/scripts/eval_libero.py
+++ b/scripts/eval_libero.py
@@ -358,6 +358,7 @@ class InProcessBackend:
             "calibration": args.calibration,
             "tactics": args.tactics,
             "tokenizer_path": args.tokenizer,
+            "norm_stats": args.norm_stats,
             "norm_key": args.norm_key,
             "action_horizon": args.action_horizon,
             "num_views": args.num_views,
@@ -615,6 +616,10 @@ def parse_args() -> argparse.Namespace:
     in_process.add_argument("--calibration", type=pathlib.Path)
     in_process.add_argument("--tactics", type=pathlib.Path, help=argparse.SUPPRESS)
     in_process.add_argument("--tokenizer", type=pathlib.Path)
+    in_process.add_argument(
+        "--norm-stats", type=pathlib.Path,
+        help="explicit OpenPI-style norm_stats.json; overrides checkpoint normalization",
+    )
     in_process.add_argument("--norm-key")
     in_process.add_argument("--action-dim", type=int, default=7, help="0 keeps the full vector")
     in_process.add_argument(
@@ -667,6 +672,14 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     if args.backend == "in-process" and args.model_dir is None:
         parser.error("--backend in-process requires --model-dir")
+    if args.norm_stats is not None:
+        if args.backend == "websocket":
+            parser.error(
+                "--norm-stats applies to --backend in-process; for the websocket "
+                "backend pass it to pi05_openpi_websocket_server.py instead"
+            )
+        if not args.norm_stats.is_file():
+            parser.error("--norm-stats must name an existing file")
     if not (0.0 <= args.warm_start_alpha <= 1.0):
         parser.error("--warm-start-alpha must be in [0, 1]")
     if args.warm_start and args.warm_start_alpha >= 1.0:

--- a/tests/test_eval_libero_norm_stats.py
+++ b/tests/test_eval_libero_norm_stats.py
@@ -1,0 +1,69 @@
+"""Exercise the evaluator CLI-to-checkpoint path without CUDA or a simulator."""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from apxinf import AutoPolicy
+from apxinf.checkpoints import detect_checkpoint
+from scripts import eval_libero
+
+
+def parse(monkeypatch, tmp_path, *extra, backend="in-process"):
+    monkeypatch.setattr(sys, "argv", [
+        "eval_libero.py", "--backend", backend, "--precision", "bf16",
+        "--model-dir", str(tmp_path),
+        "--results-jsonl", str(tmp_path / "results.jsonl"),
+        "--summary-json", str(tmp_path / "summary.json"), *extra,
+    ])
+    return eval_libero.parse_args()
+
+
+def test_explicit_norm_stats_reaches_checkpoint_loader(monkeypatch, tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"type": "pi05"}))
+    stats = tmp_path / "external-norms.json"
+    stats.write_text(json.dumps({"norm_stats": {
+        "state": {"q01": [0.0] * 7, "q99": [1.0] * 7},
+        "actions": {"q01": [2.0] * 7, "q99": [4.0] * 7},
+    }}))
+    loaded = []
+
+    def load(model_dir, **options):
+        loaded.append(detect_checkpoint(model_dir, norm_stats=options["norm_stats"]))
+        return SimpleNamespace(metadata={})
+
+    monkeypatch.setattr(AutoPolicy, "from_pretrained", load)
+    args = parse(monkeypatch, tmp_path, "--norm-stats", str(stats))
+    eval_libero.InProcessBackend(args)
+    assert loaded[0].norm_stats == stats
+    assert loaded[0].normalization.action.values["q01"] == (2.0,) * 7
+
+
+def test_omitted_norm_stats_preserves_checkpoint_defaults(monkeypatch, tmp_path):
+    options = {}
+
+    def load(model_dir, **kwargs):
+        options.update(kwargs)
+        return SimpleNamespace(metadata={})
+
+    monkeypatch.setattr(AutoPolicy, "from_pretrained", load)
+    eval_libero.InProcessBackend(parse(monkeypatch, tmp_path))
+    assert "norm_stats" not in options
+
+
+def test_websocket_norm_stats_is_rejected(monkeypatch, tmp_path, capsys):
+    stats = tmp_path / "norm_stats.json"
+    stats.write_text("{}")
+    with pytest.raises(SystemExit) as exc:
+        parse(monkeypatch, tmp_path, "--norm-stats", str(stats), backend="websocket")
+    assert exc.value.code == 2
+    assert "pass it to pi05_openpi_websocket_server.py" in capsys.readouterr().err
+
+
+def test_missing_norm_stats_is_rejected_before_rollout(monkeypatch, tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc:
+        parse(monkeypatch, tmp_path, "--norm-stats", str(tmp_path / "missing.json"))
+    assert exc.value.code == 2
+    assert "--norm-stats must name an existing file" in capsys.readouterr().err


### PR DESCRIPTION
The LIBERO README downloaded checkpoint weights without explaining how to supply matching normalization statistics, and the in-process evaluator had no `--norm-stats` option. Add the official OpenPI LIBERO stats download and an explicit override to the evaluation command so a manually assembled checkpoint can use the intended state/action scaling.

Forward `--norm-stats` to the policy loader, reject nonexistent paths before rollout, and direct websocket users to pass the option to the server. Omitted overrides preserve existing checkpoint behavior. Other checkpoints must use their own matching training statistics.

Validation: 71 tests passed across the evaluator's CLI-to-checkpoint regression tests, checkpoint-layout tests, and LIBERO observation tests. Verified that the documented official download succeeds and parses through the current normalization loader (state width 8, action width 7). `git diff --check` passes. No CUDA build or full LIBERO success-rate evaluation was run.
