### PR TITLE
feat(qwen-drive): integrate Qwen-Drive with KerSor and DSH on RTX 4090

### DIFF
--- a/crates/apxinf-cuda/adapters/custom_kernels.cu
+++ b/crates/apxinf-cuda/adapters/custom_kernels.cu
@@ -2,6 +2,7 @@
 // Stable C ABI and CUDA launch adapter for custom static-inference operators.
 
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
@@ -22,6 +23,7 @@ namespace {
 #include "../kernels/custom/elementwise.cuh"
 #include "../kernels/custom/fused.cuh"
 #include "../kernels/custom/cache.cuh"
+#include "../kernels/custom/linear_attention.cuh"
 }  // namespace
 
 namespace {
@@ -93,8 +95,7 @@ extern "C" cudaError_t apxinf_static_quantize_f16_e4m3(
 extern "C" cudaError_t apxinf_static_dequantize_e4m3_f16(
     const void* input, void* output, int64_t count, float scale,
     cudaStream_t stream) {
-  if (input == nullptr || output == nullptr || count <= 0 ||
-      !(scale > 0.0f)) {
+  if (input == nullptr || output == nullptr || count <= 0 || !(scale > 0.0f)) {
     return cudaErrorInvalidValue;
   }
   int blocks = static_cast<int>((count + 255) / 256);
@@ -108,8 +109,9 @@ extern "C" cudaError_t apxinf_static_dequantize_e4m3_f16(
 extern "C" cudaError_t apxinf_static_quantize_bf16_e4m3(
     const void* input, void* output, int64_t count, float scale,
     cudaStream_t stream) {
-  if (input == nullptr || output == nullptr || count <= 0 || !(scale > 0.0f))
+  if (input == nullptr || output == nullptr || count <= 0 || !(scale > 0.0f)) {
     return cudaErrorInvalidValue;
+  }
   int blocks = static_cast<int>((count + 255) / 256);
   blocks = blocks > 4096 ? 4096 : blocks;
   quantize_bf16_e4m3_kernel<<<blocks, 256, 0, stream>>>(
@@ -281,6 +283,44 @@ extern "C" cudaError_t apxinf_slice_columns_bf16(
   slice_columns_bf16_kernel<<<blocks, 256, 0, stream>>>(
       static_cast<const __nv_bfloat16*>(input),
       static_cast<__nv_bfloat16*>(output), rows, input_cols, output_cols);
+  return cudaGetLastError();
+}
+
+// FIX (implement_r8): block-per-row tiled softmax for the route-3 composed
+// vision attention: fp32 scores in, bf16 probabilities out (round-to-nearest,
+// matching the cast kernels). The stock thread-per-element softmax is
+// structurally unviable at the [16*3472, 3472] vision-segment geometry.
+__global__ void row_softmax_f32_bf16_kernel(
+    const float* input, __nv_bfloat16* output, uint32_t cols, uint32_t rows) {
+  const uint32_t row = blockIdx.x;
+  if (row >= rows) return;
+  const float* x = input + static_cast<size_t>(row) * cols;
+  __shared__ float scratch[32];
+  float local = -INFINITY;
+  for (uint32_t i = threadIdx.x; i < cols; i += blockDim.x) {
+    local = fmaxf(local, x[i]);
+  }
+  const float max_val = block_max(local, scratch);
+  float partial = 0.0f;
+  for (uint32_t i = threadIdx.x; i < cols; i += blockDim.x) {
+    partial += expf(x[i] - max_val);
+  }
+  const float sum = block_sum(partial, scratch);
+  __nv_bfloat16* y = output + static_cast<size_t>(row) * cols;
+  for (uint32_t i = threadIdx.x; i < cols; i += blockDim.x) {
+    y[i] = __float2bfloat16(expf(x[i] - max_val) / sum);
+  }
+}
+
+extern "C" cudaError_t apxinf_static_row_softmax_f32_bf16(
+    const void* input, void* output, uint32_t cols, uint32_t rows,
+    cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || cols == 0 || rows == 0) {
+    return cudaErrorInvalidValue;
+  }
+  row_softmax_f32_bf16_kernel<<<rows, 256, 0, stream>>>(
+      static_cast<const float*>(input), static_cast<__nv_bfloat16*>(output),
+      cols, rows);
   return cudaGetLastError();
 }
 
@@ -640,5 +680,466 @@ extern "C" cudaError_t apxinf_static_bias_position_f16(
       static_cast<const half*>(projection), static_cast<const half*>(bias),
       static_cast<const half*>(position), static_cast<half*>(output),
       count, cols, tokens_per_view);
+  return cudaGetLastError();
+}
+
+// ── linear_attention.cuh launch adapters ───────────────────────────────────
+
+extern "C" cudaError_t apxinf_static_cast_f32_bf16(
+    const void* input, void* output, int64_t count, cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || count <= 0)
+    return cudaErrorInvalidValue;
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 4096 ? 4096 : blocks;
+  cast_f32_to_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const float*>(input),
+      static_cast<__nv_bfloat16*>(output), count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_cast_bf16_f32(
+    const void* input, void* output, int64_t count, cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || count <= 0)
+    return cudaErrorInvalidValue;
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 4096 ? 4096 : blocks;
+  cast_bf16_to_f32_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<float*>(output), count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_causal_conv1d_silu_bf16(
+    const void* x, const void* weight, const void* state, void* out,
+    void* new_state, int channels, int seq, int kernel_size,
+    int64_t x_row_stride, cudaStream_t stream) {
+  if (x == nullptr || weight == nullptr || out == nullptr ||
+      new_state == nullptr || channels <= 0 || seq <= 0 || kernel_size <= 0 ||
+      kernel_size > 8 || x_row_stride < channels) {
+    return cudaErrorInvalidValue;
+  }
+  const int channel_blocks = (channels + 255) / 256;
+  causal_conv1d_silu_bf16_kernel<<<dim3(seq, channel_blocks), 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(x),
+      static_cast<const __nv_bfloat16*>(weight),
+      static_cast<const __nv_bfloat16*>(state),
+      static_cast<__nv_bfloat16*>(out),
+      static_cast<__nv_bfloat16*>(new_state),
+      channels, seq, kernel_size, x_row_stride);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_qk_prep_bf16(
+    const void* conv_out, void* q_out, void* k_out,
+    int seq, int seq_pad, int conv_dim, int key_dim,
+    int num_v_heads, int head_k_dim, float scale, float eps,
+    cudaStream_t stream) {
+  if (conv_out == nullptr || q_out == nullptr || k_out == nullptr ||
+      seq <= 0 || seq_pad < seq || conv_dim < 2 * key_dim || key_dim <= 0 ||
+      num_v_heads <= 0 || head_k_dim <= 0 ||
+      (head_k_dim & (head_k_dim - 1)) != 0 || !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  if (key_dim % head_k_dim != 0) return cudaErrorInvalidValue;
+  const int num_k_heads = key_dim / head_k_dim;
+  if (num_v_heads % num_k_heads != 0) return cudaErrorInvalidValue;
+  const size_t smem = static_cast<size_t>(2 * head_k_dim) * sizeof(float);
+  gdn_qk_prep_kernel<<<dim3(seq, num_k_heads), head_k_dim, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(conv_out),
+      static_cast<float*>(q_out), static_cast<float*>(k_out),
+      seq, seq_pad, conv_dim, key_dim, num_v_heads, head_k_dim, scale, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_vb_prep_bf16(
+    const void* conv_out, const void* b_proj, const void* a_proj,
+    const void* dt_bias, const void* a_log,
+    void* v_out, void* beta_out, void* g_out,
+    int seq, int seq_pad, int conv_dim, int v_offset,
+    int num_v_heads, int ba_row_stride, int head_v_dim,
+    cudaStream_t stream) {
+  if (conv_out == nullptr || b_proj == nullptr || a_proj == nullptr ||
+      dt_bias == nullptr || a_log == nullptr || v_out == nullptr ||
+      beta_out == nullptr || g_out == nullptr || seq <= 0 || seq_pad < seq ||
+      num_v_heads <= 0 || head_v_dim <= 0 || ba_row_stride < num_v_heads) {
+    return cudaErrorInvalidValue;
+  }
+  gdn_vb_prep_kernel<<<dim3(seq, num_v_heads), head_v_dim, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(conv_out),
+      static_cast<const __nv_bfloat16*>(b_proj),
+      static_cast<const __nv_bfloat16*>(a_proj),
+      static_cast<const float*>(dt_bias), static_cast<const float*>(a_log),
+      static_cast<float*>(v_out), static_cast<float*>(beta_out),
+      static_cast<float*>(g_out),
+      seq, seq_pad, conv_dim, v_offset, ba_row_stride, head_v_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_cumsum_f32(
+    const void* g, void* g_cum, int seq_pad, int num_v_heads, int chunk_size,
+    cudaStream_t stream) {
+  if (g == nullptr || g_cum == nullptr || seq_pad <= 0 ||
+      num_v_heads <= 0 || chunk_size <= 0 || seq_pad % chunk_size != 0) {
+    return cudaErrorInvalidValue;
+  }
+  const int chunks = seq_pad / chunk_size;
+  gdn_cumsum_kernel<<<dim3(chunks, num_v_heads), 32, 0, stream>>>(
+      static_cast<const float*>(g), static_cast<float*>(g_cum),
+      seq_pad, chunk_size);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_attn_raw_f32(
+    const void* q, const void* k, const void* beta, const void* g_cum,
+    void* a_out, void* t_out, int seq_pad, int num_v_heads, int head_k_dim,
+    int chunk_size, cudaStream_t stream) {
+  if (q == nullptr || k == nullptr || beta == nullptr || g_cum == nullptr ||
+      a_out == nullptr || t_out == nullptr || seq_pad <= 0 ||
+      num_v_heads <= 0 || head_k_dim <= 0 || chunk_size <= 0 ||
+      seq_pad % chunk_size != 0) {
+    return cudaErrorInvalidValue;
+  }
+  const int chunks = seq_pad / chunk_size;
+  gdn_attn_raw_kernel<<<dim3(chunks, num_v_heads), 256, 0, stream>>>(
+      static_cast<const float*>(q), static_cast<const float*>(k),
+      static_cast<const float*>(beta), static_cast<const float*>(g_cum),
+      static_cast<float*>(a_out), static_cast<float*>(t_out),
+      seq_pad, head_k_dim, chunk_size);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_tri_solve_f32(
+    void* a, int matrices, int chunk_size, cudaStream_t stream) {
+  if (a == nullptr || matrices <= 0 || chunk_size <= 0 || chunk_size > 128) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem =
+      (static_cast<size_t>(chunk_size) * chunk_size + chunk_size) * sizeof(float);
+  gdn_tri_solve_kernel<<<matrices, 64, smem, stream>>>(
+      static_cast<float*>(a), chunk_size);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_chunk_gemm_f32(
+    const void* a, const void* v, const void* k, const void* beta,
+    const void* g_cum, void* vt_out, void* kcd_out,
+    int seq_pad, int num_v_heads, int head_k_dim, int head_v_dim,
+    int chunk_size, cudaStream_t stream) {
+  if (a == nullptr || v == nullptr || k == nullptr || beta == nullptr ||
+      g_cum == nullptr || vt_out == nullptr || kcd_out == nullptr ||
+      seq_pad <= 0 || num_v_heads <= 0 || head_k_dim <= 0 ||
+      head_v_dim <= 0 || chunk_size <= 0 || seq_pad % chunk_size != 0) {
+    return cudaErrorInvalidValue;
+  }
+  const int chunks = seq_pad / chunk_size;
+  gdn_chunk_gemm_kernel<<<dim3(chunks, num_v_heads), 256, 0, stream>>>(
+      static_cast<const float*>(a), static_cast<const float*>(v),
+      static_cast<const float*>(k), static_cast<const float*>(beta),
+      static_cast<const float*>(g_cum),
+      static_cast<float*>(vt_out), static_cast<float*>(kcd_out),
+      seq_pad, head_k_dim, head_v_dim, chunk_size);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_chunk_state_f32(
+    const void* q, const void* k, const void* g_cum, const void* t_in,
+    const void* vt_in, const void* kcd_in, void* state, void* out,
+    int seq, int seq_pad, int num_v_heads, int head_k_dim, int head_v_dim,
+    int chunk_size, int total_chunks, int out_row_width,
+    cudaStream_t stream) {
+  if (q == nullptr || k == nullptr || g_cum == nullptr || t_in == nullptr ||
+      vt_in == nullptr || kcd_in == nullptr || state == nullptr ||
+      out == nullptr || seq <= 0 || seq_pad < seq || num_v_heads <= 0 ||
+      head_k_dim <= 0 || head_v_dim <= 0 || chunk_size <= 0 ||
+      total_chunks <= 0 || seq_pad != total_chunks * chunk_size ||
+      out_row_width != num_v_heads * head_v_dim) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem =
+      static_cast<size_t>(chunk_size) * head_v_dim * sizeof(float);
+  gdn_chunk_state_kernel<<<num_v_heads, 256, smem, stream>>>(
+      static_cast<const float*>(q), static_cast<const float*>(k),
+      static_cast<const float*>(g_cum), static_cast<const float*>(t_in),
+      static_cast<const float*>(vt_in), static_cast<const float*>(kcd_in),
+      static_cast<float*>(state), static_cast<__nv_bfloat16*>(out),
+      seq, seq_pad, head_k_dim, head_v_dim, chunk_size, total_chunks,
+      out_row_width);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gdn_recurrent_f32(
+    const void* q, const void* k, const void* v, const void* beta,
+    const void* g, void* state, void* out,
+    int num_v_heads, int head_k_dim, int head_v_dim, cudaStream_t stream) {
+  if (q == nullptr || k == nullptr || v == nullptr || beta == nullptr ||
+      g == nullptr || state == nullptr || out == nullptr ||
+      num_v_heads <= 0 || head_k_dim <= 0 || head_v_dim <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(2 * head_k_dim) * sizeof(float);
+  gdn_recurrent_kernel<<<num_v_heads, head_v_dim, smem, stream>>>(
+      static_cast<const float*>(q), static_cast<const float*>(k),
+      static_cast<const float*>(v), static_cast<const float*>(beta),
+      static_cast<const float*>(g), static_cast<float*>(state),
+      static_cast<__nv_bfloat16*>(out), head_k_dim, head_v_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gated_rms_silu_bf16(
+    const void* x, const void* z, const void* weight, void* out,
+    int rows, int cols, int z_heads, int64_t z_row_stride,
+    int64_t z_col_offset, float eps, cudaStream_t stream) {
+  if (x == nullptr || z == nullptr || weight == nullptr || out == nullptr ||
+      rows <= 0 || cols <= 0 || z_heads <= 0 || rows % z_heads != 0 ||
+      !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(cols) * sizeof(float);
+  gated_rms_silu_bf16_kernel<<<rows, 128, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(x),
+      static_cast<const __nv_bfloat16*>(z),
+      static_cast<const __nv_bfloat16*>(weight),
+      static_cast<__nv_bfloat16*>(out),
+      cols, z_heads, z_row_stride, z_col_offset, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_rms_norm_plus1_bf16(
+    const void* input, const void* weight, void* output,
+    int rows, int cols, float eps, cudaStream_t stream) {
+  if (input == nullptr || weight == nullptr || output == nullptr ||
+      rows <= 0 || cols <= 0 || !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(cols) * sizeof(float);
+  rms_norm_plus1_bf16_kernel<<<rows, 256, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<const __nv_bfloat16*>(weight),
+      static_cast<__nv_bfloat16*>(output), cols, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_partial_rope_table_bf16(
+    const void* x, const void* cos, const void* sin, void* out,
+    int rows, int heads, int head_dim, int rotary_dim, cudaStream_t stream) {
+  if (x == nullptr || cos == nullptr || sin == nullptr || out == nullptr ||
+      rows <= 0 || heads <= 0 || head_dim <= 0 || rotary_dim <= 0 ||
+      (rotary_dim & 1) != 0 || rotary_dim > head_dim) {
+    return cudaErrorInvalidValue;
+  }
+  partial_rope_table_bf16_kernel<<<dim3(rows, heads), 32, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(x),
+      static_cast<const __nv_bfloat16*>(cos),
+      static_cast<const __nv_bfloat16*>(sin),
+      static_cast<__nv_bfloat16*>(out), heads, head_dim, rotary_dim);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_full_attn_prepare_bf16(
+    const void* fused, const void* q_norm_w, const void* k_norm_w,
+    const void* cos, const void* sin, void* q_out, void* k_cache, void* v_cache,
+    int seq, int cache_offset, int q_heads, int kv_heads, int head_dim,
+    int rotary_dim, int64_t fused_width, int64_t cache_width, float eps,
+    cudaStream_t stream) {
+  if (fused == nullptr || q_norm_w == nullptr || k_norm_w == nullptr ||
+      cos == nullptr || sin == nullptr || q_out == nullptr ||
+      k_cache == nullptr || v_cache == nullptr || seq <= 0 ||
+      cache_offset < 0 || q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+      rotary_dim <= 0 || (rotary_dim & 1) != 0 || rotary_dim > head_dim ||
+      !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(head_dim) * sizeof(float);
+  full_attn_prepare_bf16_kernel
+      <<<dim3(seq, q_heads + 2 * kv_heads), 128, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(fused),
+      static_cast<const __nv_bfloat16*>(q_norm_w),
+      static_cast<const __nv_bfloat16*>(k_norm_w),
+      static_cast<const __nv_bfloat16*>(cos),
+      static_cast<const __nv_bfloat16*>(sin),
+      static_cast<__nv_bfloat16*>(q_out),
+      static_cast<__nv_bfloat16*>(k_cache),
+      static_cast<__nv_bfloat16*>(v_cache),
+      cache_offset, q_heads, kv_heads, head_dim, rotary_dim, fused_width,
+      cache_width, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_sigmoid_gate_mul_bf16(
+    void* attn, const void* fused, int rows, int heads, int head_dim,
+    int64_t fused_width, cudaStream_t stream) {
+  if (attn == nullptr || fused == nullptr || rows <= 0 || heads <= 0 ||
+      head_dim <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  sigmoid_gate_mul_bf16_kernel<<<rows, 256, 0, stream>>>(
+      static_cast<__nv_bfloat16*>(attn),
+      static_cast<const __nv_bfloat16*>(fused), heads, head_dim, fused_width);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_adaln_rms_norm_bf16(
+    const void* x, const void* weight, const void* scale, const void* shift,
+    void* out, int rows, int cols, float eps, cudaStream_t stream) {
+  if (x == nullptr || weight == nullptr || scale == nullptr ||
+      shift == nullptr || out == nullptr || rows <= 0 || cols <= 0 ||
+      !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(cols) * sizeof(float);
+  adaln_rms_norm_bf16_kernel<<<rows, 256, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(x),
+      static_cast<const __nv_bfloat16*>(weight),
+      static_cast<const __nv_bfloat16*>(scale),
+      static_cast<const __nv_bfloat16*>(shift),
+      static_cast<__nv_bfloat16*>(out), cols, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_adaln_gate_residual_bf16(
+    const void* proj, const void* residual, const void* gate, void* out,
+    int64_t count, int cols, cudaStream_t stream) {
+  if (proj == nullptr || residual == nullptr || gate == nullptr ||
+      out == nullptr || count <= 0 || cols <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 1024 ? 1024 : blocks;
+  adaln_gate_residual_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(proj),
+      static_cast<const __nv_bfloat16*>(residual),
+      static_cast<const __nv_bfloat16*>(gate),
+      static_cast<__nv_bfloat16*>(out), count, cols);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_expert_qkv_prepare_bf16(
+    const void* fused, const void* q_norm_w, const void* k_norm_w,
+    const void* cos, const void* sin, void* q_out, void* gate_out, void* k_out,
+    void* v_out, int seq, int q_heads, int kv_heads, int head_dim,
+    int rotary_dim, int64_t fused_width, float eps, cudaStream_t stream) {
+  if (fused == nullptr || q_norm_w == nullptr || k_norm_w == nullptr ||
+      cos == nullptr || sin == nullptr || q_out == nullptr ||
+      gate_out == nullptr || k_out == nullptr || v_out == nullptr ||
+      seq <= 0 || q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+      rotary_dim <= 0 || (rotary_dim & 1) != 0 || rotary_dim > head_dim ||
+      q_heads % kv_heads != 0 || !(eps > 0.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const size_t smem = static_cast<size_t>(head_dim) * sizeof(float);
+  expert_qkv_prepare_bf16_kernel
+      <<<dim3(seq, q_heads + 2 * kv_heads), 128, smem, stream>>>(
+      static_cast<const __nv_bfloat16*>(fused),
+      static_cast<const __nv_bfloat16*>(q_norm_w),
+      static_cast<const __nv_bfloat16*>(k_norm_w),
+      static_cast<const __nv_bfloat16*>(cos),
+      static_cast<const __nv_bfloat16*>(sin),
+      static_cast<__nv_bfloat16*>(q_out),
+      static_cast<__nv_bfloat16*>(gate_out),
+      static_cast<__nv_bfloat16*>(k_out),
+      static_cast<__nv_bfloat16*>(v_out),
+      q_heads, kv_heads, head_dim, rotary_dim, fused_width, eps);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_expert_sigmoid_gate_mul_bf16(
+    void* attn, const void* gate, int64_t count, cudaStream_t stream) {
+  if (attn == nullptr || gate == nullptr || count <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 1024 ? 1024 : blocks;
+  expert_sigmoid_gate_mul_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<__nv_bfloat16*>(attn),
+      static_cast<const __nv_bfloat16*>(gate), count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_fourier_features_bf16(
+    const void* waypoints, const void* freqs, void* out,
+    int rows, int point_dim, int num_features, cudaStream_t stream) {
+  if (waypoints == nullptr || freqs == nullptr || out == nullptr ||
+      rows <= 0 || point_dim <= 0 || num_features <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  fourier_features_bf16_kernel<<<rows, 64, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(waypoints),
+      static_cast<const __nv_bfloat16*>(freqs),
+      static_cast<__nv_bfloat16*>(out), point_dim, num_features);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_concat7_cols_bf16(
+    const void* s0, const void* s1, const void* s2, const void* s3,
+    const void* s4, const void* s5, const void* s6, void* dst,
+    int rows, int cols, int broadcast_mask, cudaStream_t stream) {
+  if (s0 == nullptr || s1 == nullptr || s2 == nullptr || s3 == nullptr ||
+      s4 == nullptr || s5 == nullptr || s6 == nullptr || dst == nullptr ||
+      rows <= 0 || cols <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  concat7_cols_bf16_kernel<<<rows, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(s0),
+      static_cast<const __nv_bfloat16*>(s1),
+      static_cast<const __nv_bfloat16*>(s2),
+      static_cast<const __nv_bfloat16*>(s3),
+      static_cast<const __nv_bfloat16*>(s4),
+      static_cast<const __nv_bfloat16*>(s5),
+      static_cast<const __nv_bfloat16*>(s6),
+      static_cast<__nv_bfloat16*>(dst), rows, cols, broadcast_mask);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_flow_update_f32(
+    void* w, const void* endpoint, float remaining, float step, int64_t count,
+    cudaStream_t stream) {
+  if (w == nullptr || endpoint == nullptr || count <= 0 ||
+      !(remaining > 0.0f) || !std::isfinite(step)) {
+    return cudaErrorInvalidValue;
+  }
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 1024 ? 1024 : blocks;
+  flow_update_f32_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<float*>(w), static_cast<const float*>(endpoint),
+      remaining, step, count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_suppress_logits_bf16(
+    void* logits, const uint32_t* ids, int count, cudaStream_t stream) {
+  if (logits == nullptr || ids == nullptr || count <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  const int blocks = (count + 63) / 64;
+  suppress_logits_bf16_kernel<<<blocks, 64, 0, stream>>>(
+      static_cast<__nv_bfloat16*>(logits), ids, count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_gelu_exact_bf16(
+    const void* input, void* output, int64_t count, cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || count <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  int blocks = static_cast<int>((count + 255) / 256);
+  blocks = blocks > 1024 ? 1024 : blocks;
+  gelu_exact_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<__nv_bfloat16*>(output), count);
+  return cudaGetLastError();
+}
+
+extern "C" cudaError_t apxinf_static_merge_rows_bf16(
+    const void* input, void* output, int64_t out_count, int cols, int factor,
+    cudaStream_t stream) {
+  if (input == nullptr || output == nullptr || out_count <= 0 ||
+      cols <= 0 || factor <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  int blocks = static_cast<int>((out_count + 255) / 256);
+  blocks = blocks > 1024 ? 1024 : blocks;
+  merge_rows_bf16_kernel<<<blocks, 256, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(input),
+      static_cast<__nv_bfloat16*>(output), out_count, cols, factor);
   return cudaGetLastError();
 }

--- a/crates/apxinf-cuda/kernels/custom/linear_attention.cuh
+++ b/crates/apxinf-cuda/kernels/custom/linear_attention.cuh
@@ -1,0 +1,821 @@
+#pragma once
+
+// Copyright 2026 apxinf contributors.
+// Pure CUDA operators grouped by physical operation; launch policy lives under adapters/.
+//
+// Linear-attention / hybrid-recurrent operators: gated delta rule (chunked
+// prefill + rank-1 recurrent decode), depthwise causal conv1d with SiLU,
+// gated RMSNorm, partial-rotary application from precomputed tables, adaLN
+// modulation, and small dtype/layout utilities shared by hybrid models.
+//
+// Semantics follow the published equations (Qwen3.5 gated delta net, DiT-style
+// adaLN diffusion experts); every kernel is model-neutral and parameterized by
+// raw geometry (heads, head dims, chunk size).
+
+// small device helpers
+
+__device__ __forceinline__ float la_sigmoid(float x) {
+  return 1.0f / (1.0f + expf(-x));
+}
+
+// softplus with the PyTorch threshold=20 convention.
+__device__ __forceinline__ float la_softplus(float x) {
+  return x > 20.0f ? x : log1pf(expf(x));
+}
+
+__device__ __forceinline__ float la_silu(float x) {
+  return x / (1.0f + expf(-x));
+}
+
+// dtype casts
+
+__global__ void cast_f32_to_bf16_kernel(
+    const float* input, __nv_bfloat16* output, int64_t count) {
+  const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t i = index; i < count; i += stride) {
+    output[i] = __float2bfloat16(input[i]);
+  }
+}
+
+__global__ void cast_bf16_to_f32_kernel(
+    const __nv_bfloat16* input, float* output, int64_t count) {
+  const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t i = index; i < count; i += stride) {
+    output[i] = __bfloat162float(input[i]);
+  }
+}
+
+// depthwise causal conv1d + SiLU
+//
+// x is a strided token-major stream [seq, x_row_stride] whose first `channels`
+// columns carry the mixed projection; out is dense [seq, channels].
+// weight/state/new_state are [channels, kernel_size]. The effective left
+// context of a cached call is state[:, 1..kernel_size-1] (the trailing
+// kernel_size-1 pre-conv activations), zero left-pad when state == nullptr.
+// new_state receives the last kernel_size entries of cat(effective_state, x),
+// matching the reference cache contract for prefill and cached continuation.
+// One thread per (token, channel); the last token's threads also emit the new
+// state so state writes never race the reads of other tokens.
+
+__global__ void causal_conv1d_silu_bf16_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* weight,
+    const __nv_bfloat16* state, __nv_bfloat16* out, __nv_bfloat16* new_state,
+    int channels, int seq, int kernel_size, int64_t x_row_stride) {
+  const int channel = blockIdx.y * blockDim.x + threadIdx.x;
+  if (channel >= channels) return;
+  const int token = blockIdx.x;
+  float acc = 0.0f;
+  for (int i = 0; i < kernel_size; ++i) {
+    const int src = token - (kernel_size - 1) + i;
+    float value = 0.0f;
+    if (src >= 0) {
+      value = __bfloat162float(x[static_cast<int64_t>(src) * x_row_stride + channel]);
+    } else if (state != nullptr) {
+      value = __bfloat162float(state[channel * kernel_size + kernel_size + src]);
+    }
+    acc += value * __bfloat162float(weight[channel * kernel_size + i]);
+  }
+  out[static_cast<int64_t>(token) * channels + channel] = __float2bfloat16(la_silu(acc));
+  if (token == seq - 1) {
+    for (int i = 0; i < kernel_size; ++i) {
+      float value = 0.0f;
+      if (seq + i < kernel_size) {
+        if (state != nullptr) {
+          value = __bfloat162float(state[channel * kernel_size + seq + i]);
+        }
+      } else {
+        value = __bfloat162float(
+            x[static_cast<int64_t>(seq - kernel_size + i) * x_row_stride + channel]);
+      }
+      new_state[channel * kernel_size + i] = __float2bfloat16(value);
+    }
+  }
+}
+
+// gated delta rule: prefill preparation
+//
+// q/k rows are L2-normalized (fp32, eps) from the post-conv bf16 stream,
+// scaled by 1/sqrt(head_k_dim) for q, and scattered to the value-head layout
+// (each key head repeats to num_v_heads/num_k_heads consecutive value heads).
+// Outputs are fp32 head-major [num_v_heads, seq_pad, head_k_dim]; the padded
+// tail keeps the caller's zero fill. One block per (token, key head) with
+// head_k_dim threads.
+
+__global__ void gdn_qk_prep_kernel(
+    const __nv_bfloat16* conv_out, float* q_out, float* k_out,
+    int seq, int seq_pad, int conv_dim, int key_dim,
+    int num_v_heads, int head_k_dim, float scale, float eps) {
+  const int token = blockIdx.x;
+  const int k_head = blockIdx.y;
+  const int reps = num_v_heads / gridDim.y;
+  const int d = threadIdx.x;
+  if (d >= head_k_dim) return;
+  extern __shared__ float la_reduce[];
+  const int64_t conv_base = static_cast<int64_t>(token) * conv_dim;
+  const float q_value = __bfloat162float(conv_out[conv_base + k_head * head_k_dim + d]);
+  const float k_value = __bfloat162float(conv_out[conv_base + key_dim + k_head * head_k_dim + d]);
+  la_reduce[threadIdx.x] = q_value * q_value;
+  la_reduce[blockDim.x + threadIdx.x] = k_value * k_value;
+  __syncthreads();
+  for (int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+    if (threadIdx.x < offset) {
+      la_reduce[threadIdx.x] += la_reduce[threadIdx.x + offset];
+      la_reduce[blockDim.x + threadIdx.x] += la_reduce[blockDim.x + threadIdx.x + offset];
+    }
+    __syncthreads();
+  }
+  const float q_inv = rsqrtf(la_reduce[0] + eps);
+  const float k_inv = rsqrtf(la_reduce[blockDim.x] + eps);
+  const float q_normed = q_value * q_inv * scale;
+  const float k_normed = k_value * k_inv;
+  for (int r = 0; r < reps; ++r) {
+    const int head = k_head * reps + r;
+    const int64_t dst = (static_cast<int64_t>(head) * seq_pad + token) * head_k_dim + d;
+    q_out[dst] = q_normed;
+    k_out[dst] = k_normed;
+  }
+}
+
+// beta = sigmoid(b); g = -exp(A_log) * softplus(a + dt_bias); v copied to the
+// fp32 head-major layout. b_proj/a_proj point at the first row of their column
+// slice inside a fused projection output (row stride given in elements).
+__global__ void gdn_vb_prep_kernel(
+    const __nv_bfloat16* conv_out,
+    const __nv_bfloat16* b_proj, const __nv_bfloat16* a_proj,
+    const float* dt_bias, const float* a_log,
+    float* v_out, float* beta_out, float* g_out,
+    int seq, int seq_pad, int conv_dim, int v_offset,
+    int ba_row_stride, int head_v_dim) {
+  const int token = blockIdx.x;
+  const int head = blockIdx.y;
+  const int d = threadIdx.x;
+  if (d >= head_v_dim) return;
+  const int64_t conv_base = static_cast<int64_t>(token) * conv_dim;
+  const float b_value = __bfloat162float(b_proj[static_cast<int64_t>(token) * ba_row_stride + head]);
+  const float a_value = __bfloat162float(a_proj[static_cast<int64_t>(token) * ba_row_stride + head]);
+  const float beta = la_sigmoid(b_value);
+  const float g = -expf(a_log[head]) * la_softplus(a_value + dt_bias[head]);
+  v_out[(static_cast<int64_t>(head) * seq_pad + token) * head_v_dim + d] =
+      __bfloat162float(conv_out[conv_base + v_offset + head * head_v_dim + d]);
+  if (d == 0) {
+    beta_out[static_cast<int64_t>(head) * seq_pad + token] = beta;
+    g_out[static_cast<int64_t>(head) * seq_pad + token] = g;
+  }
+}
+
+// Chunk-local inclusive cumsum of g: g_cum[h, c*chunk + i] = sum_{j<=i} g.
+__global__ void gdn_cumsum_kernel(
+    const float* g, float* g_cum, int seq_pad, int chunk_size) {
+  const int head = blockIdx.y;
+  const int chunk = blockIdx.x;
+  if (threadIdx.x != 0) return;
+  const int64_t base = static_cast<int64_t>(head) * seq_pad + static_cast<int64_t>(chunk) * chunk_size;
+  float running = 0.0f;
+  for (int i = 0; i < chunk_size; ++i) {
+    running += g[base + i];
+    g_cum[base + i] = running;
+  }
+}
+
+// A1[i,j] = -(k_beta_i . k_j) * exp(g_i - g_j) for j < i else 0
+// T[i,j]  =  (q_i . k_j)       * exp(g_i - g_j) for j <= i else 0
+// with k_beta_i = k_i * beta_i folded on the fly. One block per (head, chunk).
+__global__ void gdn_attn_raw_kernel(
+    const float* q, const float* k, const float* beta, const float* g_cum,
+    float* a_out, float* t_out,
+    int seq_pad, int head_k_dim, int chunk_size) {
+  const int head = blockIdx.y;
+  const int chunk = blockIdx.x;
+  const int64_t token_base = static_cast<int64_t>(head) * seq_pad + static_cast<int64_t>(chunk) * chunk_size;
+  const int64_t matrix_base = (static_cast<int64_t>(head) * gridDim.x + chunk) * chunk_size * chunk_size;
+  for (int cell = threadIdx.x; cell < chunk_size * chunk_size; cell += blockDim.x) {
+    const int i = cell / chunk_size;
+    const int j = cell - i * chunk_size;
+    const int64_t row_i = (token_base + i) * head_k_dim;
+    const int64_t row_j = (token_base + j) * head_k_dim;
+    float a1 = 0.0f;
+    float a2 = 0.0f;
+    const float beta_i = beta[token_base + i];
+    for (int d = 0; d < head_k_dim; ++d) {
+      const float k_j = k[row_j + d];
+      a1 += k[row_i + d] * beta_i * k_j;
+      a2 += q[row_i + d] * k_j;
+    }
+    const float decay = expf(g_cum[token_base + i] - g_cum[token_base + j]);
+    a_out[matrix_base + cell] = (j < i) ? -a1 * decay : 0.0f;
+    t_out[matrix_base + cell] = (j <= i) ? a2 * decay : 0.0f;
+  }
+}
+
+// In-place forward substitution over strictly-lower A, then A += I:
+// computes (I - A)^{-1} exactly like the reference's sequential loop.
+__global__ void gdn_tri_solve_kernel(float* a, int chunk_size) {
+  extern __shared__ float la_solve[];
+  float* matrix = la_solve;
+  float* row_copy = la_solve + chunk_size * chunk_size;
+  const int64_t matrix_base = static_cast<int64_t>(blockIdx.x) * chunk_size * chunk_size;
+  for (int cell = threadIdx.x; cell < chunk_size * chunk_size; cell += blockDim.x) {
+    matrix[cell] = a[matrix_base + cell];
+  }
+  __syncthreads();
+  for (int i = 1; i < chunk_size; ++i) {
+    if (threadIdx.x < i) row_copy[threadIdx.x] = matrix[i * chunk_size + threadIdx.x];
+    __syncthreads();
+    if (threadIdx.x < i) {
+      const int j = threadIdx.x;
+      float sum = 0.0f;
+      for (int m = 0; m < i; ++m) sum += row_copy[m] * matrix[m * chunk_size + j];
+      matrix[i * chunk_size + j] = row_copy[j] + sum;
+    }
+    __syncthreads();
+  }
+  for (int cell = threadIdx.x; cell < chunk_size * chunk_size; cell += blockDim.x) {
+    const int i = cell / chunk_size;
+    const int j = cell - i * chunk_size;
+    a[matrix_base + cell] = matrix[cell] + (i == j ? 1.0f : 0.0f);
+  }
+}
+
+// VT[i,j]  = sum_m A[i,m] * (v[m,j] * beta[m])          over head_v_dim columns
+// KCD[i,j] = sum_m A[i,m] * (k[m,j] * beta[m] * exp(g_cum[m])) over head_k_dim
+__global__ void gdn_chunk_gemm_kernel(
+    const float* a, const float* v, const float* k, const float* beta,
+    const float* g_cum, float* vt_out, float* kcd_out,
+    int seq_pad, int head_k_dim, int head_v_dim, int chunk_size) {
+  const int head = blockIdx.y;
+  const int chunk = blockIdx.x;
+  const int64_t token_base = static_cast<int64_t>(head) * seq_pad + static_cast<int64_t>(chunk) * chunk_size;
+  const int64_t a_base = (static_cast<int64_t>(head) * gridDim.x + chunk) * chunk_size * chunk_size;
+  const int64_t vt_base = (static_cast<int64_t>(head) * gridDim.x + chunk) * chunk_size * head_v_dim;
+  const int64_t kcd_base = (static_cast<int64_t>(head) * gridDim.x + chunk) * chunk_size * head_k_dim;
+  for (int cell = threadIdx.x; cell < chunk_size * head_v_dim; cell += blockDim.x) {
+    const int i = cell / head_v_dim;
+    const int j = cell - i * head_v_dim;
+    float vt = 0.0f;
+    for (int m = 0; m < chunk_size; ++m) {
+      vt += a[a_base + i * chunk_size + m] * (v[(token_base + m) * head_v_dim + j] * beta[token_base + m]);
+    }
+    vt_out[vt_base + cell] = vt;
+  }
+  for (int cell = threadIdx.x; cell < chunk_size * head_k_dim; cell += blockDim.x) {
+    const int i = cell / head_k_dim;
+    const int j = cell - i * head_k_dim;
+    float kcd = 0.0f;
+    for (int m = 0; m < chunk_size; ++m) {
+      kcd += a[a_base + i * chunk_size + m] *
+             (k[(token_base + m) * head_k_dim + j] * beta[token_base + m] * expf(g_cum[token_base + m]));
+    }
+    kcd_out[kcd_base + cell] = kcd;
+  }
+}
+
+// Sequential chunk recurrence per head (state lives in global scratch):
+//   v_prime = KCD @ S;  v_new = VT - v_prime
+//   out = (q * exp(g_cum)) @ S + T @ v_new           (bf16, token-major)
+//   S = S * exp(g_last) + (k * exp(g_last - g_cum))^T @ v_new
+// state is [head_k_dim, head_v_dim] fp32 in global memory, read at the first
+// chunk and rewritten per chunk, so the buffer carries the initial state in
+// and the final state out. Grid is (num_v_heads); each block loops chunks.
+__global__ void gdn_chunk_state_kernel(
+    const float* q, const float* k,
+    const float* g_cum, const float* t_in, const float* vt_in, const float* kcd_in,
+    float* state, __nv_bfloat16* out,
+    int seq, int seq_pad, int head_k_dim, int head_v_dim, int chunk_size,
+    int total_chunks, int out_row_width) {
+  const int head = blockIdx.x;
+  extern __shared__ float v_new[];
+  const int64_t head_token_base = static_cast<int64_t>(head) * seq_pad;
+  float* state_head = state + static_cast<int64_t>(head) * head_k_dim * head_v_dim;
+  const int cells = chunk_size * head_v_dim;
+  for (int c = 0; c < total_chunks; ++c) {
+    const int64_t token_base = head_token_base + static_cast<int64_t>(c) * chunk_size;
+    const int64_t vt_base = (static_cast<int64_t>(head) * total_chunks + c) * chunk_size * head_v_dim;
+    const int64_t kcd_base = (static_cast<int64_t>(head) * total_chunks + c) * chunk_size * head_k_dim;
+    const int64_t a_base = (static_cast<int64_t>(head) * total_chunks + c) * chunk_size * chunk_size;
+    float attn_inter[32];
+    for (int cell = threadIdx.x, it = 0; cell < cells; cell += blockDim.x, ++it) {
+      const int i = cell / head_v_dim;
+      const int j = cell - i * head_v_dim;
+      float vp = 0.0f;
+      float ai = 0.0f;
+      const float qg = expf(g_cum[token_base + i]);
+      for (int m = 0; m < head_k_dim; ++m) {
+        const float s = state_head[m * head_v_dim + j];
+        vp += kcd_in[kcd_base + i * head_k_dim + m] * s;
+        ai += q[(token_base + i) * head_k_dim + m] * qg * s;
+      }
+      v_new[cell] = vt_in[vt_base + cell] - vp;
+      attn_inter[it] = ai;
+    }
+    __syncthreads();
+    for (int cell = threadIdx.x, it = 0; cell < cells; cell += blockDim.x, ++it) {
+      const int i = cell / head_v_dim;
+      const int j = cell - i * head_v_dim;
+      float acc = attn_inter[it];
+      for (int m = 0; m < chunk_size; ++m) {
+        acc += t_in[a_base + i * chunk_size + m] * v_new[m * head_v_dim + j];
+      }
+      const int token = c * chunk_size + i;
+      if (token < seq) {
+        out[static_cast<int64_t>(token) * out_row_width + head * head_v_dim + j] =
+            __float2bfloat16(acc);
+      }
+    }
+    __syncthreads();
+    const float g_last = g_cum[token_base + chunk_size - 1];
+    const float decay = expf(g_last);
+    const int state_cells = head_k_dim * head_v_dim;
+    for (int cell = threadIdx.x; cell < state_cells; cell += blockDim.x) {
+      const int m = cell / head_v_dim;
+      const int j = cell - m * head_v_dim;
+      float acc = 0.0f;
+      for (int i = 0; i < chunk_size; ++i) {
+        const float ksd = k[(token_base + i) * head_k_dim + m] * expf(g_last - g_cum[token_base + i]);
+        acc += ksd * v_new[i * head_v_dim + j];
+      }
+      state_head[cell] = state_head[cell] * decay + acc;
+    }
+    __syncthreads();
+  }
+}
+
+// Rank-1 recurrent update for single-token decode:
+//   S *= exp(g); kv = S^T k; delta = (v - kv) * beta; S += k x delta; out = S^T q
+__global__ void gdn_recurrent_kernel(
+    const float* q, const float* k, const float* v, const float* beta,
+    const float* g, float* state, __nv_bfloat16* out,
+    int head_k_dim, int head_v_dim) {
+  const int head = blockIdx.x;
+  const int j = threadIdx.x;
+  if (j >= head_v_dim) return;
+  extern __shared__ float la_recurrent[];
+  float* q_row = la_recurrent;
+  float* k_row = la_recurrent + head_k_dim;
+  for (int d = threadIdx.x; d < head_k_dim; d += blockDim.x) {
+    q_row[d] = q[static_cast<int64_t>(head) * head_k_dim + d];
+    k_row[d] = k[static_cast<int64_t>(head) * head_k_dim + d];
+  }
+  __syncthreads();
+  const float beta_h = beta[head];
+  const float g_exp = expf(g[head]);
+  float* state_head = state + static_cast<int64_t>(head) * head_k_dim * head_v_dim;
+  float kv_mem = 0.0f;
+  for (int m = 0; m < head_k_dim; ++m) {
+    const float decayed = state_head[m * head_v_dim + j] * g_exp;
+    state_head[m * head_v_dim + j] = decayed;
+    kv_mem += decayed * k_row[m];
+  }
+  const float delta = (v[static_cast<int64_t>(head) * head_v_dim + j] - kv_mem) * beta_h;
+  float acc = 0.0f;
+  for (int m = 0; m < head_k_dim; ++m) {
+    const float updated = state_head[m * head_v_dim + j] + k_row[m] * delta;
+    state_head[m * head_v_dim + j] = updated;
+    acc += updated * q_row[m];
+  }
+  out[static_cast<int64_t>(head) * head_v_dim + j] = __float2bfloat16(acc);
+}
+
+// Gated RMSNorm: y = bf16(rms(x)), y2 = bf16(w * y), out = bf16(y2 * silu(z)).
+// x rows are [rows, cols]; z rows are strided slices z[(row/z_heads) *
+// z_row_stride + z_col_offset + (row%z_heads)*cols].
+__global__ void gated_rms_silu_bf16_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* z, const __nv_bfloat16* weight,
+    __nv_bfloat16* out, int cols, int z_heads, int64_t z_row_stride,
+    int64_t z_col_offset, float eps) {
+  const int row = blockIdx.x;
+  extern __shared__ float la_gated[];
+  const int64_t base = static_cast<int64_t>(row) * cols;
+  const int64_t z_base = static_cast<int64_t>(row / z_heads) * z_row_stride + z_col_offset
+      + static_cast<int64_t>(row % z_heads) * cols;
+  float partial = 0.0f;
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const float v = __bfloat162float(x[base + i]);
+    la_gated[i] = v;
+    partial += v * v;
+  }
+  __shared__ float warp_sums[32];
+  for (int offset = 16; offset > 0; offset >>= 1)
+    partial += __shfl_xor_sync(0xffffffff, partial, offset);
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) warp_sums[warp] = partial;
+  __syncthreads();
+  if (warp == 0) {
+    float v = (lane < (blockDim.x + 31) / 32) ? warp_sums[lane] : 0.0f;
+    for (int offset = 16; offset > 0; offset >>= 1)
+      v += __shfl_xor_sync(0xffffffff, v, offset);
+    if (lane == 0) warp_sums[0] = v;
+  }
+  __syncthreads();
+  const float rms = rsqrtf(warp_sums[0] / cols + eps);
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const float y0 = __bfloat162float(__float2bfloat16(la_gated[i] * rms));
+    const float y1 = __bfloat162float(__float2bfloat16(__bfloat162float(weight[i]) * y0));
+    const float zf = __bfloat162float(z[z_base + i]);
+    out[base + i] = __float2bfloat16(y1 * la_silu(zf));
+  }
+}
+
+// RMSNorm with zero-init (1 + w) weights: out = rms(x) * (1 + w), fp32 compute.
+__global__ void rms_norm_plus1_bf16_kernel(
+    const __nv_bfloat16* input, const __nv_bfloat16* weight, __nv_bfloat16* output,
+    int cols, float eps) {
+  const int row = blockIdx.x;
+  extern __shared__ float la_plus1[];
+  const int64_t base = static_cast<int64_t>(row) * cols;
+  float partial = 0.0f;
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const float v = __bfloat162float(input[base + i]);
+    la_plus1[i] = v;
+    partial += v * v;
+  }
+  __shared__ float warp_sums[32];
+  for (int offset = 16; offset > 0; offset >>= 1)
+    partial += __shfl_xor_sync(0xffffffff, partial, offset);
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) warp_sums[warp] = partial;
+  __syncthreads();
+  if (warp == 0) {
+    float v = (lane < (blockDim.x + 31) / 32) ? warp_sums[lane] : 0.0f;
+    for (int offset = 16; offset > 0; offset >>= 1)
+      v += __shfl_xor_sync(0xffffffff, v, offset);
+    if (lane == 0) warp_sums[0] = v;
+  }
+  __syncthreads();
+  const float rms = rsqrtf(warp_sums[0] / cols + eps);
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    output[base + i] = __float2bfloat16(
+        la_plus1[i] * rms * (1.0f + __bfloat162float(weight[i])));
+  }
+}
+
+// Partial rotary from precomputed bf16 cos/sin tables [rows, rotary_dim]:
+// rotate the leading rotary_dim channels (pairs (p, p + rotary/2)) with the
+// torch elementwise rounding chain (mul -> round, mul -> round, add -> round),
+// pass the remaining channels through. Works in place (out may alias x).
+__global__ void partial_rope_table_bf16_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* cos, const __nv_bfloat16* sin,
+    __nv_bfloat16* out, int heads, int head_dim, int rotary_dim) {
+  const int row = blockIdx.x;
+  const int head = blockIdx.y;
+  const int half = rotary_dim / 2;
+  const int64_t table_base = static_cast<int64_t>(row) * rotary_dim;
+  const int64_t base = (static_cast<int64_t>(row) * heads + head) * head_dim;
+  for (int p = threadIdx.x; p < half; p += blockDim.x) {
+    const float a = __bfloat162float(x[base + p]);
+    const float b = __bfloat162float(x[base + half + p]);
+    const float c = __bfloat162float(cos[table_base + p]);
+    const float s = __bfloat162float(sin[table_base + p]);
+    const float t1 = __bfloat162float(__float2bfloat16(a * c));
+    const float t2 = __bfloat162float(__float2bfloat16(-b * s));
+    const float t3 = __bfloat162float(__float2bfloat16(b * c));
+    const float t4 = __bfloat162float(__float2bfloat16(a * s));
+    out[base + p] = __float2bfloat16(t1 + t2);
+    out[base + half + p] = __float2bfloat16(t3 + t4);
+  }
+  for (int d = rotary_dim + threadIdx.x; d < head_dim; d += blockDim.x) {
+    out[base + d] = x[base + d];
+  }
+}
+
+// Fused full-attention input preparation for the (q|gate)-per-head layout:
+// per (token, head): per-head RMSNorm (1 + w semantics) on q/k, partial rotary
+// from tables, K/V cache append. The gate half of each q head stays in the
+// fused buffer for the post-attention sigmoid gate.
+// Grid y: [0, q_heads) -> q, [q_heads, q_heads+kv_heads) -> k, rest -> v.
+__global__ void full_attn_prepare_bf16_kernel(
+    const __nv_bfloat16* fused, const __nv_bfloat16* q_norm_w, const __nv_bfloat16* k_norm_w,
+    const __nv_bfloat16* cos, const __nv_bfloat16* sin,
+    __nv_bfloat16* q_out, __nv_bfloat16* k_cache, __nv_bfloat16* v_cache,
+    int cache_offset, int q_heads, int kv_heads, int head_dim,
+    int rotary_dim, int64_t fused_width, int64_t cache_width, float eps) {
+  const int token = blockIdx.x;
+  const int slot = blockIdx.y;
+  const int half = rotary_dim / 2;
+  extern __shared__ float la_attn[];
+  const int64_t row = static_cast<int64_t>(token) * fused_width;
+  const int64_t table_base = static_cast<int64_t>(token) * rotary_dim;
+  if (slot < q_heads + kv_heads) {
+    const bool is_q = slot < q_heads;
+    const int head = is_q ? slot : slot - q_heads;
+    const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+    const int64_t src = row + (is_q
+        ? static_cast<int64_t>(head) * 2 * head_dim
+        : static_cast<int64_t>(q_heads) * 2 * head_dim + head * head_dim);
+    float partial = 0.0f;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      const float v = __bfloat162float(fused[src + i]);
+      la_attn[i] = v;
+      partial += v * v;
+    }
+    __shared__ float warp_sums[32];
+    for (int offset = 16; offset > 0; offset >>= 1)
+      partial += __shfl_xor_sync(0xffffffff, partial, offset);
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    if (lane == 0) warp_sums[warp] = partial;
+    __syncthreads();
+    if (warp == 0) {
+      float v = (lane < (blockDim.x + 31) / 32) ? warp_sums[lane] : 0.0f;
+      for (int offset = 16; offset > 0; offset >>= 1)
+        v += __shfl_xor_sync(0xffffffff, v, offset);
+      if (lane == 0) warp_sums[0] = v;
+    }
+    __syncthreads();
+    const float rms = rsqrtf(warp_sums[0] / head_dim + eps);
+    __syncthreads();
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      la_attn[i] = __bfloat162float(__float2bfloat16(
+          la_attn[i] * rms * (1.0f + __bfloat162float(norm_w[i]))));
+    }
+    __syncthreads();
+    __nv_bfloat16* dst = is_q
+        ? q_out + (static_cast<int64_t>(token) * q_heads + head) * head_dim
+        : k_cache + (static_cast<int64_t>(cache_offset + token)) * cache_width + head * head_dim;
+    for (int p = threadIdx.x; p < half; p += blockDim.x) {
+      const float a = la_attn[p];
+      const float b = la_attn[half + p];
+      const float c = __bfloat162float(cos[table_base + p]);
+      const float s = __bfloat162float(sin[table_base + p]);
+      const float t1 = __bfloat162float(__float2bfloat16(a * c));
+      const float t2 = __bfloat162float(__float2bfloat16(-b * s));
+      const float t3 = __bfloat162float(__float2bfloat16(b * c));
+      const float t4 = __bfloat162float(__float2bfloat16(a * s));
+      dst[p] = __float2bfloat16(t1 + t2);
+      dst[half + p] = __float2bfloat16(t3 + t4);
+    }
+    for (int d = rotary_dim + threadIdx.x; d < head_dim; d += blockDim.x) {
+      dst[d] = __float2bfloat16(la_attn[d]);
+    }
+  } else {
+    const int head = slot - q_heads - kv_heads;
+    const int64_t src = row + static_cast<int64_t>(q_heads) * 2 * head_dim
+        + static_cast<int64_t>(kv_heads) * head_dim + head * head_dim;
+    __nv_bfloat16* dst = v_cache + (static_cast<int64_t>(cache_offset + token)) * cache_width
+        + head * head_dim;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      dst[i] = fused[src + i];
+    }
+  }
+}
+
+// Post-attention output gate: attn *= sigmoid(gate), with the gate read from
+// the (q|gate) interleaved fused projection (column h*2*head_dim + head_dim).
+__global__ void sigmoid_gate_mul_bf16_kernel(
+    __nv_bfloat16* attn, const __nv_bfloat16* fused, int heads, int head_dim,
+    int64_t fused_width) {
+  const int row = blockIdx.x;
+  const int64_t base = static_cast<int64_t>(row) * heads * head_dim;
+  const int64_t gate_row = static_cast<int64_t>(row) * fused_width;
+  for (int idx = threadIdx.x; idx < heads * head_dim; idx += blockDim.x) {
+    const int head = idx / head_dim;
+    const int d = idx - head * head_dim;
+    const float gate = __bfloat162float(
+        fused[gate_row + head * 2 * head_dim + head_dim + d]);
+    const float s = __bfloat162float(__float2bfloat16(la_sigmoid(gate)));
+    attn[base + idx] = __float2bfloat16(__bfloat162float(attn[base + idx]) * s);
+  }
+}
+
+// adaLN normalization: out = bf16(bf16(rms(x)*w) * bf16(1 + scale) + shift).
+__global__ void adaln_rms_norm_bf16_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* weight,
+    const __nv_bfloat16* scale, const __nv_bfloat16* shift,
+    __nv_bfloat16* out, int cols, float eps) {
+  const int row = blockIdx.x;
+  extern __shared__ float la_adaln[];
+  const int64_t base = static_cast<int64_t>(row) * cols;
+  float partial = 0.0f;
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const float v = __bfloat162float(x[base + i]);
+    la_adaln[i] = v;
+    partial += v * v;
+  }
+  __shared__ float warp_sums[32];
+  for (int offset = 16; offset > 0; offset >>= 1)
+    partial += __shfl_xor_sync(0xffffffff, partial, offset);
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) warp_sums[warp] = partial;
+  __syncthreads();
+  if (warp == 0) {
+    float v = (lane < (blockDim.x + 31) / 32) ? warp_sums[lane] : 0.0f;
+    for (int offset = 16; offset > 0; offset >>= 1)
+      v += __shfl_xor_sync(0xffffffff, v, offset);
+    if (lane == 0) warp_sums[0] = v;
+  }
+  __syncthreads();
+  const float rms = rsqrtf(warp_sums[0] / cols + eps);
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const float normed = __bfloat162float(__float2bfloat16(
+        la_adaln[i] * rms * __bfloat162float(weight[i])));
+    const float multiplier = __bfloat162float(
+        __float2bfloat16(1.0f + __bfloat162float(scale[i])));
+    const float scaled = __bfloat162float(__float2bfloat16(normed * multiplier));
+    out[base + i] = __float2bfloat16(scaled + __bfloat162float(shift[i]));
+  }
+}
+
+// adaLN residual: out = bf16(residual + bf16(proj * bf16(1 + gate))).
+__global__ void adaln_gate_residual_bf16_kernel(
+    const __nv_bfloat16* proj, const __nv_bfloat16* residual,
+    const __nv_bfloat16* gate, __nv_bfloat16* out, int64_t count, int cols) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const int col = static_cast<int>(index % cols);
+    const float multiplier = __bfloat162float(
+        __float2bfloat16(1.0f + __bfloat162float(gate[col])));
+    const float projected = __bfloat162float(
+        __float2bfloat16(__bfloat162float(proj[index]) * multiplier));
+    out[index] = __float2bfloat16(__bfloat162float(residual[index]) + projected);
+  }
+}
+
+// Expert fused-QKV preparation: per (token, group-major slot) split the fused
+// projection into query/gate/key/value, apply per-head RMSNorm (plain weight)
+// and partial rotary to q/k. Grid y covers q_heads + kv_heads + kv_heads slots.
+__global__ void expert_qkv_prepare_bf16_kernel(
+    const __nv_bfloat16* fused, const __nv_bfloat16* q_norm_w, const __nv_bfloat16* k_norm_w,
+    const __nv_bfloat16* cos, const __nv_bfloat16* sin,
+    __nv_bfloat16* q_out, __nv_bfloat16* gate_out, __nv_bfloat16* k_out, __nv_bfloat16* v_out,
+    int q_heads, int kv_heads, int head_dim, int rotary_dim,
+    int64_t fused_width, float eps) {
+  const int token = blockIdx.x;
+  const int slot = blockIdx.y;
+  const int half = rotary_dim / 2;
+  const int heads_per_group = q_heads / kv_heads;
+  const int group_width = (2 * heads_per_group + 2) * head_dim;
+  const int64_t row = static_cast<int64_t>(token) * fused_width;
+  const int64_t table_base = static_cast<int64_t>(token) * rotary_dim;
+  extern __shared__ float la_expert[];
+  if (slot < q_heads + kv_heads) {
+    const bool is_q = slot < q_heads;
+    const int head = is_q ? slot : slot - q_heads;
+    const int group = is_q ? head / heads_per_group : head;
+    const int64_t src = row + static_cast<int64_t>(group) * group_width
+        + (is_q ? static_cast<int64_t>(head - group * heads_per_group) * head_dim
+                : static_cast<int64_t>(2 * heads_per_group) * head_dim);
+    const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+    float partial = 0.0f;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      const float v = __bfloat162float(fused[src + i]);
+      la_expert[i] = v;
+      partial += v * v;
+    }
+    __shared__ float warp_sums[32];
+    for (int offset = 16; offset > 0; offset >>= 1)
+      partial += __shfl_xor_sync(0xffffffff, partial, offset);
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    if (lane == 0) warp_sums[warp] = partial;
+    __syncthreads();
+    if (warp == 0) {
+      float v = (lane < (blockDim.x + 31) / 32) ? warp_sums[lane] : 0.0f;
+      for (int offset = 16; offset > 0; offset >>= 1)
+        v += __shfl_xor_sync(0xffffffff, v, offset);
+      if (lane == 0) warp_sums[0] = v;
+    }
+    __syncthreads();
+    const float rms = rsqrtf(warp_sums[0] / head_dim + eps);
+    __syncthreads();
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      la_expert[i] = __bfloat162float(__float2bfloat16(
+          la_expert[i] * rms * __bfloat162float(norm_w[i])));
+    }
+    __syncthreads();
+    __nv_bfloat16* dst = is_q
+        ? q_out + (static_cast<int64_t>(token) * q_heads + head) * head_dim
+        : k_out + (static_cast<int64_t>(token) * kv_heads + head) * head_dim;
+    for (int p = threadIdx.x; p < half; p += blockDim.x) {
+      const float a = la_expert[p];
+      const float b = la_expert[half + p];
+      const float c = __bfloat162float(cos[table_base + p]);
+      const float s = __bfloat162float(sin[table_base + p]);
+      const float t1 = __bfloat162float(__float2bfloat16(a * c));
+      const float t2 = __bfloat162float(__float2bfloat16(-b * s));
+      const float t3 = __bfloat162float(__float2bfloat16(b * c));
+      const float t4 = __bfloat162float(__float2bfloat16(a * s));
+      dst[p] = __float2bfloat16(t1 + t2);
+      dst[half + p] = __float2bfloat16(t3 + t4);
+    }
+    for (int d = rotary_dim + threadIdx.x; d < head_dim; d += blockDim.x) {
+      dst[d] = __float2bfloat16(la_expert[d]);
+    }
+    if (is_q) {
+      __nv_bfloat16* gate_dst = gate_out + (static_cast<int64_t>(token) * q_heads + head) * head_dim;
+      const int64_t gate_src = row + static_cast<int64_t>(group) * group_width
+          + static_cast<int64_t>(heads_per_group + head - group * heads_per_group) * head_dim;
+      for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+        gate_dst[i] = fused[gate_src + i];
+      }
+    }
+  } else {
+    const int head = slot - q_heads - kv_heads;
+    const int64_t src = row + static_cast<int64_t>(head) * group_width
+        + static_cast<int64_t>(2 * heads_per_group + 1) * head_dim;
+    __nv_bfloat16* dst = v_out + (static_cast<int64_t>(token) * kv_heads + head) * head_dim;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+      dst[i] = fused[src + i];
+    }
+  }
+}
+
+// Expert post-attention gate from a standalone gate tensor [rows, heads*dim].
+__global__ void expert_sigmoid_gate_mul_bf16_kernel(
+    __nv_bfloat16* attn, const __nv_bfloat16* gate, int64_t count) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const float g = __bfloat162float(gate[index]);
+    const float s = __bfloat162float(__float2bfloat16(la_sigmoid(g)));
+    attn[index] = __float2bfloat16(__bfloat162float(attn[index]) * s);
+  }
+}
+
+// Fourier waypoint features: per channel, cat(sin(w*f*2pi), cos(w*f*2pi)).
+__global__ void fourier_features_bf16_kernel(
+    const __nv_bfloat16* waypoints, const __nv_bfloat16* freqs, __nv_bfloat16* out,
+    int point_dim, int num_features) {
+  const int token = blockIdx.x;
+  const int width = point_dim * num_features * 2;
+  const int64_t base = static_cast<int64_t>(token) * width;
+  for (int idx = threadIdx.x; idx < point_dim * num_features; idx += blockDim.x) {
+    const int c = idx / num_features;
+    const int f = idx - c * num_features;
+    const float w = __bfloat162float(waypoints[static_cast<int64_t>(token) * point_dim + c]);
+    const float freq = __bfloat162float(freqs[f]);
+    const float angle = (w * freq) * 6.2831855f;
+    out[base + c * 2 * num_features + f] = __float2bfloat16(sinf(angle));
+    out[base + c * 2 * num_features + num_features + f] = __float2bfloat16(cosf(angle));
+  }
+}
+
+// Column concat of seven same-width sources into one [rows, 7*cols] buffer;
+// a set broadcast bit replicates source row 0 for every output row.
+__global__ void concat7_cols_bf16_kernel(
+    const __nv_bfloat16* s0, const __nv_bfloat16* s1, const __nv_bfloat16* s2,
+    const __nv_bfloat16* s3, const __nv_bfloat16* s4, const __nv_bfloat16* s5,
+    const __nv_bfloat16* s6, __nv_bfloat16* dst, int rows, int cols,
+    int broadcast_mask) {
+  const int token = blockIdx.x;
+  const int64_t dst_base = static_cast<int64_t>(token) * 7 * cols;
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    const int64_t src_idx = static_cast<int64_t>(token) * cols + i;
+    const int64_t bcast_idx = i;
+    dst[dst_base + i] = (broadcast_mask & 1) ? s0[bcast_idx] : s0[src_idx];
+    dst[dst_base + cols + i] = (broadcast_mask & 2) ? s1[bcast_idx] : s1[src_idx];
+    dst[dst_base + 2 * cols + i] = (broadcast_mask & 4) ? s2[bcast_idx] : s2[src_idx];
+    dst[dst_base + 3 * cols + i] = (broadcast_mask & 8) ? s3[bcast_idx] : s3[src_idx];
+    dst[dst_base + 4 * cols + i] = (broadcast_mask & 16) ? s4[bcast_idx] : s4[src_idx];
+    dst[dst_base + 5 * cols + i] = (broadcast_mask & 32) ? s5[bcast_idx] : s5[src_idx];
+    dst[dst_base + 6 * cols + i] = (broadcast_mask & 64) ? s6[bcast_idx] : s6[src_idx];
+  }
+}
+
+// Flow-matching Euler update: w += (endpoint - w) / remaining * step (fp32).
+__global__ void flow_update_f32_kernel(
+    float* w, const float* endpoint, float remaining, float step, int64_t count) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const float delta = endpoint[index] - w[index];
+    w[index] = w[index] + (delta / remaining) * step;
+  }
+}
+
+// Set the listed logits columns to -inf (min-new-tokens EOS suppression).
+__global__ void suppress_logits_bf16_kernel(
+    __nv_bfloat16* logits, const uint32_t* ids, int count) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= count) return;
+  logits[ids[idx]] = __float2bfloat16(-INFINITY);
+}
+
+// Exact (erf) GELU, fp32 compute, bf16 storage.
+__global__ void gelu_exact_bf16_kernel(
+    const __nv_bfloat16* input, __nv_bfloat16* output, int64_t count) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < count; index += stride) {
+    const float x = __bfloat162float(input[index]);
+    output[index] = __float2bfloat16(x * 0.5f * (1.0f + erff(x * 0.70710678f)));
+  }
+}
+
+// Merge `factor` consecutive rows into one: out[r, s*cols + c] = in[r*factor+s, c].
+__global__ void merge_rows_bf16_kernel(
+    const __nv_bfloat16* input, __nv_bfloat16* output, int64_t out_count, int cols, int factor) {
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (; index < out_count; index += stride) {
+    const int64_t r = index / (static_cast<int64_t>(factor) * cols);
+    const int64_t rem = index - r * factor * cols;
+    const int64_t s = rem / cols;
+    const int64_t c = rem - s * cols;
+    output[index] = input[(r * factor + s) * cols + c];
+  }
+}

--- a/crates/apxinf-cuda/src/ffi/linear_attention.rs
+++ b/crates/apxinf-cuda/src/ffi/linear_attention.rs
@@ -1,0 +1,318 @@
+//! Raw bindings for the linear-attention / hybrid-recurrent custom operators.
+
+use std::ffi::c_void;
+
+use super::cuda::{cudaError_t, cudaStream_t};
+
+extern "C" {
+    pub fn apxinf_static_cast_f32_bf16(
+        input: *const c_void,
+        output: *mut c_void,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_cast_bf16_f32(
+        input: *const c_void,
+        output: *mut c_void,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    // FIX (implement_r8): tiled block-per-row softmax (fp32 in, bf16 out) for the
+    // route-3 composed vision attention; defined in adapters/custom_kernels.cu.
+    pub fn apxinf_static_row_softmax_f32_bf16(
+        input: *const c_void,
+        output: *mut c_void,
+        cols: u32,
+        rows: u32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_causal_conv1d_silu_bf16(
+        x: *const c_void,
+        weight: *const c_void,
+        state: *const c_void,
+        out: *mut c_void,
+        new_state: *mut c_void,
+        channels: i32,
+        seq: i32,
+        kernel_size: i32,
+        x_row_stride: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_qk_prep_bf16(
+        conv_out: *const c_void,
+        q_out: *mut c_void,
+        k_out: *mut c_void,
+        seq: i32,
+        seq_pad: i32,
+        conv_dim: i32,
+        key_dim: i32,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        scale: f32,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_vb_prep_bf16(
+        conv_out: *const c_void,
+        b_proj: *const c_void,
+        a_proj: *const c_void,
+        dt_bias: *const c_void,
+        a_log: *const c_void,
+        v_out: *mut c_void,
+        beta_out: *mut c_void,
+        g_out: *mut c_void,
+        seq: i32,
+        seq_pad: i32,
+        conv_dim: i32,
+        v_offset: i32,
+        num_v_heads: i32,
+        ba_row_stride: i32,
+        head_v_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_gdn_cumsum_f32(
+        g: *const c_void,
+        g_cum: *mut c_void,
+        seq_pad: i32,
+        num_v_heads: i32,
+        chunk_size: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_attn_raw_f32(
+        q: *const c_void,
+        k: *const c_void,
+        beta: *const c_void,
+        g_cum: *const c_void,
+        a_out: *mut c_void,
+        t_out: *mut c_void,
+        seq_pad: i32,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        chunk_size: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_gdn_tri_solve_f32(
+        a: *mut c_void,
+        matrices: i32,
+        chunk_size: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_chunk_gemm_f32(
+        a: *const c_void,
+        v: *const c_void,
+        k: *const c_void,
+        beta: *const c_void,
+        g_cum: *const c_void,
+        vt_out: *mut c_void,
+        kcd_out: *mut c_void,
+        seq_pad: i32,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        head_v_dim: i32,
+        chunk_size: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_chunk_state_f32(
+        q: *const c_void,
+        k: *const c_void,
+        g_cum: *const c_void,
+        t_in: *const c_void,
+        vt_in: *const c_void,
+        kcd_in: *const c_void,
+        state: *mut c_void,
+        out: *mut c_void,
+        seq: i32,
+        seq_pad: i32,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        head_v_dim: i32,
+        chunk_size: i32,
+        total_chunks: i32,
+        out_row_width: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gdn_recurrent_f32(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        beta: *const c_void,
+        g: *const c_void,
+        state: *mut c_void,
+        out: *mut c_void,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        head_v_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_gated_rms_silu_bf16(
+        x: *const c_void,
+        z: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        rows: i32,
+        cols: i32,
+        z_heads: i32,
+        z_row_stride: i64,
+        z_col_offset: i64,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_rms_norm_plus1_bf16(
+        input: *const c_void,
+        weight: *const c_void,
+        output: *mut c_void,
+        rows: i32,
+        cols: i32,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_partial_rope_table_bf16(
+        x: *const c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        out: *mut c_void,
+        rows: i32,
+        heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_full_attn_prepare_bf16(
+        fused: *const c_void,
+        q_norm_w: *const c_void,
+        k_norm_w: *const c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        q_out: *mut c_void,
+        k_cache: *mut c_void,
+        v_cache: *mut c_void,
+        seq: i32,
+        cache_offset: i32,
+        q_heads: i32,
+        kv_heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        fused_width: i64,
+        cache_width: i64,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_sigmoid_gate_mul_bf16(
+        attn: *mut c_void,
+        fused: *const c_void,
+        rows: i32,
+        heads: i32,
+        head_dim: i32,
+        fused_width: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_adaln_rms_norm_bf16(
+        x: *const c_void,
+        weight: *const c_void,
+        scale: *const c_void,
+        shift: *const c_void,
+        out: *mut c_void,
+        rows: i32,
+        cols: i32,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_adaln_gate_residual_bf16(
+        proj: *const c_void,
+        residual: *const c_void,
+        gate: *const c_void,
+        out: *mut c_void,
+        count: i64,
+        cols: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_expert_qkv_prepare_bf16(
+        fused: *const c_void,
+        q_norm_w: *const c_void,
+        k_norm_w: *const c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        q_out: *mut c_void,
+        gate_out: *mut c_void,
+        k_out: *mut c_void,
+        v_out: *mut c_void,
+        seq: i32,
+        q_heads: i32,
+        kv_heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        fused_width: i64,
+        eps: f32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_expert_sigmoid_gate_mul_bf16(
+        attn: *mut c_void,
+        gate: *const c_void,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_fourier_features_bf16(
+        waypoints: *const c_void,
+        freqs: *const c_void,
+        out: *mut c_void,
+        rows: i32,
+        point_dim: i32,
+        num_features: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    #[allow(clippy::too_many_arguments)]
+    pub fn apxinf_static_concat7_cols_bf16(
+        s0: *const c_void,
+        s1: *const c_void,
+        s2: *const c_void,
+        s3: *const c_void,
+        s4: *const c_void,
+        s5: *const c_void,
+        s6: *const c_void,
+        dst: *mut c_void,
+        rows: i32,
+        cols: i32,
+        broadcast_mask: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_flow_update_f32(
+        w: *mut c_void,
+        endpoint: *const c_void,
+        remaining: f32,
+        step: f32,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_suppress_logits_bf16(
+        logits: *mut c_void,
+        ids: *const u32,
+        count: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_gelu_exact_bf16(
+        input: *const c_void,
+        output: *mut c_void,
+        count: i64,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+    pub fn apxinf_static_merge_rows_bf16(
+        input: *const c_void,
+        output: *mut c_void,
+        out_count: i64,
+        cols: i32,
+        factor: i32,
+        stream: cudaStream_t,
+    ) -> cudaError_t;
+}

--- a/crates/apxinf-cuda/src/ffi/mod.rs
+++ b/crates/apxinf-cuda/src/ffi/mod.rs
@@ -12,6 +12,7 @@ mod custom;
 mod cutlass;
 mod driver;
 mod fa2;
+mod linear_attention;
 
 pub(crate) use cublas::*;
 pub(crate) use cublaslt::*;
@@ -20,3 +21,4 @@ pub(crate) use custom::*;
 pub(crate) use cutlass::*;
 pub(crate) use driver::*;
 pub(crate) use fa2::*;
+pub(crate) use linear_attention::*;

--- a/crates/apxinf-cuda/src/kernels/attention.rs
+++ b/crates/apxinf-cuda/src/kernels/attention.rs
@@ -1235,13 +1235,158 @@ pub fn segmented_mha_bf16(
     )?;
     #[cfg(any(apxinf_fa2_sm80, apxinf_fa2_f16_sm100))]
     {
+        // TEMP-DIAG (implement_r4): per-call gate + clock; revert in the acceptance-bound revision.
+        static MHA_DIAG_CALL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let mha_diag_call = MHA_DIAG_CALL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mha_diag = mha_diag_call < 2; // blocks 0 and 1 are the receipt-implicated calls
+        let mha_t0 = std::time::Instant::now();
+        // FIX (implement_r8): route-3 composed gemm_ex + tiled-softmax per-segment attention
+        // replaces the r6/r7 pad route. The vendored FA2 fwd family is measured pathological
+        // on sm_89 across hdim96 IsEvenK=false (r4 ~19.3s/launch), hdim96 IsEvenK=true
+        // (r6 ~19.2s) and hdim128 IsEvenK=true (r7 ~28.2s), so the head_dim==64 vision arm
+        // runs on measured-healthy cuBLAS GEMMs plus the tiled row-softmax kernel; scores
+        // stay fp32 end-to-end and P is rounded to bf16 for the PV MMA exactly as FA2 does.
+        // Revert/replace in the acceptance-bound revision per the prevailing marker policy.
+        let orig_head_dim = shape[2]; // FIX (implement_r6)
+        if orig_head_dim == 64 { // FIX (implement_r8): composed per-segment attention at the true dim
+            let qf32_buf = CudaBuffer::alloc(shape[0] * shape[1] * orig_head_dim * 4, ctx.device_id())
+                .map_err(Error::Cuda)?; // FIX (implement_r8)
+            let qf32_t = qf32_buf.as_tensor(q.shape().clone(), DType::F32).map_err(Error::Cuda)?; // FIX (implement_r8)
+            super::linear_attention::cast_bf16_to_f32(ctx, q, &qf32_t)?; // FIX (implement_r8)
+            let kf32_buf = CudaBuffer::alloc(shape[0] * shape[1] * orig_head_dim * 4, ctx.device_id())
+                .map_err(Error::Cuda)?; // FIX (implement_r8)
+            let kf32_t = kf32_buf.as_tensor(k.shape().clone(), DType::F32).map_err(Error::Cuda)?; // FIX (implement_r8)
+            super::linear_attention::cast_bf16_to_f32(ctx, k, &kf32_t)?; // FIX (implement_r8)
+            let output = output_buffer(ctx, q.size_in_bytes())?; // FIX (implement_r8): packed [T,16,64]; out_bytes=85,327,872 signs the composed route
+            // TEMP-DIAG (implement_r4): entry-alloc bracket; revert in the acceptance-bound revision.
+            if mha_diag {
+                eprintln!("[qwen_drive] mha_alloc_ok call={} out_bytes={} lse_bytes={} ms={}",
+                          mha_diag_call, q.size_in_bytes(),
+                          0, mha_t0.elapsed().as_millis());
+            }
+            for (seg_idx, bounds) in host_offsets.windows(2).enumerate() {
+                let start = bounds[0] as usize;
+                let tokens = (bounds[1] - bounds[0]) as usize;
+                if tokens == 0 { continue; } // FIX (implement_r8): degenerate-segment guard
+                // TEMP-DIAG (implement_r4): pre-launch segment marker; revert in the acceptance-bound revision.
+                if mha_diag {
+                    eprintln!("[qwen_drive] mha_seg call={} i={} start={} tokens={} ms={}",
+                              mha_diag_call, seg_idx, start, tokens, mha_t0.elapsed().as_millis());
+                }
+                let scores = CudaBuffer::alloc(shape[1] * tokens * tokens * 4, ctx.device_id())
+                    .map_err(Error::Cuda)?; // FIX (implement_r8): fp32 [heads,tokens,tokens]
+                let probs = CudaBuffer::alloc(shape[1] * tokens * tokens * 2, ctx.device_id())
+                    .map_err(Error::Cuda)?; // FIX (implement_r8): bf16 [heads,tokens,tokens]
+                for head in 0..shape[1] {
+                    let q_head = buffer_slice(
+                        &qf32_buf,
+                        (start * shape[1] * orig_head_dim + head * orig_head_dim) * 4,
+                        ((tokens - 1) * shape[1] * orig_head_dim + orig_head_dim) * 4,
+                    )?; // FIX (implement_r8)
+                    let k_head = buffer_slice(
+                        &kf32_buf,
+                        (start * shape[1] * orig_head_dim + head * orig_head_dim) * 4,
+                        ((tokens - 1) * shape[1] * orig_head_dim + orig_head_dim) * 4,
+                    )?; // FIX (implement_r8)
+                    let scores_head = buffer_slice(&scores, head * tokens * tokens * 4, tokens * tokens * 4)?; // FIX (implement_r8)
+                    ctx.cublas()
+                        .gemm_ex(
+                            DType::F32,
+                            CublasTranspose::None,
+                            CublasTranspose::Transpose,
+                            tokens,
+                            tokens,
+                            orig_head_dim,
+                            (orig_head_dim as f32).sqrt().recip(),
+                            &q_head,
+                            (shape[1] * orig_head_dim) as i32,
+                            &k_head,
+                            (shape[1] * orig_head_dim) as i32,
+                            0.0,
+                            &scores_head,
+                            tokens as i32,
+                        )
+                        .map_err(Error::Cuda)?; // FIX (implement_r8): Q*K^T; alpha folds the softmax scale bound to the true dim 64
+                }
+                unsafe {
+                    ffi::check_cuda(ffi::apxinf_static_row_softmax_f32_bf16(
+                        scores.ptr() as *const std::ffi::c_void,
+                        probs.ptr(),
+                        tokens as u32,
+                        (shape[1] * tokens) as u32,
+                        ctx.stream().handle(),
+                    ))
+                    .map_err(Error::Cuda)?; // FIX (implement_r8): tiled block-per-row softmax, fp32 in / bf16 out
+                }
+                for head in 0..shape[1] {
+                    let probs_head = buffer_slice(&probs, head * tokens * tokens * 2, tokens * tokens * 2)?; // FIX (implement_r8)
+                    let v_head = tensor_slice(
+                        v,
+                        (start * shape[1] * orig_head_dim + head * orig_head_dim) * 2,
+                        ((tokens - 1) * shape[1] * orig_head_dim + orig_head_dim) * 2,
+                        ctx.device_id(),
+                    )?; // FIX (implement_r8)
+                    let out_head = buffer_slice(
+                        &output,
+                        (start * shape[1] * orig_head_dim + head * orig_head_dim) * 2,
+                        ((tokens - 1) * shape[1] * orig_head_dim + orig_head_dim) * 2,
+                    )?; // FIX (implement_r8)
+                    ctx.cublas()
+                        .gemm_ex(
+                            DType::BF16,
+                            CublasTranspose::None,
+                            CublasTranspose::None,
+                            tokens,
+                            orig_head_dim,
+                            tokens,
+                            1.0,
+                            &probs_head,
+                            tokens as i32,
+                            &v_head,
+                            (shape[1] * orig_head_dim) as i32,
+                            0.0,
+                            &out_head,
+                            (shape[1] * orig_head_dim) as i32,
+                        )
+                        .map_err(Error::Cuda)?; // FIX (implement_r8): P*V straight into the packed [T,16,64] output
+                }
+                // TEMP-DIAG (implement_r4): post-launch retirement probe; converts an async fault into a loud Err; revert in the acceptance-bound revision.
+                if mha_diag {
+                    ctx.synchronize().map_err(Error::Cuda)?;
+                    eprintln!("[qwen_drive] mha_seg_ok call={} i={} ms={}",
+                              mha_diag_call, seg_idx, mha_t0.elapsed().as_millis());
+                }
+            }
+            // TEMP-DIAG (implement_r4): separates "12 launches retired" from "epilogue cudaFree wedged"; revert in the acceptance-bound revision.
+            if mha_diag {
+                eprintln!("[qwen_drive] mha_loop_done call={} ms={}", mha_diag_call, mha_t0.elapsed().as_millis());
+            }
+            let result = make_gpu_tensor(
+                q.shape().clone(),
+                DType::BF16,
+                ctx.device_id(),
+                output,
+            );
+            return Ok(result);
+        }
         let output = output_buffer(ctx, q.size_in_bytes())?;
         let softmax_lse = output_buffer(ctx, shape[0] * shape[1] * std::mem::size_of::<f32>())?;
+        // TEMP-DIAG (implement_r4): entry-alloc bracket; revert in the acceptance-bound revision.
+        if mha_diag {
+            eprintln!("[qwen_drive] mha_alloc_ok call={} out_bytes={} lse_bytes={} ms={}",
+                      mha_diag_call, q.size_in_bytes(),
+                      shape[0] * shape[1] * std::mem::size_of::<f32>(), mha_t0.elapsed().as_millis());
+        }
         let row_bytes = shape[1] * shape[2] * DType::BF16.size_in_bytes();
         let lse_row_bytes = shape[1] * std::mem::size_of::<f32>();
-        for bounds in host_offsets.windows(2) {
+        for (seg_idx, bounds) in host_offsets.windows(2).enumerate() {
             let start = bounds[0] as usize;
             let tokens = (bounds[1] - bounds[0]) as usize;
+            // TEMP-DIAG (implement_r4): pre-launch segment marker; revert in the acceptance-bound revision.
+            if mha_diag {
+                eprintln!("[qwen_drive] mha_seg call={} i={} start={} tokens={} ms={}",
+                          mha_diag_call, seg_idx, start, tokens, mha_t0.elapsed().as_millis());
+            }
             unsafe {
                 ffi::check_cuda(ffi::apxinf_static_fa2_bf16(
                     gpu_ptr(q)?.cast::<u8>().add(start * row_bytes).cast(),
@@ -1264,13 +1409,24 @@ pub fn segmented_mha_bf16(
                 ))
                 .map_err(Error::Cuda)?;
             }
+            // TEMP-DIAG (implement_r4): post-launch retirement probe; converts an async fault into a loud Err; revert in the acceptance-bound revision.
+            if mha_diag {
+                ctx.synchronize().map_err(Error::Cuda)?;
+                eprintln!("[qwen_drive] mha_seg_ok call={} i={} ms={}",
+                          mha_diag_call, seg_idx, mha_t0.elapsed().as_millis());
+            }
         }
-        return Ok(make_gpu_tensor(
+        // TEMP-DIAG (implement_r4): separates "12 launches retired" from "epilogue cudaFree wedged"; revert in the acceptance-bound revision.
+        if mha_diag {
+            eprintln!("[qwen_drive] mha_loop_done call={} ms={}", mha_diag_call, mha_t0.elapsed().as_millis());
+        }
+        let result = make_gpu_tensor(
             q.shape().clone(),
             DType::BF16,
             ctx.device_id(),
             output,
-        ));
+        );
+        return Ok(result);
     }
     #[cfg(not(any(apxinf_fa2_sm80, apxinf_fa2_f16_sm100)))]
     let output = output_buffer(ctx, q.size_in_bytes())?;
@@ -1633,7 +1789,6 @@ pub fn mha_f16(
                 output.ptr(),
                 batches as i32,
                 tokens_per_batch as i32,
-                tokens_per_batch as i32,
                 shape[1] as i32,
                 shape[1] as i32,
                 shape[2] as i32,
@@ -1641,7 +1796,7 @@ pub fn mha_f16(
             );
             if status == 0 {
                 return Ok(make_gpu_tensor(
-                    q.shape().clone(),
+                    Shape::new(vec![tokens, heads, head_dim]),
                     DType::F16,
                     ctx.device_id(),
                     output,
@@ -1708,6 +1863,9 @@ pub fn mqa_f16_e4m3_522(
     if q.dtype() != DType::F16
         || k.dtype() != DType::F16
         || v.dtype() != DType::F16
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape().dims() != k_shape
         || q_shape != [522, 8, 256]
         || k_shape != [522, 1, 256]
         || v.shape().dims() != k_shape

--- a/crates/apxinf-cuda/src/kernels/linear_attention.rs
+++ b/crates/apxinf-cuda/src/kernels/linear_attention.rs
@@ -1,0 +1,1163 @@
+//! Linear-attention / hybrid-recurrent operator contracts.
+//!
+//! Model-neutral safe wrappers for the gated delta rule (chunked prefill and
+//! rank-1 recurrent decode), depthwise causal conv1d with SiLU, gated RMSNorm,
+//! partial rotary application from precomputed tables, adaLN helpers, and
+//! small dtype/layout utilities. Physical implementations live in
+//! `kernels/custom/linear_attention.cuh`; every wrapper owns validation and
+//! the raw FFI call.
+
+use apxinf_core::{DType, Error, Result, Shape, Tensor};
+
+use super::contracts::{
+    bf16_output, check_cuda, gpu_ptr, make_gpu_tensor, matrix_shape, optional_ptr,
+    require_buffers,
+};
+use crate::buffer::CudaBuffer;
+use crate::context::CudaContext;
+use crate::ffi;
+use crate::workspace::output_buffer;
+
+fn expect_bf16(tensor: &Tensor, name: &str) -> Result<()> {
+    if tensor.dtype() != DType::BF16 {
+        return Err(Error::Other(format!("linear-attention {name} expects BF16")));
+    }
+    Ok(())
+}
+
+fn f32_bytes(elements: usize) -> Result<usize> {
+    elements
+        .checked_mul(DType::F32.size_in_bytes())
+        .ok_or_else(|| Error::Other("linear-attention buffer size overflow".into()))
+}
+
+/// Cast an F32 tensor to BF16 (round-to-nearest-even).
+pub fn cast_f32_to_bf16(ctx: &CudaContext, input: &Tensor, output: &Tensor) -> Result<()> {
+    if input.dtype() != DType::F32 || output.dtype() != DType::BF16 || input.numel() != output.numel() {
+        return Err(Error::Other("cast f32->bf16 shape/dtype mismatch".into()));
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_cast_f32_bf16(
+            gpu_ptr(input)?,
+            gpu_ptr(output)?,
+            input.numel() as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Cast a BF16 tensor to F32 (exact widening).
+pub fn cast_bf16_to_f32(ctx: &CudaContext, input: &Tensor, output: &Tensor) -> Result<()> {
+    if input.dtype() != DType::BF16 || output.dtype() != DType::F32 || input.numel() != output.numel() {
+        return Err(Error::Other("cast bf16->f32 shape/dtype mismatch".into()));
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_cast_bf16_f32(
+            gpu_ptr(input)?,
+            gpu_ptr(output)?,
+            input.numel() as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Depthwise causal conv1d + SiLU over a strided token-major stream.
+///
+/// `x` is `[seq, x_row_stride]` BF16; the mixed projection occupies its first
+/// `channels` columns. `out` is dense `[seq, channels]`. `state` (optional)
+/// and `new_state` are `[channels, kernel_size]`; the new state is written to
+/// `new_state`, which must not alias `state`.
+pub fn causal_conv1d_silu_bf16(
+    ctx: &CudaContext,
+    x: &Tensor,
+    weight: &Tensor,
+    state: Option<&Tensor>,
+    out: &Tensor,
+    new_state: &Tensor,
+    kernel_size: usize,
+) -> Result<()> {
+    let (seq, x_stride) = matrix_shape(x, "causal conv1d")?;
+    let (out_seq, channels) = matrix_shape(out, "causal conv1d")?;
+    if seq == 0
+        || out_seq != seq
+        || channels == 0
+        || x_stride < channels
+        || kernel_size == 0
+        || kernel_size > 8
+        || weight.shape().dims() != [channels, kernel_size]
+        || new_state.shape().dims() != [channels, kernel_size]
+        || state.is_some_and(|value| value.shape().dims() != [channels, kernel_size])
+    {
+        return Err(Error::Other("causal conv1d shape mismatch".into()));
+    }
+    for tensor in [x, weight, out, new_state] {
+        expect_bf16(tensor, "causal conv1d")?;
+    }
+    if let Some(state) = state {
+        expect_bf16(state, "causal conv1d")?;
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_causal_conv1d_silu_bf16(
+            gpu_ptr(x)?,
+            gpu_ptr(weight)?,
+            optional_ptr(state)?,
+            gpu_ptr(out)?,
+            gpu_ptr(new_state)?,
+            channels as i32,
+            seq as i32,
+            kernel_size as i32,
+            x_stride as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Gated-delta-rule q/k preparation: L2-normalize q/k rows of the post-conv
+/// stream (fp32, eps), scale q by 1/sqrt(head_k_dim), scatter key heads to the
+/// value-head layout. Outputs are caller-owned fp32 buffers
+/// `[num_v_heads, seq_pad, head_k_dim]` (zero-filled tail by the caller).
+pub fn gdn_qk_prep(
+    ctx: &CudaContext,
+    conv_out: &Tensor,
+    q: &CudaBuffer,
+    k: &CudaBuffer,
+    seq_pad: usize,
+    num_k_heads: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    key_dim: usize,
+    eps: f32,
+) -> Result<()> {
+    let (seq, conv_dim) = matrix_shape(conv_out, "GDN qk prep")?;
+    if seq == 0
+        || seq > seq_pad
+        || conv_dim < 2 * key_dim
+        || key_dim != num_k_heads * head_k_dim
+        || num_v_heads == 0
+        || num_k_heads == 0
+        || num_v_heads % num_k_heads != 0
+        || head_k_dim == 0
+        || !eps.is_finite()
+        || eps <= 0.0
+    {
+        return Err(Error::Other("GDN qk prep shape mismatch".into()));
+    }
+    expect_bf16(conv_out, "GDN qk prep")?;
+    require_buffers(
+        ctx,
+        "GDN qk prep",
+        &[
+            ("q", q, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("k", k, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+        ],
+    )?;
+    let scale = 1.0f32 / (head_k_dim as f32).sqrt();
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_qk_prep_bf16(
+            gpu_ptr(conv_out)?,
+            q.ptr(),
+            k.ptr(),
+            seq as i32,
+            seq_pad as i32,
+            conv_dim as i32,
+            key_dim as i32,
+            num_v_heads as i32,
+            head_k_dim as i32,
+            scale,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// GDN value/beta/decay preparation. `b_col`/`a_col` are the column offsets of
+/// the beta and decay projections inside the fused `zba` output; `v_offset` is
+/// the value channel offset inside `conv_out`. Outputs: fp32 head-major
+/// `v [num_v_heads, seq_pad, head_v_dim]`, `beta/g [num_v_heads, seq_pad]`.
+pub fn gdn_vb_prep(
+    ctx: &CudaContext,
+    conv_out: &Tensor,
+    zba: &Tensor,
+    b_col: usize,
+    a_col: usize,
+    dt_bias: &Tensor,
+    a_log: &Tensor,
+    v: &CudaBuffer,
+    beta: &CudaBuffer,
+    g: &CudaBuffer,
+    seq_pad: usize,
+    num_v_heads: usize,
+    head_v_dim: usize,
+    v_offset: usize,
+) -> Result<()> {
+    let (seq, conv_dim) = matrix_shape(conv_out, "GDN vb prep")?;
+    let (zba_seq, zba_width) = matrix_shape(zba, "GDN vb prep")?;
+    if seq == 0
+        || seq > seq_pad
+        || zba_seq != seq
+        || conv_dim < v_offset + num_v_heads * head_v_dim
+        || a_col + num_v_heads > zba_width
+        || b_col >= a_col
+        || num_v_heads == 0
+        || head_v_dim == 0
+        || dt_bias.shape().dims() != [num_v_heads]
+        || a_log.shape().dims() != [num_v_heads]
+        || dt_bias.dtype() != DType::F32
+        || a_log.dtype() != DType::F32
+    {
+        return Err(Error::Other("GDN vb prep shape mismatch".into()));
+    }
+    expect_bf16(conv_out, "GDN vb prep")?;
+    expect_bf16(zba, "GDN vb prep")?;
+    require_buffers(
+        ctx,
+        "GDN vb prep",
+        &[
+            ("v", v, f32_bytes(num_v_heads * seq_pad * head_v_dim)?),
+            ("beta", beta, f32_bytes(num_v_heads * seq_pad)?),
+            ("g", g, f32_bytes(num_v_heads * seq_pad)?),
+        ],
+    )?;
+    let element = DType::BF16.size_in_bytes();
+    let b_ptr = gpu_ptr(zba)?.cast::<u8>().wrapping_add(b_col * element).cast();
+    let a_ptr = gpu_ptr(zba)?.cast::<u8>().wrapping_add(a_col * element).cast();
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_vb_prep_bf16(
+            gpu_ptr(conv_out)?,
+            b_ptr,
+            a_ptr,
+            gpu_ptr(dt_bias)?,
+            gpu_ptr(a_log)?,
+            v.ptr(),
+            beta.ptr(),
+            g.ptr(),
+            seq as i32,
+            seq_pad as i32,
+            conv_dim as i32,
+            v_offset as i32,
+            num_v_heads as i32,
+            zba_width as i32,
+            head_v_dim as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Chunk-local inclusive cumsum of the decay `g`.
+pub fn gdn_cumsum(
+    ctx: &CudaContext,
+    g: &CudaBuffer,
+    g_cum: &CudaBuffer,
+    seq_pad: usize,
+    num_v_heads: usize,
+    chunk_size: usize,
+) -> Result<()> {
+    if seq_pad == 0 || seq_pad % chunk_size != 0 || chunk_size == 0 || num_v_heads == 0 {
+        return Err(Error::Other("GDN cumsum shape mismatch".into()));
+    }
+    require_buffers(
+        ctx,
+        "GDN cumsum",
+        &[
+            ("g", g, f32_bytes(num_v_heads * seq_pad)?),
+            ("g_cum", g_cum, f32_bytes(num_v_heads * seq_pad)?),
+        ],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_cumsum_f32(
+            g.ptr(),
+            g_cum.ptr(),
+            seq_pad as i32,
+            num_v_heads as i32,
+            chunk_size as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Raw masked intra-chunk matrices: A = -(k_beta @ k^T) * decay (strictly
+/// lower), T = (q @ k^T) * decay (lower). Caller-owned fp32 buffers
+/// `[num_v_heads, chunks, chunk_size, chunk_size]`.
+pub fn gdn_attn_raw(
+    ctx: &CudaContext,
+    q: &CudaBuffer,
+    k: &CudaBuffer,
+    beta: &CudaBuffer,
+    g_cum: &CudaBuffer,
+    a: &CudaBuffer,
+    t: &CudaBuffer,
+    seq_pad: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    chunk_size: usize,
+) -> Result<()> {
+    let chunks = seq_pad.checked_div(chunk_size).unwrap_or(0);
+    if seq_pad == 0 || chunks == 0 || seq_pad % chunk_size != 0 || num_v_heads == 0 {
+        return Err(Error::Other("GDN attn raw shape mismatch".into()));
+    }
+    let matrix = chunk_size * chunk_size;
+    require_buffers(
+        ctx,
+        "GDN attn raw",
+        &[
+            ("q", q, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("k", k, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("beta", beta, f32_bytes(num_v_heads * seq_pad)?),
+            ("g_cum", g_cum, f32_bytes(num_v_heads * seq_pad)?),
+            ("a", a, f32_bytes(num_v_heads * chunks * matrix)?),
+            ("t", t, f32_bytes(num_v_heads * chunks * matrix)?),
+        ],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_attn_raw_f32(
+            q.ptr(),
+            k.ptr(),
+            beta.ptr(),
+            g_cum.ptr(),
+            a.ptr(),
+            t.ptr(),
+            seq_pad as i32,
+            num_v_heads as i32,
+            head_k_dim as i32,
+            chunk_size as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// In-place forward substitution + identity on each chunk matrix, producing
+/// (I - A)^-1. `matrices` is the total chunk-matrix count (heads * chunks).
+pub fn gdn_tri_solve(ctx: &CudaContext, a: &CudaBuffer, matrices: usize, chunk_size: usize) -> Result<()> {
+    if matrices == 0 || chunk_size == 0 || chunk_size > 128 {
+        return Err(Error::Other("GDN triangular solve shape mismatch".into()));
+    }
+    require_buffers(
+        ctx,
+        "GDN triangular solve",
+        &[("a", a, f32_bytes(matrices * chunk_size * chunk_size)?)],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_tri_solve_f32(
+            a.ptr(),
+            matrices as i32,
+            chunk_size as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// VT = A @ (v * beta), KCD = A @ (k * beta * exp(g_cum)) per chunk.
+pub fn gdn_chunk_gemm(
+    ctx: &CudaContext,
+    a: &CudaBuffer,
+    v: &CudaBuffer,
+    k: &CudaBuffer,
+    beta: &CudaBuffer,
+    g_cum: &CudaBuffer,
+    vt: &CudaBuffer,
+    kcd: &CudaBuffer,
+    seq_pad: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    chunk_size: usize,
+) -> Result<()> {
+    let chunks = seq_pad.checked_div(chunk_size).unwrap_or(0);
+    if seq_pad == 0 || chunks == 0 || seq_pad % chunk_size != 0 || num_v_heads == 0 {
+        return Err(Error::Other("GDN chunk gemm shape mismatch".into()));
+    }
+    require_buffers(
+        ctx,
+        "GDN chunk gemm",
+        &[
+            ("a", a, f32_bytes(num_v_heads * chunks * chunk_size * chunk_size)?),
+            ("v", v, f32_bytes(num_v_heads * seq_pad * head_v_dim)?),
+            ("k", k, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("beta", beta, f32_bytes(num_v_heads * seq_pad)?),
+            ("g_cum", g_cum, f32_bytes(num_v_heads * seq_pad)?),
+            ("vt", vt, f32_bytes(num_v_heads * chunks * chunk_size * head_v_dim)?),
+            ("kcd", kcd, f32_bytes(num_v_heads * chunks * chunk_size * head_k_dim)?),
+        ],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_chunk_gemm_f32(
+            a.ptr(),
+            v.ptr(),
+            k.ptr(),
+            beta.ptr(),
+            g_cum.ptr(),
+            vt.ptr(),
+            kcd.ptr(),
+            seq_pad as i32,
+            num_v_heads as i32,
+            head_k_dim as i32,
+            head_v_dim as i32,
+            chunk_size as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Sequential chunk recurrence with state read-in/write-back; emits the
+/// token-major BF16 layer output `[seq, num_v_heads * head_v_dim]`.
+pub fn gdn_chunk_state(
+    ctx: &CudaContext,
+    q: &CudaBuffer,
+    k: &CudaBuffer,
+    g_cum: &CudaBuffer,
+    t: &CudaBuffer,
+    vt: &CudaBuffer,
+    kcd: &CudaBuffer,
+    state: &CudaBuffer,
+    out: &Tensor,
+    seq_pad: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    chunk_size: usize,
+) -> Result<()> {
+    let chunks = seq_pad.checked_div(chunk_size).unwrap_or(0);
+    let (seq, out_width) = matrix_shape(out, "GDN chunk state")?;
+    if seq == 0
+        || chunks == 0
+        || seq_pad % chunk_size != 0
+        || seq > seq_pad
+        || out_width != num_v_heads * head_v_dim
+        || chunk_size * head_v_dim / 256 > 32
+        || num_v_heads == 0
+    {
+        return Err(Error::Other("GDN chunk state shape mismatch".into()));
+    }
+    expect_bf16(out, "GDN chunk state")?;
+    require_buffers(
+        ctx,
+        "GDN chunk state",
+        &[
+            ("q", q, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("k", k, f32_bytes(num_v_heads * seq_pad * head_k_dim)?),
+            ("g_cum", g_cum, f32_bytes(num_v_heads * seq_pad)?),
+            ("t", t, f32_bytes(num_v_heads * chunks * chunk_size * chunk_size)?),
+            ("vt", vt, f32_bytes(num_v_heads * chunks * chunk_size * head_v_dim)?),
+            ("kcd", kcd, f32_bytes(num_v_heads * chunks * chunk_size * head_k_dim)?),
+            ("state", state, f32_bytes(num_v_heads * head_k_dim * head_v_dim)?),
+        ],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_chunk_state_f32(
+            q.ptr(),
+            k.ptr(),
+            g_cum.ptr(),
+            t.ptr(),
+            vt.ptr(),
+            kcd.ptr(),
+            state.ptr(),
+            gpu_ptr(out)?,
+            seq as i32,
+            seq_pad as i32,
+            num_v_heads as i32,
+            head_k_dim as i32,
+            head_v_dim as i32,
+            chunk_size as i32,
+            chunks as i32,
+            out_width as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Single-token recurrent update. q/k/v are head-major fp32
+/// `[num_v_heads, head_dim]` (seq_pad == 1 layout); state read-in/write-back;
+/// out is `[1, num_v_heads * head_v_dim]` BF16.
+pub fn gdn_recurrent(
+    ctx: &CudaContext,
+    q: &CudaBuffer,
+    k: &CudaBuffer,
+    v: &CudaBuffer,
+    beta: &CudaBuffer,
+    g: &CudaBuffer,
+    state: &CudaBuffer,
+    out: &Tensor,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+) -> Result<()> {
+    let (rows, out_width) = matrix_shape(out, "GDN recurrent")?;
+    if rows != 1 || out_width != num_v_heads * head_v_dim || num_v_heads == 0 {
+        return Err(Error::Other("GDN recurrent shape mismatch".into()));
+    }
+    expect_bf16(out, "GDN recurrent")?;
+    require_buffers(
+        ctx,
+        "GDN recurrent",
+        &[
+            ("q", q, f32_bytes(num_v_heads * head_k_dim)?),
+            ("k", k, f32_bytes(num_v_heads * head_k_dim)?),
+            ("v", v, f32_bytes(num_v_heads * head_v_dim)?),
+            ("beta", beta, f32_bytes(num_v_heads)?),
+            ("g", g, f32_bytes(num_v_heads)?),
+            ("state", state, f32_bytes(num_v_heads * head_k_dim * head_v_dim)?),
+        ],
+    )?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gdn_recurrent_f32(
+            q.ptr(),
+            k.ptr(),
+            v.ptr(),
+            beta.ptr(),
+            g.ptr(),
+            state.ptr(),
+            gpu_ptr(out)?,
+            num_v_heads as i32,
+            head_k_dim as i32,
+            head_v_dim as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Gated RMSNorm: rows of `x` (BF16) normalized (fp32), scaled by `weight`,
+/// multiplied by silu(z). `z` lives in column slices of a fused projection:
+/// row `r` reads `z[r / z_heads, z_col_offset + (r % z_heads) * cols ..]`.
+pub fn gated_rms_silu(
+    ctx: &CudaContext,
+    x: &Tensor,
+    z: &Tensor,
+    z_col_offset: usize,
+    z_heads: usize,
+    weight: &Tensor,
+    eps: f32,
+) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(x, "gated rms silu")?;
+    let (z_rows, z_width) = matrix_shape(z, "gated rms silu")?;
+    if rows == 0
+        || z_heads == 0
+        || rows % z_heads != 0
+        || z_rows != rows / z_heads
+        || z_col_offset + z_heads * cols > z_width
+        || weight.shape().dims() != [cols]
+        || !eps.is_finite()
+        || eps <= 0.0
+    {
+        return Err(Error::Other("gated rms silu shape mismatch".into()));
+    }
+    for tensor in [x, z, weight] {
+        expect_bf16(tensor, "gated rms silu")?;
+    }
+    let output = bf16_output(ctx, rows, cols)?;
+    let z_ptr = gpu_ptr(z)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gated_rms_silu_bf16(
+            gpu_ptr(x)?,
+            z_ptr,
+            gpu_ptr(weight)?,
+            output.ptr(),
+            rows as i32,
+            cols as i32,
+            z_heads as i32,
+            z_width as i64,
+            z_col_offset as i64,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// RMSNorm with zero-init (1 + weight) semantics, fp32 compute, BF16 storage.
+pub fn rms_norm_plus1(ctx: &CudaContext, input: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(input, "rms norm plus1")?;
+    if rows == 0 || cols == 0 || weight.shape().dims() != [cols] || !eps.is_finite() || eps <= 0.0 {
+        return Err(Error::Other("rms norm plus1 shape mismatch".into()));
+    }
+    expect_bf16(input, "rms norm plus1")?;
+    expect_bf16(weight, "rms norm plus1")?;
+    let output = bf16_output(ctx, rows, cols)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_rms_norm_plus1_bf16(
+            gpu_ptr(input)?,
+            gpu_ptr(weight)?,
+            output.ptr(),
+            rows as i32,
+            cols as i32,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Partial rotary from precomputed BF16 cos/sin tables `[rows, rotary_dim]`.
+/// `x` is `[rows, heads, head_dim]`; leading `rotary_dim` channels rotate,
+/// the rest pass through.
+pub fn partial_rope_table(
+    ctx: &CudaContext,
+    x: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<Tensor> {
+    let dims = x.shape().dims();
+    if dims.len() != 3
+        || dims[1] != heads
+        || dims[2] != head_dim
+        || rotary_dim == 0
+        || rotary_dim % 2 != 0
+        || rotary_dim > head_dim
+        || cos.shape().dims() != [dims[0], rotary_dim]
+        || sin.shape().dims() != [dims[0], rotary_dim]
+    {
+        return Err(Error::Other("partial rope table shape mismatch".into()));
+    }
+    for tensor in [x, cos, sin] {
+        expect_bf16(tensor, "partial rope table")?;
+    }
+    let rows = dims[0];
+    let output = output_buffer(ctx, x.size_in_bytes())?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_partial_rope_table_bf16(
+            gpu_ptr(x)?,
+            gpu_ptr(cos)?,
+            gpu_ptr(sin)?,
+            output.ptr(),
+            rows as i32,
+            heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        x.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Full-attention (q|gate) input preparation: per-head (1 + w) RMSNorm on q/k,
+/// partial rotary from tables, K/V append into caller-owned caches at
+/// `cache_offset`. `fused` is the fused qkv projection `[seq, width]`; q_out is
+/// `[seq, q_heads, head_dim]`; caches are `[capacity, kv_heads, head_dim]`.
+pub fn full_attn_prepare(
+    ctx: &CudaContext,
+    fused: &Tensor,
+    q_norm_w: &Tensor,
+    k_norm_w: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    q_out: &Tensor,
+    k_cache: &Tensor,
+    v_cache: &Tensor,
+    cache_offset: usize,
+    q_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    eps: f32,
+) -> Result<()> {
+    let (seq, width) = matrix_shape(fused, "full attention prepare")?;
+    let expected = q_heads * 2 * head_dim + 2 * kv_heads * head_dim;
+    let q_dims = q_out.shape().dims();
+    let cache_dims = k_cache.shape().dims();
+    if seq == 0
+        || width < expected
+        || q_dims != [seq, q_heads, head_dim]
+        || cache_dims.len() != 3
+        || cache_dims[1] != kv_heads
+        || cache_dims[2] != head_dim
+        || v_cache.shape().dims() != cache_dims
+        || cache_offset + seq > cache_dims[0]
+        || q_norm_w.shape().dims() != [head_dim]
+        || k_norm_w.shape().dims() != [head_dim]
+        || cos.shape().dims() != [seq, rotary_dim]
+        || sin.shape().dims() != [seq, rotary_dim]
+        || rotary_dim == 0
+        || rotary_dim % 2 != 0
+        || rotary_dim > head_dim
+    {
+        return Err(Error::Other("full attention prepare shape mismatch".into()));
+    }
+    for tensor in [fused, q_norm_w, k_norm_w, cos, sin, q_out, k_cache, v_cache] {
+        expect_bf16(tensor, "full attention prepare")?;
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_full_attn_prepare_bf16(
+            gpu_ptr(fused)?,
+            gpu_ptr(q_norm_w)?,
+            gpu_ptr(k_norm_w)?,
+            gpu_ptr(cos)?,
+            gpu_ptr(sin)?,
+            gpu_ptr(q_out)?,
+            gpu_ptr(k_cache)?,
+            gpu_ptr(v_cache)?,
+            seq as i32,
+            cache_offset as i32,
+            q_heads as i32,
+            kv_heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            width as i64,
+            (kv_heads * head_dim) as i64,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// In-place post-attention sigmoid gate: `attn *= sigmoid(gate)` where the
+/// gate is read from the (q|gate) fused projection rows.
+pub fn sigmoid_gate_mul(ctx: &CudaContext, attn: &Tensor, fused: &Tensor, heads: usize, head_dim: usize) -> Result<()> {
+    let (rows, width) = matrix_shape(attn, "sigmoid gate")?;
+    let (fused_rows, fused_width) = matrix_shape(fused, "sigmoid gate")?;
+    if rows == 0
+        || width != heads * head_dim
+        || fused_rows != rows
+        || fused_width < 2 * heads * head_dim
+    {
+        return Err(Error::Other("sigmoid gate shape mismatch".into()));
+    }
+    expect_bf16(attn, "sigmoid gate")?;
+    expect_bf16(fused, "sigmoid gate")?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_sigmoid_gate_mul_bf16(
+            gpu_ptr(attn)?,
+            gpu_ptr(fused)?,
+            rows as i32,
+            heads as i32,
+            head_dim as i32,
+            fused_width as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// adaLN normalization: out = bf16(bf16(rms(x)*w) * bf16(1 + scale) + shift).
+pub fn adaln_rms_norm(
+    ctx: &CudaContext,
+    x: &Tensor,
+    weight: &Tensor,
+    scale: &Tensor,
+    shift: &Tensor,
+    eps: f32,
+) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(x, "adaln rms norm")?;
+    if rows == 0
+        || weight.shape().dims() != [cols]
+        || scale.shape().dims() != [cols]
+        || shift.shape().dims() != [cols]
+        || !eps.is_finite()
+        || eps <= 0.0
+    {
+        return Err(Error::Other("adaln rms norm shape mismatch".into()));
+    }
+    for tensor in [x, weight, scale, shift] {
+        expect_bf16(tensor, "adaln rms norm")?;
+    }
+    let output = bf16_output(ctx, rows, cols)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_adaln_rms_norm_bf16(
+            gpu_ptr(x)?,
+            gpu_ptr(weight)?,
+            gpu_ptr(scale)?,
+            gpu_ptr(shift)?,
+            output.ptr(),
+            rows as i32,
+            cols as i32,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// adaLN residual: out = bf16(residual + bf16(proj * bf16(1 + gate))).
+pub fn adaln_gate_residual(
+    ctx: &CudaContext,
+    proj: &Tensor,
+    residual: &Tensor,
+    gate: &Tensor,
+) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(proj, "adaln gate residual")?;
+    if rows == 0
+        || residual.shape().dims() != [rows, cols]
+        || gate.shape().dims() != [cols]
+    {
+        return Err(Error::Other("adaln gate residual shape mismatch".into()));
+    }
+    for tensor in [proj, residual, gate] {
+        expect_bf16(tensor, "adaln gate residual")?;
+    }
+    let output = bf16_output(ctx, rows, cols)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_adaln_gate_residual_bf16(
+            gpu_ptr(proj)?,
+            gpu_ptr(residual)?,
+            gpu_ptr(gate)?,
+            output.ptr(),
+            (rows * cols) as i64,
+            cols as i32,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows, cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Expert group-major fused QKV preparation: split (query, gate, key, value),
+/// per-head plain RMSNorm on q/k, partial rotary from tables. Outputs are
+/// caller tensors: q/gate `[seq, q_heads, head_dim]`, k/v `[seq, kv_heads, head_dim]`.
+pub fn expert_qkv_prepare(
+    ctx: &CudaContext,
+    fused: &Tensor,
+    q_norm_w: &Tensor,
+    k_norm_w: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    q_out: &Tensor,
+    gate_out: &Tensor,
+    k_out: &Tensor,
+    v_out: &Tensor,
+    q_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    eps: f32,
+) -> Result<()> {
+    let (seq, width) = matrix_shape(fused, "expert qkv prepare")?;
+    let heads_per_group = q_heads.checked_div(kv_heads).unwrap_or(0);
+    let expected = kv_heads * (2 * heads_per_group + 2) * head_dim;
+    if seq == 0
+        || kv_heads == 0
+        || q_heads % kv_heads != 0
+        || width < expected
+        || q_out.shape().dims() != [seq, q_heads, head_dim]
+        || gate_out.shape().dims() != [seq, q_heads, head_dim]
+        || k_out.shape().dims() != [seq, kv_heads, head_dim]
+        || v_out.shape().dims() != [seq, kv_heads, head_dim]
+        || q_norm_w.shape().dims() != [head_dim]
+        || k_norm_w.shape().dims() != [head_dim]
+        || cos.shape().dims() != [seq, rotary_dim]
+        || sin.shape().dims() != [seq, rotary_dim]
+        || rotary_dim == 0
+        || rotary_dim % 2 != 0
+        || rotary_dim > head_dim
+    {
+        return Err(Error::Other("expert qkv prepare shape mismatch".into()));
+    }
+    for tensor in [fused, q_norm_w, k_norm_w, cos, sin, q_out, gate_out, k_out, v_out] {
+        expect_bf16(tensor, "expert qkv prepare")?;
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_expert_qkv_prepare_bf16(
+            gpu_ptr(fused)?,
+            gpu_ptr(q_norm_w)?,
+            gpu_ptr(k_norm_w)?,
+            gpu_ptr(cos)?,
+            gpu_ptr(sin)?,
+            gpu_ptr(q_out)?,
+            gpu_ptr(gate_out)?,
+            gpu_ptr(k_out)?,
+            gpu_ptr(v_out)?,
+            seq as i32,
+            q_heads as i32,
+            kv_heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            width as i64,
+            eps,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// In-place post-attention sigmoid gate from a standalone gate tensor.
+pub fn expert_sigmoid_gate_mul(ctx: &CudaContext, attn: &Tensor, gate: &Tensor) -> Result<()> {
+    if attn.shape().dims() != gate.shape().dims() || attn.numel() == 0 {
+        return Err(Error::Other("expert sigmoid gate shape mismatch".into()));
+    }
+    expect_bf16(attn, "expert sigmoid gate")?;
+    expect_bf16(gate, "expert sigmoid gate")?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_expert_sigmoid_gate_mul_bf16(
+            gpu_ptr(attn)?,
+            gpu_ptr(gate)?,
+            attn.numel() as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Fourier features: `[rows, point_dim * num_features * 2]` with per-channel
+/// cat(sin, cos) layout.
+pub fn fourier_features(
+    ctx: &CudaContext,
+    waypoints: &Tensor,
+    freqs: &Tensor,
+    point_dim: usize,
+    num_features: usize,
+) -> Result<Tensor> {
+    let (rows, width) = matrix_shape(waypoints, "fourier features")?;
+    if rows == 0
+        || width != point_dim
+        || point_dim == 0
+        || num_features == 0
+        || freqs.shape().dims() != [num_features]
+    {
+        return Err(Error::Other("fourier features shape mismatch".into()));
+    }
+    expect_bf16(waypoints, "fourier features")?;
+    expect_bf16(freqs, "fourier features")?;
+    let out_width = point_dim * num_features * 2;
+    let output = bf16_output(ctx, rows, out_width)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_fourier_features_bf16(
+            gpu_ptr(waypoints)?,
+            gpu_ptr(freqs)?,
+            output.ptr(),
+            rows as i32,
+            point_dim as i32,
+            num_features as i32,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![rows, out_width]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Column-concatenate seven `[rows|1, cols]` sources into `[rows, 7 * cols]`;
+/// `broadcast_mask` bit `i` broadcasts source `i` row 0 across rows.
+pub fn concat7_cols(ctx: &CudaContext, srcs: [&Tensor; 7], broadcast_mask: u32) -> Result<Tensor> {
+    let (first_rows, cols) = matrix_shape(srcs[0], "concat7")?;
+    if first_rows == 0 || cols == 0 {
+        return Err(Error::Other("concat7 shape mismatch".into()));
+    }
+    for (index, src) in srcs.iter().enumerate() {
+        let (rows, width) = matrix_shape(src, "concat7")?;
+        let expect_rows = if (broadcast_mask >> index) & 1 == 1 { 1 } else { first_rows };
+        if rows != expect_rows || width != cols {
+            return Err(Error::Other("concat7 shape mismatch".into()));
+        }
+        expect_bf16(src, "concat7")?;
+    }
+    let output = bf16_output(ctx, first_rows, 7 * cols)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_concat7_cols_bf16(
+            gpu_ptr(srcs[0])?,
+            gpu_ptr(srcs[1])?,
+            gpu_ptr(srcs[2])?,
+            gpu_ptr(srcs[3])?,
+            gpu_ptr(srcs[4])?,
+            gpu_ptr(srcs[5])?,
+            gpu_ptr(srcs[6])?,
+            output.ptr(),
+            first_rows as i32,
+            cols as i32,
+            broadcast_mask as i32,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![first_rows, 7 * cols]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// In-place flow-matching Euler update on an F32 state:
+/// `w += (endpoint - w) / remaining * step`.
+pub fn flow_update(
+    ctx: &CudaContext,
+    w: &Tensor,
+    endpoint: &Tensor,
+    remaining: f32,
+    step: f32,
+) -> Result<()> {
+    if w.dtype() != DType::F32
+        || endpoint.dtype() != DType::F32
+        || w.shape().dims() != endpoint.shape().dims()
+        || w.numel() == 0
+        || !remaining.is_finite()
+        || remaining <= 0.0
+        || !step.is_finite()
+    {
+        return Err(Error::Other("flow update shape mismatch".into()));
+    }
+    unsafe {
+        check_cuda(ffi::apxinf_static_flow_update_f32(
+            gpu_ptr(w)?,
+            gpu_ptr(endpoint)?,
+            remaining,
+            step,
+            w.numel() as i64,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Set the listed columns of one logits row to -inf (EOS suppression).
+pub fn suppress_logits(ctx: &CudaContext, logits: &Tensor, row: usize, ids: &CudaBuffer) -> Result<()> {
+    let (rows, cols) = matrix_shape(logits, "logits suppression")?;
+    if row >= rows {
+        return Err(Error::Other("logits suppression row out of range".into()));
+    }
+    expect_bf16(logits, "logits suppression")?;
+    let count = ids.len() / std::mem::size_of::<u32>();
+    if count == 0 {
+        return Ok(());
+    }
+    let row_ptr = gpu_ptr(logits)?.cast::<u8>().wrapping_add(row * cols * DType::BF16.size_in_bytes()).cast();
+    unsafe {
+        check_cuda(ffi::apxinf_static_suppress_logits_bf16(
+            row_ptr,
+            ids.ptr().cast(),
+            count as i32,
+            ctx.stream().handle(),
+        ))
+    }
+}
+
+/// Exact (erf) GELU, BF16 storage.
+pub fn gelu_exact(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
+    expect_bf16(input, "gelu exact")?;
+    let output = output_buffer(ctx, input.size_in_bytes())?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_gelu_exact_bf16(
+            gpu_ptr(input)?,
+            output.ptr(),
+            input.numel() as i64,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        input.shape().clone(),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Merge `factor` consecutive rows into one row:
+/// `[rows, cols] -> [rows / factor, cols * factor]`.
+pub fn merge_rows(ctx: &CudaContext, input: &Tensor, factor: usize) -> Result<Tensor> {
+    let (rows, cols) = matrix_shape(input, "merge rows")?;
+    if rows == 0 || factor == 0 || rows % factor != 0 {
+        return Err(Error::Other("merge rows shape mismatch".into()));
+    }
+    expect_bf16(input, "merge rows")?;
+    let out_rows = rows / factor;
+    let output = bf16_output(ctx, out_rows, cols * factor)?;
+    unsafe {
+        check_cuda(ffi::apxinf_static_merge_rows_bf16(
+            gpu_ptr(input)?,
+            output.ptr(),
+            (out_rows * cols * factor) as i64,
+            cols as i32,
+            factor as i32,
+            ctx.stream().handle(),
+        ))
+    }?;
+    Ok(make_gpu_tensor(
+        Shape::new(vec![out_rows, cols * factor]),
+        DType::BF16,
+        ctx.device_id(),
+        output,
+    ))
+}
+
+/// Non-causal joint GQA attention over caller-owned K/V (BF16, FA2 backend).
+///
+/// `q` is `[q_tokens, q_heads, head_dim]`; `k`/`v` are `[key_tokens, kv_heads,
+/// head_dim]` with `q_heads % kv_heads == 0`. Returns `[q_tokens, q_heads,
+/// head_dim]`. Hybrid diffusion experts use this primitive to read an external
+/// cache concatenated with their own tokens; it shares the FA2 provider path
+/// with `attention::causal_gqa_bf16` but applies no causal mask.
+pub fn gqa_bf16(
+    ctx: &CudaContext,
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    key_tokens: usize,
+) -> Result<Tensor> {
+    let q_shape = q.shape().dims();
+    let k_shape = k.shape().dims();
+    if [q, k, v].into_iter().any(|tensor| tensor.dtype() != DType::BF16)
+        || q_shape.len() != 3
+        || k_shape.len() != 3
+        || v.shape() != k.shape()
+        || k_shape[0] < key_tokens
+        || k_shape[2] != q_shape[2]
+        || k_shape[1] == 0
+        || q_shape[1] % k_shape[1] != 0
+        || key_tokens == 0
+    {
+        return Err(Error::Other(
+            "non-causal joint BF16 GQA shape mismatch".into(),
+        ));
+    }
+    #[cfg(any(apxinf_fa2_sm80, apxinf_fa2_f16_sm100))]
+    {
+        let output = output_buffer(ctx, q.size_in_bytes())?;
+        let lse_elements = q_shape[0]
+            .checked_mul(q_shape[1])
+            .ok_or_else(|| Error::Other("joint GQA LSE size overflow".into()))?;
+        let softmax_lse = output_buffer(
+            ctx,
+            lse_elements
+                .checked_mul(std::mem::size_of::<f32>())
+                .ok_or_else(|| Error::Other("joint GQA LSE byte overflow".into()))?,
+        )?;
+        unsafe {
+            check_cuda(ffi::apxinf_static_fa2_bf16(
+                gpu_ptr(q)?,
+                gpu_ptr(k)?,
+                gpu_ptr(v)?,
+                output.ptr(),
+                softmax_lse.ptr(),
+                1,
+                q_shape[0] as i32,
+                key_tokens as i32,
+                q_shape[1] as i32,
+                k_shape[1] as i32,
+                q_shape[2] as i32,
+                (q_shape[2] as f32).sqrt().recip(),
+                ctx.stream().handle(),
+            ))?;
+        }
+        return Ok(make_gpu_tensor(
+            q.shape().clone(),
+            DType::BF16,
+            ctx.device_id(),
+            output,
+        ));
+    }
+    #[cfg(not(any(apxinf_fa2_sm80, apxinf_fa2_f16_sm100)))]
+    Err(Error::Other(
+        "non-causal joint BF16 GQA requires the FA2 backend".into(),
+    ))
+}

--- a/crates/apxinf-cuda/src/kernels/mod.rs
+++ b/crates/apxinf-cuda/src/kernels/mod.rs
@@ -12,6 +12,7 @@ pub mod elementwise;
 pub mod embedding;
 pub mod fused;
 pub mod gemm;
+pub mod linear_attention;
 pub mod norm;
 pub mod preprocess;
 pub mod quantization;

--- a/crates/apxinf-model/src/builtin.rs
+++ b/crates/apxinf-model/src/builtin.rs
@@ -17,6 +17,8 @@ pub fn register_builtin_models() {
     registry::register("llama", load_llama);
     registry::register("qwen3_vl", load_qwen3vl);
     registry::register("qwen3vl", load_qwen3vl);
+    registry::register("qwen_drive", load_qwen_drive);
+    registry::register("qwen_drive-cuda", load_qwen_drive);
 
     #[cfg(feature = "cuda")]
     crate::pi05::register_builtin();
@@ -64,6 +66,46 @@ fn load_qwen3vl(
         .map_err(|error| Error::Other(format!("load {}: {error}", path.display())))?;
     let model = GeneralQwen3VL::from_weights_with_backend(config, tensors, backend)?;
     Ok(LoadedModel::text(Box::new(model)))
+}
+
+/// Load the Qwen-Drive VLM through the maintained registry surface. When the
+/// checkpoint ships the SFT planner head beside the VLM it is attached so the
+/// direct-planning flow works out of the box; the Python policy passes an
+/// explicit planner path for the RL head. CUDA-only: other devices fail
+/// clearly here.
+fn load_qwen_drive(
+    path: &Path,
+    device: Device,
+    backend: Arc<dyn Backend>,
+    _options: &LoadOptions,
+) -> Result<LoadedModel> {
+    #[cfg(feature = "cuda")]
+    {
+        let model_dir = if path.is_dir() {
+            path
+        } else {
+            path.parent().unwrap_or_else(|| Path::new("."))
+        };
+        let planner_dir = model_dir.join("planner-sft");
+        let planner = if planner_dir.is_dir() {
+            Some(planner_dir.as_path())
+        } else {
+            None
+        };
+        let model = crate::qwen_drive::QwenDriveModel::load_with_backend(
+            model_dir, planner, backend,
+        )?;
+        Ok(LoadedModel::text(Box::new(model)))
+    }
+    #[cfg(not(feature = "cuda"))]
+    {
+        let _ = (path, device, backend);
+        Err(Error::Other(
+            "qwen_drive requires the cuda feature (native CUDA deployment); \
+             this build has no CUDA support"
+                .into(),
+        ))
+    }
 }
 
 fn upcast_bf16_weights(tensors: &mut HashMap<String, Tensor>) -> Result<()> {

--- a/crates/apxinf-model/src/lib.rs
+++ b/crates/apxinf-model/src/lib.rs
@@ -29,6 +29,8 @@ pub use profiling::GenerationProfile;
 pub use pi05::{Pi05Config, Pi05PerformanceProfile};
 pub use qwen3vl::{GeneralQwen3VL, Qwen3VLConfig, Qwen3VLTextWeights};
 pub use qwen_drive::QwenDriveConfig;
+#[cfg(feature = "cuda")]
+pub use qwen_drive::QwenDriveModel;
 pub use vla::{
     Action, ImageLayout, InferenceSpec, InitialLatent, Observation,
     PreparedInference, VisionObservation, VlaContract, VlaRequest, VlaRuntime,

--- a/crates/apxinf-model/src/lib.rs
+++ b/crates/apxinf-model/src/lib.rs
@@ -11,6 +11,7 @@ pub mod auto;
 pub mod profiling;
 pub mod pi05;
 pub mod qwen3vl;
+pub mod qwen_drive;
 pub mod vla;
 mod walloss;
 
@@ -27,6 +28,7 @@ pub use auto::{AutoModel, LoadOptions, LoadedModel, ModelPrecision, SyntheticWei
 pub use profiling::GenerationProfile;
 pub use pi05::{Pi05Config, Pi05PerformanceProfile};
 pub use qwen3vl::{GeneralQwen3VL, Qwen3VLConfig, Qwen3VLTextWeights};
+pub use qwen_drive::QwenDriveConfig;
 pub use vla::{
     Action, ImageLayout, InferenceSpec, InitialLatent, Observation,
     PreparedInference, VisionObservation, VlaContract, VlaRequest, VlaRuntime,

--- a/crates/apxinf-model/src/qwen_drive/backend.rs
+++ b/crates/apxinf-model/src/qwen_drive/backend.rs
@@ -1,0 +1,9 @@
+//! Compile-time backend seam for the Qwen-Drive model family.
+//!
+//! Executor code depends on this model-local alias and the model-neutral
+//! kernel contract; adding another accelerator backend changes this seam,
+//! not the layer topology. Mirrors the maintained pi05 pattern.
+
+pub(crate) use crate::accelerator::cuda::{
+    downcast_arc, kernels, transfers, Context, CublasTranspose, DeviceBuffer, RuntimeBackend,
+};

--- a/crates/apxinf-model/src/qwen_drive/config.rs
+++ b/crates/apxinf-model/src/qwen_drive/config.rs
@@ -1,0 +1,553 @@
+//! Qwen-Drive-1.0 configuration, parsed from the checkpoint `config.json`.
+//!
+//! The schema mirrors `configuration_qwen_drive.py` in the pinned reference
+//! (revision 28091c1532e869bc7aee91fc0aef6b3e6fd0b2e0): a Qwen3.5 hybrid VLM
+//! (`vlm_config`) plus a flow-matching planning expert (`expert_config`), with
+//! trajectory and sampler constants at the top level. Parsing here keeps the
+//! loader crate model-agnostic and matches "each model owns its config".
+
+use std::path::Path;
+
+use apxinf_core::{Error, Result};
+
+/// Text-decoder geometry of the Qwen3.5 VLM. The decoder is hybrid: layers
+/// listed as `full_attention` carry a standard GQA KV cache (these are the
+/// caches the planning expert reads), while `linear_attention` layers are
+/// gated delta net (GDN) linear-attention layers with a recurrent state.
+#[derive(Clone, Debug)]
+pub struct QwenDriveTextConfig {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub n_layers: usize,
+    pub n_heads: usize,
+    pub n_kv_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f32,
+    /// Qwen3.5 emits a per-head sigmoid gate on the attention output.
+    pub attn_output_gate: bool,
+    /// Per-layer type names: `full_attention` or `linear_attention`.
+    pub layer_types: Vec<String>,
+    // GDN geometry (only meaningful for `linear_attention` layers).
+    pub linear_num_key_heads: usize,
+    pub linear_key_head_dim: usize,
+    pub linear_num_value_heads: usize,
+    pub linear_value_head_dim: usize,
+    pub linear_conv_kernel_dim: usize,
+    // Partial interleaved mRoPE.
+    pub rope_theta: f32,
+    pub partial_rotary_factor: f32,
+    pub mrope_section: [usize; 3],
+    pub mrope_interleaved: bool,
+    pub tie_word_embeddings: bool,
+    pub eos_token_id: u32,
+}
+
+impl QwenDriveTextConfig {
+    /// Rotary channel count of the partial RoPE (64 of 256 for Qwen3.5-4B).
+    pub fn rotary_dim(&self) -> usize {
+        (self.head_dim as f32 * self.partial_rotary_factor).round() as usize
+    }
+
+    /// Indices of the full-attention layers, in layer order. These are exactly
+    /// the caches the planning expert consumes (config.full_attention_layers).
+    pub fn full_attention_layers(&self) -> Vec<usize> {
+        self.layer_types
+            .iter()
+            .enumerate()
+            .filter(|(_, kind)| kind.as_str() == "full_attention")
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    pub fn is_full_attention(&self, layer_index: usize) -> bool {
+        self.layer_types
+            .get(layer_index)
+            .map(|kind| kind.as_str() == "full_attention")
+            .unwrap_or(false)
+    }
+
+    /// Validate cross-field invariants the executor relies on.
+    pub fn validate(&self) -> Result<()> {
+        if self.layer_types.len() != self.n_layers {
+            return Err(Error::Other(format!(
+                "qwen_drive text config: layer_types has {} entries but num_hidden_layers is {}",
+                self.layer_types.len(),
+                self.n_layers
+            )));
+        }
+        for (index, kind) in self.layer_types.iter().enumerate() {
+            if kind != "full_attention" && kind != "linear_attention" {
+                return Err(Error::Other(format!(
+                    "qwen_drive text config: unknown layer type {kind:?} at index {index}"
+                )));
+            }
+        }
+        let rotary = self.rotary_dim();
+        if rotary == 0 || rotary % 2 != 0 || rotary > self.head_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive text config: invalid rotary dim {rotary} for head dim {}",
+                self.head_dim
+            )));
+        }
+        let pairs: usize = self.mrope_section.iter().sum();
+        if pairs != rotary / 2 {
+            return Err(Error::Other(format!(
+                "qwen_drive text config: mrope_section {:?} must sum to {} frequency pairs",
+                self.mrope_section,
+                rotary / 2
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Vision tower geometry (ViT, 24 blocks, hidden 1024, merger to 2560).
+#[derive(Clone, Debug)]
+pub struct QwenDriveVisionConfig {
+    pub depth: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_heads: usize,
+    pub head_dim: usize,
+    pub patch_size: usize,
+    pub temporal_patch_size: usize,
+    pub in_channels: usize,
+    pub spatial_merge_size: usize,
+    pub num_position_embeddings: usize,
+    pub out_hidden_size: usize,
+}
+
+impl QwenDriveVisionConfig {
+    pub fn head_dim(&self) -> usize {
+        if self.head_dim != 0 {
+            self.head_dim
+        } else {
+            self.hidden_size / self.num_heads
+        }
+    }
+}
+
+/// Planning expert geometry (`PlanningExpertConfig` in the reference).
+#[derive(Clone, Debug)]
+pub struct PlanningExpertConfig {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub n_layers: usize,
+    pub n_heads: usize,
+    pub n_kv_heads: usize,
+    pub head_dim: usize,
+    /// Consecutive expert layers sharing one VLM scene cache.
+    pub layers_per_kv: usize,
+    pub rms_norm_eps: f32,
+    pub time_embed_dim: usize,
+    pub time_embed_scale: f32,
+    pub fourier_num_features: usize,
+    pub fourier_max_frequency: f32,
+    pub nav_command_classes: usize,
+    pub ego_status_dim: usize,
+    pub history_dynamics_dim: usize,
+    pub rope_theta: f32,
+    pub partial_rotary_factor: f32,
+    pub mrope_section: [usize; 3],
+}
+
+impl PlanningExpertConfig {
+    pub fn rotary_dim(&self) -> usize {
+        (self.head_dim as f32 * self.partial_rotary_factor).round() as usize
+    }
+
+    /// Number of VLM scene caches consumed (one per `layers_per_kv` layers).
+    pub fn num_kv_sources(&self) -> usize {
+        self.n_layers / self.layers_per_kv
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.n_layers % self.layers_per_kv != 0 {
+            return Err(Error::Other(format!(
+                "qwen_drive expert config: {} layers not divisible by layers_per_kv {}",
+                self.n_layers,
+                self.layers_per_kv
+            )));
+        }
+        let rotary = self.rotary_dim();
+        if rotary % 2 != 0 || rotary > self.head_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive expert config: invalid rotary dim {rotary}"
+            )));
+        }
+        let pairs: usize = self.mrope_section.iter().sum();
+        if pairs != rotary / 2 {
+            return Err(Error::Other(format!(
+                "qwen_drive expert config: mrope_section {:?} must sum to {} frequency pairs",
+                self.mrope_section,
+                rotary / 2
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Full Qwen-Drive-1.0 configuration (`QwenDriveConfig` in the reference).
+#[derive(Clone, Debug)]
+pub struct QwenDriveConfig {
+    pub text: QwenDriveTextConfig,
+    pub vision: QwenDriveVisionConfig,
+    pub expert: PlanningExpertConfig,
+    pub image_token_id: u32,
+    pub video_token_id: u32,
+    pub vision_start_token_id: u32,
+    pub vision_end_token_id: u32,
+    // Trajectory geometry.
+    pub num_future_points: usize,
+    pub num_history_points: usize,
+    pub trajectory_point_dim: usize,
+    pub trajectory_hz: f32,
+    /// Per-channel normalization scale; the heading entry is the bfloat16
+    /// rounding of pi/2 (1.5703125), which is the value training saw.
+    pub trajectory_scale: [f32; 3],
+    // Flow-matching sampler.
+    pub num_inference_steps: usize,
+    pub noise_init_std: f32,
+    pub noise_seed: u64,
+    pub min_one_minus_t: f32,
+    // Image preprocessing budgets.
+    pub history_image_pixels: usize,
+    pub current_image_pixels: usize,
+    pub image_patch_size: usize,
+    pub image_temporal_patch_size: usize,
+    pub image_spatial_merge_size: usize,
+    // Reasoning-stage generation bounds.
+    pub max_reasoning_tokens: usize,
+    pub min_reasoning_tokens: usize,
+}
+
+impl QwenDriveConfig {
+    pub fn from_json_file(path: &Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| Error::Other(format!("read {}: {e}", path.display())))?;
+        Self::from_json_str(&raw)
+    }
+
+    pub fn from_json_str(s: &str) -> Result<Self> {
+        let v: serde_json::Value = serde_json::from_str(s)
+            .map_err(|e| Error::Other(format!("qwen_drive config json: {e}")))?;
+        let vlm = &v["vlm_config"];
+        if !vlm.is_object() {
+            return Err(Error::Other("qwen_drive config: missing vlm_config".into()));
+        }
+        let tc = &vlm["text_config"];
+        if !tc.is_object() {
+            return Err(Error::Other(
+                "qwen_drive config: missing vlm_config.text_config".into(),
+            ));
+        }
+        let layer_types: Vec<String> = tc["layer_types"]
+            .as_array()
+            .ok_or_else(|| Error::Other("qwen_drive config: missing text_config.layer_types".into()))?
+            .iter()
+            .filter_map(|entry| entry.as_str().map(str::to_owned))
+            .collect();
+        let rope = &tc["rope_parameters"];
+        let section = rope["mrope_section"]
+            .as_array()
+            .ok_or_else(|| {
+                Error::Other("qwen_drive config: missing rope_parameters.mrope_section".into())
+            })?;
+        if section.len() != 3 {
+            return Err(Error::Other(format!(
+                "qwen_drive config: mrope_section must have 3 entries, got {}",
+                section.len()
+            )));
+        }
+        let mrope_section = [
+            section[0].as_u64().unwrap_or(11) as usize,
+            section[1].as_u64().unwrap_or(11) as usize,
+            section[2].as_u64().unwrap_or(10) as usize,
+        ];
+        let text = QwenDriveTextConfig {
+            hidden_size: tc["hidden_size"].as_u64().unwrap_or(2560) as usize,
+            intermediate_size: tc["intermediate_size"].as_u64().unwrap_or(9216) as usize,
+            n_layers: tc["num_hidden_layers"].as_u64().unwrap_or(32) as usize,
+            n_heads: tc["num_attention_heads"].as_u64().unwrap_or(16) as usize,
+            n_kv_heads: tc["num_key_value_heads"].as_u64().unwrap_or(4) as usize,
+            head_dim: tc["head_dim"].as_u64().unwrap_or(256) as usize,
+            vocab_size: tc["vocab_size"].as_u64().unwrap_or(248320) as usize,
+            max_position_embeddings: tc["max_position_embeddings"].as_u64().unwrap_or(32768) as usize,
+            rms_norm_eps: tc["rms_norm_eps"].as_f64().unwrap_or(1e-6) as f32,
+            attn_output_gate: tc["attn_output_gate"].as_bool().unwrap_or(true),
+            layer_types,
+            linear_num_key_heads: tc["linear_num_key_heads"].as_u64().unwrap_or(16) as usize,
+            linear_key_head_dim: tc["linear_key_head_dim"].as_u64().unwrap_or(128) as usize,
+            linear_num_value_heads: tc["linear_num_value_heads"].as_u64().unwrap_or(32) as usize,
+            linear_value_head_dim: tc["linear_value_head_dim"].as_u64().unwrap_or(128) as usize,
+            linear_conv_kernel_dim: tc["linear_conv_kernel_dim"].as_u64().unwrap_or(4) as usize,
+            rope_theta: rope["rope_theta"].as_f64().unwrap_or(10_000_000.0) as f32,
+            partial_rotary_factor: rope["partial_rotary_factor"].as_f64().unwrap_or(0.25) as f32,
+            mrope_section,
+            mrope_interleaved: rope["mrope_interleaved"].as_bool().unwrap_or(true),
+            tie_word_embeddings: tc["tie_word_embeddings"].as_bool().unwrap_or(true),
+            eos_token_id: tc["eos_token_id"].as_u64().unwrap_or(248044) as u32,
+        };
+        text.validate()?;
+
+        let vc = &vlm["vision_config"];
+        if !vc.is_object() {
+            return Err(Error::Other(
+                "qwen_drive config: missing vlm_config.vision_config".into(),
+            ));
+        }
+        let vision = QwenDriveVisionConfig {
+            depth: vc["depth"].as_u64().unwrap_or(24) as usize,
+            hidden_size: vc["hidden_size"].as_u64().unwrap_or(1024) as usize,
+            intermediate_size: vc["intermediate_size"].as_u64().unwrap_or(4096) as usize,
+            num_heads: vc["num_heads"].as_u64().unwrap_or(16) as usize,
+            head_dim: vc.get("head_dim").and_then(|x| x.as_u64()).map(|x| x as usize).unwrap_or(0),
+            patch_size: vc["patch_size"].as_u64().unwrap_or(16) as usize,
+            temporal_patch_size: vc["temporal_patch_size"].as_u64().unwrap_or(2) as usize,
+            in_channels: vc["in_channels"].as_u64().unwrap_or(3) as usize,
+            spatial_merge_size: vc["spatial_merge_size"].as_u64().unwrap_or(2) as usize,
+            num_position_embeddings: vc["num_position_embeddings"].as_u64().unwrap_or(2304) as usize,
+            out_hidden_size: vc["out_hidden_size"].as_u64().unwrap_or(2560) as usize,
+        };
+
+        let ec = &v["expert_config"];
+        if !ec.is_object() {
+            return Err(Error::Other("qwen_drive config: missing expert_config".into()));
+        }
+        let esection = ec["mrope_section"]
+            .as_array()
+            .ok_or_else(|| Error::Other("qwen_drive config: missing expert mrope_section".into()))?;
+        if esection.len() != 3 {
+            return Err(Error::Other(format!(
+                "qwen_drive config: expert mrope_section must have 3 entries, got {}",
+                esection.len()
+            )));
+        }
+        let expert = PlanningExpertConfig {
+            hidden_size: ec["hidden_size"].as_u64().unwrap_or(1024) as usize,
+            intermediate_size: ec["intermediate_size"].as_u64().unwrap_or(3584) as usize,
+            n_layers: ec["num_hidden_layers"].as_u64().unwrap_or(32) as usize,
+            n_heads: ec["num_attention_heads"].as_u64().unwrap_or(16) as usize,
+            n_kv_heads: ec["num_key_value_heads"].as_u64().unwrap_or(4) as usize,
+            head_dim: ec["head_dim"].as_u64().unwrap_or(256) as usize,
+            layers_per_kv: ec["layers_per_kv"].as_u64().unwrap_or(4) as usize,
+            rms_norm_eps: ec["rms_norm_eps"].as_f64().unwrap_or(1e-5) as f32,
+            time_embed_dim: ec["time_embed_dim"].as_u64().unwrap_or(128) as usize,
+            time_embed_scale: ec["time_embed_scale"].as_f64().unwrap_or(1000.0) as f32,
+            fourier_num_features: ec["fourier_num_features"].as_u64().unwrap_or(16) as usize,
+            fourier_max_frequency: ec["fourier_max_frequency"].as_f64().unwrap_or(16.0) as f32,
+            nav_command_classes: ec["nav_command_classes"].as_u64().unwrap_or(3) as usize,
+            ego_status_dim: ec["ego_status_dim"].as_u64().unwrap_or(8) as usize,
+            history_dynamics_dim: ec["history_dynamics_dim"].as_u64().unwrap_or(2) as usize,
+            rope_theta: ec["rope_theta"].as_f64().unwrap_or(10_000_000.0) as f32,
+            partial_rotary_factor: ec["partial_rotary_factor"].as_f64().unwrap_or(0.25) as f32,
+            mrope_section: [
+                esection[0].as_u64().unwrap_or(11) as usize,
+                esection[1].as_u64().unwrap_or(11) as usize,
+                esection[2].as_u64().unwrap_or(10) as usize,
+            ],
+        };
+        expert.validate()?;
+
+        let scale = v["trajectory_scale"]
+            .as_array()
+            .ok_or_else(|| Error::Other("qwen_drive config: missing trajectory_scale".into()))?;
+        if scale.len() != 3 {
+            return Err(Error::Other(format!(
+                "qwen_drive config: trajectory_scale must have 3 entries, got {}",
+                scale.len()
+            )));
+        }
+        let config = QwenDriveConfig {
+            text,
+            vision,
+            expert,
+            image_token_id: vlm["image_token_id"].as_u64().unwrap_or(248056) as u32,
+            video_token_id: vlm["video_token_id"].as_u64().unwrap_or(248057) as u32,
+            vision_start_token_id: vlm["vision_start_token_id"].as_u64().unwrap_or(248053) as u32,
+            vision_end_token_id: vlm["vision_end_token_id"].as_u64().unwrap_or(248054) as u32,
+            num_future_points: v["num_future_points"].as_u64().unwrap_or(50) as usize,
+            num_history_points: v["num_history_points"].as_u64().unwrap_or(16) as usize,
+            trajectory_point_dim: v["trajectory_point_dim"].as_u64().unwrap_or(3) as usize,
+            trajectory_hz: v["trajectory_hz"].as_f64().unwrap_or(10.0) as f32,
+            trajectory_scale: [
+                scale[0].as_f64().unwrap_or(165.0) as f32,
+                scale[1].as_f64().unwrap_or(25.0) as f32,
+                scale[2].as_f64().unwrap_or(1.5703125) as f32,
+            ],
+            num_inference_steps: v["num_inference_steps"].as_u64().unwrap_or(10) as usize,
+            noise_init_std: v["noise_init_std"].as_f64().unwrap_or(1.0) as f32,
+            noise_seed: v["noise_seed"].as_u64().unwrap_or(42),
+            min_one_minus_t: v["min_one_minus_t"].as_f64().unwrap_or(0.1) as f32,
+            history_image_pixels: v["history_image_pixels"].as_u64().unwrap_or(174080) as usize,
+            current_image_pixels: v["current_image_pixels"].as_u64().unwrap_or(921600) as usize,
+            image_patch_size: v["image_patch_size"].as_u64().unwrap_or(16) as usize,
+            image_temporal_patch_size: v["image_temporal_patch_size"].as_u64().unwrap_or(2) as usize,
+            image_spatial_merge_size: v["image_spatial_merge_size"].as_u64().unwrap_or(2) as usize,
+            max_reasoning_tokens: v["max_reasoning_tokens"].as_u64().unwrap_or(256) as usize,
+            min_reasoning_tokens: v["min_reasoning_tokens"].as_u64().unwrap_or(10) as usize,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Cross-validate the VLM and the expert: the expert reads the VLM's
+    /// post-rotary K/V directly, so their attention geometry must match and
+    /// the number of exported caches must equal the expert's KV sources.
+    pub fn validate(&self) -> Result<()> {
+        let full = self.text.full_attention_layers();
+        if full.len() != self.expert.num_kv_sources() {
+            return Err(Error::Other(format!(
+                "qwen_drive config: {} VLM full-attention layers but the expert expects {} scene caches",
+                full.len(),
+                self.expert.num_kv_sources()
+            )));
+        }
+        if self.text.n_kv_heads != self.expert.n_kv_heads || self.text.head_dim != self.expert.head_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive config: expert KV geometry ({} heads x dim {}) must match the VLM ({} x {})",
+                self.expert.n_kv_heads,
+                self.expert.head_dim,
+                self.text.n_kv_heads,
+                self.text.head_dim
+            )));
+        }
+        if self.num_history_points < 2 {
+            return Err(Error::Other(
+                "qwen_drive config: num_history_points must be at least 2".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Abbreviated but schema-faithful excerpt of the released checkpoint
+    // config (experiment/qwen-drive-k3/checkpoint-configs/config.json).
+    const CHECKPOINT_CONFIG: &str = r#"{
+        "model_type": "qwen_drive",
+        "num_future_points": 50,
+        "num_history_points": 16,
+        "trajectory_point_dim": 3,
+        "trajectory_hz": 10.0,
+        "trajectory_scale": [165.0, 25.0, 1.5703125],
+        "num_inference_steps": 10,
+        "noise_init_std": 1.0,
+        "noise_seed": 42,
+        "min_one_minus_t": 0.1,
+        "max_reasoning_tokens": 256,
+        "history_image_pixels": 174080,
+        "current_image_pixels": 921600,
+        "image_patch_size": 16,
+        "image_temporal_patch_size": 2,
+        "image_spatial_merge_size": 2,
+        "expert_config": {
+            "hidden_size": 1024,
+            "intermediate_size": 3584,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "layers_per_kv": 4,
+            "rms_norm_eps": 1e-05,
+            "time_embed_dim": 128,
+            "time_embed_scale": 1000.0,
+            "fourier_num_features": 16,
+            "fourier_max_frequency": 16.0,
+            "nav_command_classes": 3,
+            "ego_status_dim": 8,
+            "history_dynamics_dim": 2,
+            "rope_theta": 10000000.0,
+            "partial_rotary_factor": 0.25,
+            "mrope_section": [11, 11, 10]
+        },
+        "vlm_config": {
+            "model_type": "qwen3_5",
+            "image_token_id": 248056,
+            "video_token_id": 248057,
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+            "tie_word_embeddings": true,
+            "text_config": {
+                "hidden_size": 2560,
+                "intermediate_size": 9216,
+                "num_hidden_layers": 32,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "head_dim": 256,
+                "vocab_size": 248320,
+                "max_position_embeddings": 32768,
+                "rms_norm_eps": 1e-06,
+                "attn_output_gate": true,
+                "eos_token_id": 248044,
+                "tie_word_embeddings": true,
+                "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention", "linear_attention", "linear_attention", "linear_attention", "full_attention"],
+                "linear_num_key_heads": 16,
+                "linear_key_head_dim": 128,
+                "linear_num_value_heads": 32,
+                "linear_value_head_dim": 128,
+                "linear_conv_kernel_dim": 4,
+                "rope_parameters": {
+                    "mrope_interleaved": true,
+                    "mrope_section": [11, 11, 10],
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 10000000
+                }
+            },
+            "vision_config": {
+                "depth": 24,
+                "hidden_size": 1024,
+                "intermediate_size": 4096,
+                "num_heads": 16,
+                "in_channels": 3,
+                "num_position_embeddings": 2304,
+                "out_hidden_size": 2560,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2
+            }
+        }
+    }"#;
+
+    #[test]
+    fn parses_checkpoint_schema() {
+        let cfg = QwenDriveConfig::from_json_str(CHECKPOINT_CONFIG).unwrap();
+        assert_eq!(cfg.text.hidden_size, 2560);
+        assert_eq!(cfg.text.n_layers, 32);
+        assert_eq!(cfg.text.head_dim, 256);
+        assert_eq!(cfg.text.rotary_dim(), 64);
+        assert_eq!(cfg.text.mrope_section, [11, 11, 10]);
+        assert!(cfg.text.attn_output_gate);
+        assert!(cfg.text.is_full_attention(3));
+        assert!(!cfg.text.is_full_attention(0));
+        assert_eq!(
+            cfg.text.full_attention_layers(),
+            vec![3, 7, 11, 15, 19, 23, 27, 31]
+        );
+        assert_eq!(cfg.vision.depth, 24);
+        assert_eq!(cfg.vision.head_dim(), 64);
+        assert_eq!(cfg.expert.n_layers, 32);
+        assert_eq!(cfg.expert.num_kv_sources(), 8);
+        assert_eq!(cfg.expert.rotary_dim(), 64);
+        assert_eq!(cfg.trajectory_scale, [165.0, 25.0, 1.5703125]);
+        assert_eq!(cfg.noise_seed, 42);
+        assert_eq!(cfg.num_future_points, 50);
+        assert_eq!(cfg.min_reasoning_tokens, 10);
+    }
+
+    #[test]
+    fn rejects_expert_vlm_cache_mismatch() {
+        // Growing the expert to 36 layers makes it expect 9 scene caches
+        // while the VLM only has 8 full-attention layers.
+        let broken = CHECKPOINT_CONFIG.replacen("\"num_hidden_layers\": 32,", "\"num_hidden_layers\": 36,", 1);
+        let err = QwenDriveConfig::from_json_str(&broken);
+        assert!(err.is_err());
+        let message = format!("{}", err.err().unwrap());
+        assert!(message.contains("full-attention"), "unexpected error: {message}");
+    }
+}

--- a/crates/apxinf-model/src/qwen_drive/device_weights.rs
+++ b/crates/apxinf-model/src/qwen_drive/device_weights.rs
@@ -1,0 +1,426 @@
+//! Device-resident BF16 weights for the Qwen-Drive native executor.
+//!
+//! Built once at load from the checkpoint maps: HF `[out, in]` projections
+//! are transposed to `[in, out]` for the row-major GEMM path (the scaffold's
+//! transpose), per-layer Q/K/V and gate/up projections are concatenated into
+//! fused weights (a canonical rewrite: identical dot products, one GEMM), and
+//! the GDN in_proj_qkv/z/b/a projections are fused into one GEMM whose column
+//! slices the preparation kernels read strided. Every transformation runs
+//! once at load, never on the hot path.
+
+use std::collections::HashMap;
+
+use apxinf_core::{Backend, DType, Error, Result, Tensor};
+
+use super::config::QwenDriveConfig;
+use super::weights::{transpose_2d, QwenDriveExpertWeights, QwenDriveVlmWeights};
+
+fn take(map: &mut HashMap<String, Tensor>, name: &str) -> Result<Tensor> {
+    map.remove(name)
+        .ok_or_else(|| Error::Other(format!("qwen_drive device weights: missing {name}")))
+}
+
+fn take_transposed(map: &mut HashMap<String, Tensor>, name: &str) -> Result<Tensor> {
+    transpose_2d(&take(map, name)?)
+}
+
+/// Host-side column concat of equally tall `[in, out_i]` matrices into
+/// `[in, sum(out_i)]`. BF16 only (all checkpoint projections are bf16).
+fn concat_columns(tensors: &[&Tensor]) -> Result<Tensor> {
+    if tensors.is_empty() {
+        return Err(Error::Other("qwen_drive concat: no tensors".into()));
+    }
+    let rows = tensors[0].shape().dims()[0];
+    let mut cols = 0usize;
+    for tensor in tensors {
+        let dims = tensor.shape().dims();
+        if dims.len() != 2 || dims[0] != rows || tensor.dtype() != DType::BF16 {
+            return Err(Error::Other(
+                "qwen_drive concat: expected equally tall BF16 matrices".into(),
+            ));
+        }
+        cols += dims[1];
+    }
+    let mut out = vec![half::bf16::from_f32(0.0); rows * cols];
+    for r in 0..rows {
+        let mut offset = 0usize;
+        for tensor in tensors {
+            let width = tensor.shape().dims()[1];
+            let data = tensor.as_bf16()?;
+            out[r * cols + offset..r * cols + offset + width]
+                .copy_from_slice(&data[r * width..(r + 1) * width]);
+            offset += width;
+        }
+    }
+    Tensor::from_bf16(vec![rows, cols], &out)
+}
+
+/// Exact bf16 -> f32 widening on the host (for fp32-consumed constants).
+fn widen_to_f32(tensor: &Tensor) -> Result<Tensor> {
+    let dims = tensor.shape().dims().to_vec();
+    let values = tensor.to_f32_vec()?;
+    Tensor::from_f32(dims, &values)
+}
+
+/// f32 -> bf16 narrowing on the host (round-to-nearest-even, the reference's
+/// `.to(bfloat16)` cast). The checkpoint stores the GDN gated-RMSNorm weight
+/// (`linear_attn.norm.weight`) in f32; the gated RMS kernel expects bf16.
+fn narrow_to_bf16(tensor: &Tensor) -> Result<Tensor> {
+    let dims = tensor.shape().dims().to_vec();
+    let values = tensor.to_f32_vec()?;
+    let narrowed: Vec<half::bf16> = values.iter().map(|value| half::bf16::from_f32(*value)).collect();
+    Tensor::from_bf16(dims, &narrowed)
+}
+
+fn up(backend: &dyn Backend, tensor: &Tensor) -> Result<Tensor> {
+    backend.to_device(tensor)
+}
+
+fn up_mlp(backend: &dyn Backend, mlp: &super::weights::ExpertMlp) -> Result<DeviceMlp> {
+    Ok(DeviceMlp {
+        fc1_w: up(backend, &mlp.fc1_w)?,
+        fc1_b: up(backend, &mlp.fc1_b)?,
+        fc2_w: up(backend, &mlp.fc2_w)?,
+        fc2_b: up(backend, &mlp.fc2_b)?,
+    })
+}
+
+/// One Linear -> SiLU -> Linear block on device.
+pub struct DeviceMlp {
+    pub fc1_w: Tensor,
+    pub fc1_b: Tensor,
+    pub fc2_w: Tensor,
+    pub fc2_b: Tensor,
+}
+
+pub struct FullAttentionLayerWeights {
+    pub input_norm: Tensor,
+    /// Fused `[hidden, q_heads*2*head_dim + 2*kv_heads*head_dim]` (q|gate per
+    /// head first, then k heads, then v heads), transposed at load.
+    pub qkv_w: Tensor,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+    pub o_w: Tensor,
+    pub post_norm: Tensor,
+    /// Fused `[hidden, 2*intermediate]` (gate rows first).
+    pub gate_up_w: Tensor,
+    pub down_w: Tensor,
+}
+
+pub struct GdnLayerWeights {
+    pub input_norm: Tensor,
+    /// Fused `[hidden, conv_dim + value_dim + 2*num_v_heads]`
+    /// (in_proj_qkv | in_proj_z | in_proj_b | in_proj_a).
+    pub qkvzba_w: Tensor,
+    /// `[conv_dim, kernel_size]` (squeezed depthwise conv weight).
+    pub conv_w: Tensor,
+    /// `[num_v_heads]` fp32.
+    pub dt_bias: Tensor,
+    /// `[num_v_heads]` fp32.
+    pub a_log: Tensor,
+    /// `[head_v_dim]` gated RMSNorm weight (plain semantics).
+    pub gated_norm: Tensor,
+    pub out_w: Tensor,
+    pub post_norm: Tensor,
+    pub gate_up_w: Tensor,
+    pub down_w: Tensor,
+}
+
+pub enum MixerWeights {
+    FullAttention(FullAttentionLayerWeights),
+    Gdn(GdnLayerWeights),
+}
+
+pub struct VisionBlockWeights {
+    pub norm1_w: Tensor,
+    pub norm1_b: Tensor,
+    pub qkv_w: Tensor,
+    pub qkv_b: Tensor,
+    pub proj_w: Tensor,
+    pub proj_b: Tensor,
+    pub norm2_w: Tensor,
+    pub norm2_b: Tensor,
+    pub fc1_w: Tensor,
+    pub fc1_b: Tensor,
+    pub fc2_w: Tensor,
+    pub fc2_b: Tensor,
+}
+
+pub struct VisionDeviceWeights {
+    /// `[3 * temporal * patch * patch, hidden]` flattened Conv3d, transposed.
+    pub patch_w: Tensor,
+    pub patch_b: Tensor,
+    /// `[num_position_embeddings, hidden]` learned table (bilinear source).
+    pub pos_embed: Tensor,
+    pub blocks: Vec<VisionBlockWeights>,
+    pub merger_norm_w: Tensor,
+    pub merger_norm_b: Tensor,
+    pub merger_fc1_w: Tensor,
+    pub merger_fc1_b: Tensor,
+    pub merger_fc2_w: Tensor,
+    pub merger_fc2_b: Tensor,
+}
+
+pub struct ExpertLayerDeviceWeights {
+    pub input_norm: Tensor,
+    pub qkv_w: Tensor,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+    pub o_w: Tensor,
+    pub post_norm: Tensor,
+    pub gate_up_w: Tensor,
+    pub down_w: Tensor,
+    pub modulation_w: Tensor,
+    pub modulation_b: Tensor,
+}
+
+pub struct ExpertDeviceWeights {
+    pub trajectory_proj_w: Tensor,
+    pub trajectory_proj_b: Tensor,
+    pub fourier: DeviceMlp,
+    pub waypoint_embed: Tensor,
+    pub time_mlp: DeviceMlp,
+    pub nav_mlp: DeviceMlp,
+    pub ego_mlp: DeviceMlp,
+    pub history_encoder: DeviceMlp,
+    pub history_velocity_encoder: DeviceMlp,
+    pub history_acceleration_encoder: DeviceMlp,
+    pub query_fusion: DeviceMlp,
+    pub layers: Vec<ExpertLayerDeviceWeights>,
+    pub final_norm: Tensor,
+    pub out_proj_w: Tensor,
+    pub out_proj_b: Tensor,
+    /// bf16 logspace frequency table (rounding is semantic), built at load.
+    pub fourier_freqs: Tensor,
+}
+
+/// torch.logspace(0, log10(max_frequency), steps, dtype=bf16) rebuilt in the
+/// compute dtype exactly like the reference encoder.
+fn fourier_freq_table(num_features: usize, max_frequency: f32) -> Result<Tensor> {
+    if num_features == 0 {
+        return Err(Error::Other("qwen_drive: empty Fourier table".into()));
+    }
+    let log_max = (max_frequency as f64).log10() as f32;
+    let step = if num_features > 1 {
+        log_max / (num_features - 1) as f32
+    } else {
+        0.0
+    };
+    let values: Vec<half::bf16> = (0..num_features)
+        .map(|i| half::bf16::from_f32(10f32.powf(step * i as f32)))
+        .collect();
+    Tensor::from_bf16(vec![num_features], &values)
+}
+
+pub struct QwenDriveDeviceWeights {
+    /// `[vocab, hidden]`; doubles as the tied lm_head via a transposed GEMM.
+    pub embed_tokens: Tensor,
+    pub layers: Vec<MixerWeights>,
+    pub final_norm: Tensor,
+    pub vision: VisionDeviceWeights,
+    pub expert: Option<ExpertDeviceWeights>,
+}
+
+impl QwenDriveDeviceWeights {
+    pub fn from_maps(
+        config: &QwenDriveConfig,
+        vlm: QwenDriveVlmWeights,
+        expert: Option<QwenDriveExpertWeights>,
+        backend: &dyn Backend,
+    ) -> Result<Self> {
+        let mut language = vlm.language;
+        let mut visual = vlm.visual;
+        let text = &config.text;
+        let hidden = text.hidden_size;
+        let kv_width = text.n_kv_heads * text.head_dim;
+        let q_width = text.n_heads * 2 * text.head_dim;
+
+        let mut layers = Vec::with_capacity(text.n_layers);
+        for index in 0..text.n_layers {
+            let p = format!("model.language_model.layers.{index}");
+            let input_norm = up(backend, &take(&mut language, &format!("{p}.input_layernorm.weight"))?)?;
+            let post_norm = up(backend, &take(&mut language, &format!("{p}.post_attention_layernorm.weight"))?)?;
+            let gate = take_transposed(&mut language, &format!("{p}.mlp.gate_proj.weight"))?;
+            let up_w = take_transposed(&mut language, &format!("{p}.mlp.up_proj.weight"))?;
+            let gate_up_w = up(backend, &concat_columns(&[&gate, &up_w])?)?;
+            let down_w = up(backend, &take_transposed(&mut language, &format!("{p}.mlp.down_proj.weight"))?)?;
+            if text.is_full_attention(index) {
+                let q = take_transposed(&mut language, &format!("{p}.self_attn.q_proj.weight"))?;
+                let k = take_transposed(&mut language, &format!("{p}.self_attn.k_proj.weight"))?;
+                let v = take_transposed(&mut language, &format!("{p}.self_attn.v_proj.weight"))?;
+                let qkv_w = concat_columns(&[&q, &k, &v])?;
+                let dims = qkv_w.shape().dims().to_vec();
+                if dims != [hidden, q_width + 2 * kv_width] {
+                    return Err(Error::Other(format!(
+                        "qwen_drive: fused qkv width mismatch at layer {index}: {dims:?}"
+                    )));
+                }
+                layers.push(MixerWeights::FullAttention(FullAttentionLayerWeights {
+                    input_norm,
+                    qkv_w: up(backend, &qkv_w)?,
+                    q_norm: up(backend, &take(&mut language, &format!("{p}.self_attn.q_norm.weight"))?)?,
+                    k_norm: up(backend, &take(&mut language, &format!("{p}.self_attn.k_norm.weight"))?)?,
+                    o_w: up(backend, &take_transposed(&mut language, &format!("{p}.self_attn.o_proj.weight"))?)?,
+                    post_norm,
+                    gate_up_w,
+                    down_w,
+                }));
+            } else {
+                let in_qkv = take_transposed(&mut language, &format!("{p}.linear_attn.in_proj_qkv.weight"))?;
+                let in_z = take_transposed(&mut language, &format!("{p}.linear_attn.in_proj_z.weight"))?;
+                let in_b = take_transposed(&mut language, &format!("{p}.linear_attn.in_proj_b.weight"))?;
+                let in_a = take_transposed(&mut language, &format!("{p}.linear_attn.in_proj_a.weight"))?;
+                let conv = take(&mut language, &format!("{p}.linear_attn.conv1d.weight"))?;
+                let conv_dims = conv.shape().dims().to_vec();
+                let conv_dim = 2 * text.linear_num_key_heads * text.linear_key_head_dim
+                    + text.linear_num_value_heads * text.linear_value_head_dim;
+                let kernel = text.linear_conv_kernel_dim;
+                if conv_dims != [conv_dim, 1, kernel] {
+                    return Err(Error::Other(format!(
+                        "qwen_drive: conv1d weight at layer {index} has shape {conv_dims:?}, expected [{conv_dim}, 1, {kernel}]"
+                    )));
+                }
+                layers.push(MixerWeights::Gdn(GdnLayerWeights {
+                    input_norm,
+                    qkvzba_w: up(backend, &concat_columns(&[&in_qkv, &in_z, &in_b, &in_a])?)?,
+                    conv_w: up(backend, &conv.reshape(vec![conv_dim, kernel])?)?,
+                    dt_bias: up(backend, &widen_to_f32(&take(&mut language, &format!("{p}.linear_attn.dt_bias"))?)?)?,
+                    a_log: up(backend, &widen_to_f32(&take(&mut language, &format!("{p}.linear_attn.A_log"))?)?)?,
+                    gated_norm: up(backend, &narrow_to_bf16(&take(&mut language, &format!("{p}.linear_attn.norm.weight"))?)?)?,
+                    out_w: up(backend, &take_transposed(&mut language, &format!("{p}.linear_attn.out_proj.weight"))?)?,
+                    post_norm,
+                    gate_up_w,
+                    down_w,
+                }));
+            }
+        }
+        let embed_tokens = up(backend, &take(&mut language, "model.language_model.embed_tokens.weight")?)?;
+        let final_norm = up(backend, &take(&mut language, "model.language_model.norm.weight")?)?;
+        if !language.is_empty() {
+            let mut names: Vec<String> = language.keys().cloned().collect();
+            names.sort_unstable();
+            // MTP/auxiliary tensors are allowed but must be named, not silently
+            // dropped: keep the check informational-strict like the scaffold.
+            let mtp_only = names.iter().all(|name| name.starts_with("model.language_model.mtp"));
+            if !mtp_only {
+                return Err(Error::Other(format!(
+                    "qwen_drive device weights: {} unconsumed language tensors, first: {}",
+                    names.len(),
+                    names[0]
+                )));
+            }
+        }
+
+        // Vision tower.
+        let vision_cfg = &config.vision;
+        let merge_sq = vision_cfg.spatial_merge_size * vision_cfg.spatial_merge_size;
+        let patch = take(&mut visual, "model.visual.patch_embed.proj.weight")?;
+        let patch_dims = patch.shape().dims().to_vec();
+        let patch_vec = vision_cfg.in_channels * vision_cfg.temporal_patch_size
+            * vision_cfg.patch_size * vision_cfg.patch_size;
+        if patch_dims.len() != 5 || patch_dims[0] != vision_cfg.hidden_size
+            || patch_dims.iter().product::<usize>() != vision_cfg.hidden_size * patch_vec
+        {
+            return Err(Error::Other(format!(
+                "qwen_drive: patch_embed weight has shape {patch_dims:?}"
+            )));
+        }
+        let patch_w = transpose_2d(&patch.reshape(vec![vision_cfg.hidden_size, patch_vec])?)?;
+        let mut blocks = Vec::with_capacity(vision_cfg.depth);
+        for index in 0..vision_cfg.depth {
+            let p = format!("model.visual.blocks.{index}");
+            blocks.push(VisionBlockWeights {
+                norm1_w: up(backend, &take(&mut visual, &format!("{p}.norm1.weight"))?)?,
+                norm1_b: up(backend, &take(&mut visual, &format!("{p}.norm1.bias"))?)?,
+                qkv_w: up(backend, &take_transposed(&mut visual, &format!("{p}.attn.qkv.weight"))?)?,
+                qkv_b: up(backend, &take(&mut visual, &format!("{p}.attn.qkv.bias"))?)?,
+                proj_w: up(backend, &take_transposed(&mut visual, &format!("{p}.attn.proj.weight"))?)?,
+                proj_b: up(backend, &take(&mut visual, &format!("{p}.attn.proj.bias"))?)?,
+                norm2_w: up(backend, &take(&mut visual, &format!("{p}.norm2.weight"))?)?,
+                norm2_b: up(backend, &take(&mut visual, &format!("{p}.norm2.bias"))?)?,
+                fc1_w: up(backend, &take_transposed(&mut visual, &format!("{p}.mlp.linear_fc1.weight"))?)?,
+                fc1_b: up(backend, &take(&mut visual, &format!("{p}.mlp.linear_fc1.bias"))?)?,
+                fc2_w: up(backend, &take_transposed(&mut visual, &format!("{p}.mlp.linear_fc2.weight"))?)?,
+                fc2_b: up(backend, &take(&mut visual, &format!("{p}.mlp.linear_fc2.bias"))?)?,
+            });
+        }
+        let merger_fc1 = take_transposed(&mut visual, "model.visual.merger.linear_fc1.weight")?;
+        let merger_fc2 = take_transposed(&mut visual, "model.visual.merger.linear_fc2.weight")?;
+        let expected_fc1 = vision_cfg.hidden_size * merge_sq;
+        if merger_fc1.shape().dims() != [expected_fc1, expected_fc1] {
+            return Err(Error::Other("qwen_drive: merger fc1 shape mismatch".into()));
+        }
+        let vision = VisionDeviceWeights {
+            patch_w: up(backend, &patch_w)?,
+            patch_b: up(backend, &take(&mut visual, "model.visual.patch_embed.proj.bias")?)?,
+            pos_embed: up(backend, &take(&mut visual, "model.visual.pos_embed.weight")?)?,
+            blocks,
+            merger_norm_w: up(backend, &take(&mut visual, "model.visual.merger.norm.weight")?)?,
+            merger_norm_b: up(backend, &take(&mut visual, "model.visual.merger.norm.bias")?)?,
+            merger_fc1_w: up(backend, &merger_fc1)?,
+            merger_fc1_b: up(backend, &take(&mut visual, "model.visual.merger.linear_fc1.bias")?)?,
+            merger_fc2_w: up(backend, &merger_fc2)?,
+            merger_fc2_b: up(backend, &take(&mut visual, "model.visual.merger.linear_fc2.bias")?)?,
+        };
+        if !visual.is_empty() {
+            let mut names: Vec<String> = visual.keys().cloned().collect();
+            names.sort_unstable();
+            return Err(Error::Other(format!(
+                "qwen_drive device weights: {} unconsumed visual tensors, first: {}",
+                names.len(),
+                names[0]
+            )));
+        }
+
+        let expert = expert
+            .map(|expert| Self::upload_expert(config, expert, backend))
+            .transpose()?;
+        Ok(Self { embed_tokens, layers, final_norm, vision, expert })
+    }
+
+    fn upload_expert(
+        config: &QwenDriveConfig,
+        weights: QwenDriveExpertWeights,
+        backend: &dyn Backend,
+    ) -> Result<ExpertDeviceWeights> {
+        let mut layers = Vec::with_capacity(weights.layers.len());
+        for layer in &weights.layers {
+            layers.push(ExpertLayerDeviceWeights {
+                input_norm: up(backend, &layer.input_layernorm)?,
+                qkv_w: up(backend, &layer.qkv_w)?,
+                q_norm: up(backend, &layer.q_norm)?,
+                k_norm: up(backend, &layer.k_norm)?,
+                o_w: up(backend, &layer.o_w)?,
+                post_norm: up(backend, &layer.post_attention_layernorm)?,
+                gate_up_w: up(backend, &layer.gate_up_w)?,
+                down_w: up(backend, &layer.down_w)?,
+                modulation_w: up(backend, &layer.modulation_w)?,
+                modulation_b: up(backend, &layer.modulation_b)?,
+            });
+        }
+        Ok(ExpertDeviceWeights {
+            trajectory_proj_w: up(backend, &weights.trajectory_proj_w)?,
+            trajectory_proj_b: up(backend, &weights.trajectory_proj_b)?,
+            fourier: up_mlp(backend, &weights.fourier_encoder)?,
+            waypoint_embed: up(backend, &weights.waypoint_embed)?,
+            time_mlp: up_mlp(backend, &weights.time_mlp)?,
+            nav_mlp: up_mlp(backend, &weights.nav_mlp)?,
+            ego_mlp: up_mlp(backend, &weights.ego_mlp)?,
+            history_encoder: up_mlp(backend, &weights.history_encoder)?,
+            history_velocity_encoder: up_mlp(backend, &weights.history_velocity_encoder)?,
+            history_acceleration_encoder: up_mlp(backend, &weights.history_acceleration_encoder)?,
+            query_fusion: up_mlp(backend, &weights.query_fusion)?,
+            layers,
+            final_norm: up(backend, &weights.final_layernorm)?,
+            out_proj_w: up(backend, &weights.out_proj_w)?,
+            out_proj_b: up(backend, &weights.out_proj_b)?,
+            fourier_freqs: up(
+                backend,
+                &fourier_freq_table(
+                    config.expert.fourier_num_features,
+                    config.expert.fourier_max_frequency,
+                )?,
+            )?,
+        })
+    }
+}

--- a/crates/apxinf-model/src/qwen_drive/expert.rs
+++ b/crates/apxinf-model/src/qwen_drive/expert.rs
@@ -1,0 +1,327 @@
+//! Planning-expert device executor: joint-attention diffusion transformer
+//! with flow-matching sampling, on the CUDA kernel path.
+//!
+//! Ported from the pinned reference (`planning_expert.py`) and the saved K3
+//! CPU scaffold (`planner.rs`, retained as the correctness oracle): adaLN
+//! conditioning (rms -> *(1+scale) + shift, residual + (1+gate) * proj),
+//! group-major fused QKV with plain per-head RMSNorm, partial interleaved
+//! mRoPE with the reference's bf16-rounded frequency/position tables,
+//! non-causal joint GQA over concat(scene KV, waypoint KV) with a per-head
+//! sigmoid output gate, SwiGLU FFN, and clean-endpoint flow matching with an
+//! fp32 solver state. All steady-state computation runs on device; host work
+//! is limited to per-request table construction and the final output copy.
+
+use apxinf_core::{DType, Error, Result, Shape, Tensor};
+
+use super::backend::{kernels, transfers, Context, DeviceBuffer};
+use kernels::{activation, elementwise, embedding, gemm, linear_attention as la, norm};
+
+use super::config::{PlanningExpertConfig, QwenDriveConfig};
+use super::device_weights::{DeviceMlp, ExpertDeviceWeights};
+use super::planner::ExpertConditioning;
+
+/// bf16 rounding of one f32 value, returned as f32 (the value a bf16 tensor
+/// would hold). Mirrors the scaffold's semantic-rounding helper.
+fn bf16_round(value: f32) -> f32 {
+    half::bf16::from_f32(value).to_f32()
+}
+
+fn upload_u32(ctx: &Context, values: &[u32]) -> Result<DeviceBuffer> {
+    let bytes: Vec<u8> = values.iter().flat_map(|value| value.to_ne_bytes()).collect();
+    let buffer = DeviceBuffer::alloc(bytes.len().max(1), ctx.device_id()).map_err(Error::Cuda)?;
+    buffer.copy_from_host(&bytes).map_err(Error::Cuda)?;
+    Ok(buffer)
+}
+
+fn device_tensor(ctx: &Context, shape: &[usize], dtype: DType) -> Result<Tensor> {
+    let elements: usize = shape.iter().product();
+    let bytes = elements
+        .checked_mul(dtype.size_in_bytes())
+        .ok_or_else(|| Error::Other("qwen_drive expert: tensor size overflow".into()))?;
+    let buffer = DeviceBuffer::alloc(bytes.max(1), ctx.device_id()).map_err(Error::Cuda)?;
+    buffer
+        .as_tensor(Shape::new(shape.to_vec()), dtype)
+        .map_err(Error::Cuda)
+}
+
+fn bf16_tensor(ctx: &Context, values: &[f32], shape: Vec<usize>) -> Result<Tensor> {
+    let rounded: Vec<half::bf16> = values.iter().map(|&v| half::bf16::from_f32(v)).collect();
+    let tensor = Tensor::from_bf16(shape, &rounded)?;
+    transfers::to_cuda(&tensor, ctx.device_id())
+}
+
+/// One `[cols]` column view of a `[1, N * cols]` row tensor.
+fn row_col_slice(tensor: &Tensor, col: usize, cols: usize) -> Result<Tensor> {
+    let buffer = DeviceBuffer::from_tensor(tensor).map_err(Error::Cuda)?;
+    let view = buffer
+        .view(col * DType::BF16.size_in_bytes(), cols * DType::BF16.size_in_bytes())
+        .map_err(Error::Cuda)?;
+    view.as_tensor(Shape::new(vec![cols]), DType::BF16)
+        .map_err(Error::Cuda)
+}
+
+fn mlp(ctx: &Context, mlp: &DeviceMlp, x: &Tensor) -> Result<Tensor> {
+    let h = gemm::matmul(ctx, x, &mlp.fc1_w)?;
+    let h = activation::bias_silu_bf16(ctx, &h, Some(&mlp.fc1_b))?;
+    let h = gemm::matmul(ctx, &h, &mlp.fc2_w)?;
+    elementwise::bias_bf16(ctx, &h, Some(&mlp.fc2_b))
+}
+
+fn one_hot(classes: usize, index: i64) -> Vec<f32> {
+    let mut out = vec![0.0f32; classes];
+    if index >= 0 && (index as usize) < classes {
+        out[index as usize] = 1.0;
+    }
+    out
+}
+
+/// Sinusoidal time embedding (scaffold semantics): decay = ln(10000)/(half-1),
+/// angles = (scale * t) * freq in f32, sin/cos rounded to bf16.
+fn time_embedding(dim: usize, scale: f32, t: f32) -> Vec<f32> {
+    let half = dim / 2;
+    let decay = (10000.0f64).ln() as f32 / (half.max(2) - 1) as f32;
+    let mut out = Vec::with_capacity(dim);
+    for i in 0..half {
+        let freq = (-(i as f32) * decay).exp();
+        out.push(bf16_round((scale * t * freq).sin()));
+    }
+    for i in 0..half {
+        let freq = (-(i as f32) * decay).exp();
+        out.push(bf16_round((scale * t * freq).cos()));
+    }
+    out
+}
+
+/// Waypoint rope tables (scaffold semantics): positions `anchor + 1 ..= anchor
+/// + length` cast to bf16, multiplied with the bf16-rounded inverse-frequency
+/// table, merged section-wise, cos/sin rounded to bf16. Returns `(cos, sin)`,
+/// each `[length, rotary_dim]` in f32 (bf16-rounded values).
+fn waypoint_rope_tables(
+    config: &PlanningExpertConfig,
+    anchor: i64,
+    length: usize,
+) -> Result<(Vec<f32>, Vec<f32>)> {
+    let rotary_dim = config.rotary_dim();
+    let pairs = rotary_dim / 2;
+    let theta = config.rope_theta;
+    let mut inv_freq = Vec::with_capacity(pairs);
+    for i in 0..pairs {
+        let exponent = (2 * i) as f32 / rotary_dim as f32;
+        inv_freq.push(bf16_round(1.0 / theta.powf(exponent)));
+    }
+    let mut angles = vec![[0.0f32; 3].map(|_| vec![0.0f32; pairs]); length];
+    let mut cos = vec![0.0f32; length * rotary_dim];
+    let mut sin = vec![0.0f32; length * rotary_dim];
+    for l in 0..length {
+        let position = bf16_round((anchor + 1 + l as i64) as f32);
+        for p in 0..pairs {
+            let angle = bf16_round(position * inv_freq[p]);
+            for section in &mut angles[l] {
+                section[p] = angle;
+            }
+        }
+        let mut merged = angles[l][0].clone();
+        let mut offset = 1usize;
+        for (section_index, section_length) in config.mrope_section.iter().enumerate().skip(1) {
+            let mut p = offset;
+            let mut taken = 0usize;
+            while p < pairs && taken < *section_length {
+                merged[p] = angles[l][section_index][p];
+                taken += 1;
+                p += 3;
+            }
+            offset += 1;
+        }
+        for p in 0..pairs {
+            cos[l * rotary_dim + p] = bf16_round(merged[p].cos());
+            cos[l * rotary_dim + pairs + p] = cos[l * rotary_dim + p];
+            sin[l * rotary_dim + p] = bf16_round(merged[p].sin());
+            sin[l * rotary_dim + pairs + p] = sin[l * rotary_dim + p];
+        }
+    }
+    Ok((cos, sin))
+}
+
+/// Inputs for one expert planning call. `scene` holds one `(K, V)` pair per
+/// expert KV source (VLM full-attention layers, post-rotary, bf16
+/// `[scene_len, kv_heads, head_dim]` on device).
+pub struct ExpertPlan<'a> {
+    pub scene: &'a [(Tensor, Tensor)],
+    pub scene_len: usize,
+    pub anchor: i64,
+    pub cond: &'a ExpertConditioning,
+    pub noise: &'a [f32],
+    pub num_steps: usize,
+}
+
+/// Run the flow-matching sampler; returns the normalized `[length, 3]`
+/// trajectory in fp32 (the caller denormalizes).
+pub fn plan(
+    config: &QwenDriveConfig,
+    weights: &ExpertDeviceWeights,
+    ctx: &Context,
+    input: &ExpertPlan,
+) -> Result<Vec<f32>> {
+    let ec = &config.expert;
+    let hidden_size = ec.hidden_size;
+    let length = config.num_future_points;
+    let point_dim = config.trajectory_point_dim;
+    let heads = ec.n_heads;
+    let kv_heads = ec.n_kv_heads;
+    let head_dim = ec.head_dim;
+    let rotary_dim = ec.rotary_dim();
+    let eps = ec.rms_norm_eps;
+    let steps = input.num_steps.max(1);
+    if input.scene.len() != ec.num_kv_sources() {
+        return Err(Error::Other(format!(
+            "qwen_drive expert: {} scene caches, expected {}",
+            input.scene.len(),
+            ec.num_kv_sources()
+        )));
+    }
+    if input.noise.len() != length * point_dim {
+        return Err(Error::Other(format!(
+            "qwen_drive expert: noise has {} values, expected {}",
+            input.noise.len(),
+            length * point_dim
+        )));
+    }
+    input.cond.validate(config)?;
+
+    // Conditioning (request lifetime).
+    let nav = one_hot(ec.nav_command_classes, input.cond.nav_command);
+    let mut history_in = input.cond.history.clone();
+    history_in.extend_from_slice(&nav);
+    let history_t = bf16_tensor(ctx, &history_in, vec![1, history_in.len()])?;
+    let velocity_t = bf16_tensor(ctx, &input.cond.history_velocity, vec![1, input.cond.history_velocity.len()])?;
+    let acceleration_t = bf16_tensor(ctx, &input.cond.history_acceleration, vec![1, input.cond.history_acceleration.len()])?;
+    let ego_t = bf16_tensor(ctx, &input.cond.ego_status, vec![1, input.cond.ego_status.len()])?;
+    let nav_t = bf16_tensor(ctx, &nav, vec![1, nav.len()])?;
+    let pose_q = mlp(ctx, &weights.history_encoder, &history_t)?;
+    let velocity_q = mlp(ctx, &weights.history_velocity_encoder, &velocity_t)?;
+    let acceleration_q = mlp(ctx, &weights.history_acceleration_encoder, &acceleration_t)?;
+    let nav_out = mlp(ctx, &weights.nav_mlp, &nav_t)?;
+    let ego_out = mlp(ctx, &weights.ego_mlp, &ego_t)?;
+
+    let ids: Vec<u32> = (0..length as u32).collect();
+    let ids_dev = upload_u32(ctx, &ids)?;
+    let wp_idx = embedding::lookup_bf16(ctx, &weights.waypoint_embed, &ids_dev, length)?;
+
+    let (cos, sin) = waypoint_rope_tables(ec, input.anchor, length)?;
+    let cos_t = bf16_tensor(ctx, &cos, vec![length, rotary_dim])?;
+    let sin_t = bf16_tensor(ctx, &sin, vec![length, rotary_dim])?;
+
+    // fp32 solver state on device.
+    let noise_tensor = Tensor::from_f32(vec![length, point_dim], input.noise)?;
+    let waypoints = transfers::to_cuda(&noise_tensor, ctx.device_id())?;
+
+    let step_f64 = 1.0f64 / steps as f64;
+    for index in 0..steps {
+        let t_f64 = index as f64 * step_f64;
+        let t_emb = time_embedding(ec.time_embed_dim, ec.time_embed_scale, t_f64 as f32);
+        let t_emb_t = bf16_tensor(ctx, &t_emb, vec![1, ec.time_embed_dim])?;
+        let time_condition = mlp(ctx, &weights.time_mlp, &t_emb_t)?;
+        let condition = elementwise::add(ctx, &time_condition, &nav_out)?;
+        let condition = elementwise::add(ctx, &condition, &ego_out)?;
+        let condition_silu = activation::silu(ctx, &condition)?;
+
+        let wp_bf16 = device_tensor(ctx, &[length, point_dim], DType::BF16)?;
+        la::cast_f32_to_bf16(ctx, &waypoints, &wp_bf16)?;
+        let traj = gemm::matmul(ctx, &wp_bf16, &weights.trajectory_proj_w)?;
+        let traj = elementwise::bias_bf16(ctx, &traj, Some(&weights.trajectory_proj_b))?;
+        let fourier_feat = la::fourier_features(
+            ctx,
+            &wp_bf16,
+            &weights.fourier_freqs,
+            point_dim,
+            ec.fourier_num_features,
+        )?;
+        let fourier = mlp(ctx, &weights.fourier, &fourier_feat)?;
+        // broadcast bits: time(2), pose(3), velocity(5), acceleration(6).
+        let fused = la::concat7_cols(
+            ctx,
+            [
+                &traj,
+                &fourier,
+                &time_condition,
+                &pose_q,
+                &wp_idx,
+                &velocity_q,
+                &acceleration_q,
+            ],
+            (1 << 2) | (1 << 3) | (1 << 5) | (1 << 6),
+        )?;
+        let mut hidden = mlp(ctx, &weights.query_fusion, &fused)?;
+
+        for (layer_index, layer) in weights.layers.iter().enumerate() {
+            let (scene_k, scene_v) = &input.scene[layer_index / ec.layers_per_kv];
+            let modulation = gemm::matmul(ctx, &condition_silu, &layer.modulation_w)?;
+            let modulation = elementwise::bias_bf16(ctx, &modulation, Some(&layer.modulation_b))?;
+            let shift_attn = row_col_slice(&modulation, 0, hidden_size)?;
+            let scale_attn = row_col_slice(&modulation, hidden_size, hidden_size)?;
+            let gate_attn = row_col_slice(&modulation, 2 * hidden_size, hidden_size)?;
+            let shift_ffn = row_col_slice(&modulation, 3 * hidden_size, hidden_size)?;
+            let scale_ffn = row_col_slice(&modulation, 4 * hidden_size, hidden_size)?;
+            let gate_ffn = row_col_slice(&modulation, 5 * hidden_size, hidden_size)?;
+
+            let x = la::adaln_rms_norm(ctx, &hidden, &layer.input_norm, &scale_attn, &shift_attn, eps)?;
+            let qkv = gemm::matmul(ctx, &x, &layer.qkv_w)?;
+            let q_out = device_tensor(ctx, &[length, heads, head_dim], DType::BF16)?;
+            let gate_out = device_tensor(ctx, &[length, heads, head_dim], DType::BF16)?;
+            let k_out = device_tensor(ctx, &[length, kv_heads, head_dim], DType::BF16)?;
+            let v_out = device_tensor(ctx, &[length, kv_heads, head_dim], DType::BF16)?;
+            la::expert_qkv_prepare(
+                ctx,
+                &qkv,
+                &layer.q_norm,
+                &layer.k_norm,
+                &cos_t,
+                &sin_t,
+                &q_out,
+                &gate_out,
+                &k_out,
+                &v_out,
+                heads,
+                kv_heads,
+                head_dim,
+                rotary_dim,
+                eps,
+            )?;
+            let k_cat = elementwise::concat_rows_bf16(
+                ctx,
+                &scene_k.reshape(vec![input.scene_len, kv_heads * head_dim])?,
+                &k_out.reshape(vec![length, kv_heads * head_dim])?,
+            )?;
+            let v_cat = elementwise::concat_rows_bf16(
+                ctx,
+                &scene_v.reshape(vec![input.scene_len, kv_heads * head_dim])?,
+                &v_out.reshape(vec![length, kv_heads * head_dim])?,
+            )?;
+            let k_cat = k_cat.reshape(vec![input.scene_len + length, kv_heads, head_dim])?;
+            let v_cat = v_cat.reshape(vec![input.scene_len + length, kv_heads, head_dim])?;
+            let attn = la::gqa_bf16(ctx, &q_out, &k_cat, &v_cat, input.scene_len + length)?;
+            la::expert_sigmoid_gate_mul(ctx, &attn, &gate_out)?;
+            let attn = attn.reshape(vec![length, heads * head_dim])?;
+            let proj = gemm::matmul(ctx, &attn, &layer.o_w)?;
+            hidden = la::adaln_gate_residual(ctx, &proj, &hidden, &gate_attn)?;
+
+            let x2 = la::adaln_rms_norm(ctx, &hidden, &layer.post_norm, &scale_ffn, &shift_ffn, eps)?;
+            let gu = gemm::matmul(ctx, &x2, &layer.gate_up_w)?;
+            let act = activation::swiglu_bf16(ctx, &gu)?;
+            let down = gemm::matmul(ctx, &act, &layer.down_w)?;
+            hidden = la::adaln_gate_residual(ctx, &down, &hidden, &gate_ffn)?;
+        }
+
+        let final_normed = norm::rms_bf16(ctx, &hidden, &weights.final_norm, eps)?;
+        let endpoint = gemm::matmul(ctx, &final_normed, &weights.out_proj_w)?;
+        let endpoint = elementwise::bias_bf16(ctx, &endpoint, Some(&weights.out_proj_b))?;
+        let endpoint_f32 = device_tensor(ctx, &[length, point_dim], DType::F32)?;
+        la::cast_bf16_to_f32(ctx, &endpoint, &endpoint_f32)?;
+        let remaining = (1.0f64 - t_f64).max(config.min_one_minus_t as f64) as f32;
+        la::flow_update(ctx, &waypoints, &endpoint_f32, remaining, step_f64 as f32)?;
+    }
+
+    let cpu = transfers::to_cpu(&waypoints)?;
+    cpu.to_f32_vec()
+        .map_err(|e| Error::Other(format!("qwen_drive expert: output download: {e}")))
+}

--- a/crates/apxinf-model/src/qwen_drive/general.rs
+++ b/crates/apxinf-model/src/qwen_drive/general.rs
@@ -1,0 +1,952 @@
+//! Qwen-Drive native model: Qwen3.5 hybrid VLM (gated-delta linear attention
+//! + gated full attention with partial interleaved mRoPE) plus the planning
+//! expert driver, on the CUDA kernel path.
+//!
+//! The hybrid cache is model-owned: full-attention layers append post-rotary
+//! K/V into per-layer `[capacity, kv_heads, head_dim]` BF16 buffers (exactly
+//! the post-rotary caches the planning expert reads), while GDN layers
+//! advance a causal-conv state and an fp32 recurrent state. The type
+//! implements `LlmTrait` for the maintained registry/AutoModel surface and
+//! exposes the dedicated VQA / direct-planning / reasoning-planning flows
+//! used by the PyO3 binding. All layer mathematics run on device.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use apxinf_core::{
+    Backend, DType, Device, Error, NextTokenLogits, Result, RngKey, Shape, Tensor,
+    TokenSamplingInit, TokenSamplingParams, TokenSamplingSpec,
+};
+use apxinf_loader::ModelConfig;
+
+use crate::accelerator::create_backend;
+use crate::llm_trait::{LlmCapabilities, LlmInput, LlmTrait};
+
+use super::backend::{
+    downcast_arc, kernels, transfers, Context, CublasTranspose, DeviceBuffer, RuntimeBackend,
+};
+use kernels::{activation, attention, elementwise, embedding, gemm, linear_attention as la};
+
+use super::config::QwenDriveConfig;
+use super::device_weights::{MixerWeights, QwenDriveDeviceWeights};
+use super::expert::{self, ExpertPlan};
+use super::planner::ExpertConditioning;
+use super::vision;
+use super::weights::{QwenDriveExpertWeights, QwenDriveVlmWeights};
+
+const GDN_CHUNK: usize = 64;
+
+fn bf16_round(value: f32) -> f32 {
+    half::bf16::from_f32(value).to_f32()
+}
+
+fn device_tensor(ctx: &Context, shape: &[usize], dtype: DType) -> Result<Tensor> {
+    let elements: usize = shape.iter().product();
+    let bytes = elements
+        .checked_mul(dtype.size_in_bytes())
+        .ok_or_else(|| Error::Other("qwen_drive: tensor size overflow".into()))?;
+    let buffer = DeviceBuffer::alloc(bytes.max(1), ctx.device_id()).map_err(Error::Cuda)?;
+    buffer
+        .as_tensor(Shape::new(shape.to_vec()), dtype)
+        .map_err(Error::Cuda)
+}
+
+fn alloc_zeros(ctx: &Context, bytes: usize) -> Result<DeviceBuffer> {
+    DeviceBuffer::alloc_zeros(bytes.max(1), ctx.device_id()).map_err(Error::Cuda)
+}
+
+fn upload_u32(ctx: &Context, values: &[u32]) -> Result<DeviceBuffer> {
+    let bytes: Vec<u8> = values.iter().flat_map(|value| value.to_ne_bytes()).collect();
+    let buffer = DeviceBuffer::alloc(bytes.len().max(1), ctx.device_id()).map_err(Error::Cuda)?;
+    buffer.copy_from_host(&bytes).map_err(Error::Cuda)?;
+    Ok(buffer)
+}
+
+/// `[kv_len, kv_heads, head_dim]` prefix view of a cache tensor.
+fn cache_view(cache: &Tensor, kv_len: usize) -> Result<Tensor> {
+    let dims = cache.shape().dims().to_vec();
+    if dims.len() != 3 || kv_len == 0 || kv_len > dims[0] {
+        return Err(Error::Other("qwen_drive: cache view shape mismatch".into()));
+    }
+    let buffer = DeviceBuffer::from_tensor(cache).map_err(Error::Cuda)?;
+    let bytes = kv_len * dims[1] * dims[2] * DType::BF16.size_in_bytes();
+    let view = buffer.view(0, bytes).map_err(Error::Cuda)?;
+    view.as_tensor(Shape::new(vec![kv_len, dims[1], dims[2]]), DType::BF16)
+        .map_err(Error::Cuda)
+}
+
+enum LayerCache {
+    FullAttention { k: Tensor, v: Tensor },
+    Gdn {
+        conv_state_a: Tensor,
+        conv_state_b: Tensor,
+        /// false -> a is current, b is scratch; true -> b is current.
+        flip: bool,
+        recurrent: Tensor,
+    },
+}
+
+/// The native Qwen-Drive model (VLM + optional planning expert).
+pub struct QwenDriveModel {
+    config: QwenDriveConfig,
+    backend: Arc<dyn Backend>,
+    cuda: Arc<RuntimeBackend>,
+    weights: QwenDriveDeviceWeights,
+    caches: Vec<LayerCache>,
+    cache_len: usize,
+    rope_delta: i64,
+    max_seq_len: usize,
+    /// mRoPE position of the last processed token (all three axes equal for
+    /// the text tokens that close every supported prompt).
+    last_position: i64,
+}
+
+impl QwenDriveModel {
+    /// Load the VLM (and optional planner head) onto a CUDA device.
+    pub fn load(model_dir: &Path, planner_dir: Option<&Path>, device: Device) -> Result<Self> {
+        let backend = create_backend(device)?;
+        Self::load_with_backend(model_dir, planner_dir, backend)
+    }
+
+    pub fn load_with_backend(
+        model_dir: &Path,
+        planner_dir: Option<&Path>,
+        backend: Arc<dyn Backend>,
+    ) -> Result<Self> {
+        let cuda = downcast_arc(backend.clone()).ok_or_else(|| {
+            Error::Other(
+                "qwen_drive requires the CUDA backend (native device execution); \
+                 the CPU backend is not a deployment target"
+                    .into(),
+            )
+        })?;
+        let config = QwenDriveConfig::from_json_file(&model_dir.join("config.json"))?;
+        eprintln!("[qwen_drive] loading VLM weights from {}", model_dir.display());
+        let (tensors, _meta) = apxinf_loader::safetensors::load_native_path(model_dir)
+            .map_err(|e| Error::Other(format!("qwen_drive: load VLM weights: {e}")))?;
+        eprintln!("[qwen_drive] VLM safetensors loaded: {} tensors", tensors.len());
+        let vlm = QwenDriveVlmWeights::from_map(tensors)?;
+        eprintln!(
+            "[qwen_drive] VLM weights classified: {} language tensors, {} visual tensors",
+            vlm.language_tensor_count(),
+            vlm.visual_tensor_count()
+        );
+        let expert = planner_dir
+            .map(|dir| -> Result<QwenDriveExpertWeights> {
+                let (tensors, _meta) = apxinf_loader::safetensors::load_native_path(dir)
+                    .map_err(|e| Error::Other(format!("qwen_drive: load planner weights: {e}")))?;
+                QwenDriveExpertWeights::from_map(&config, &tensors)
+            })
+            .transpose()?;
+        let weights = QwenDriveDeviceWeights::from_maps(&config, vlm, expert, &*backend)?;
+        eprintln!(
+            "[qwen_drive] device weights resident (planner={}); allocating caches",
+            weights.expert.is_some()
+        );
+        let max_seq_len = config.text.max_position_embeddings.min(16384); // FIX (implement_r5): 8192 < measured 10457-token VQA prompt (12x868 image tokens + text); 16384 covers the post-clamp-revert worst case 10457+2048=12505 under the config ceiling 32768 (+256MiB full-attn KV cache).
+        let caches = Self::fresh_caches(&config, &cuda, max_seq_len)?;
+        Ok(Self {
+            config,
+            backend,
+            cuda,
+            weights,
+            caches,
+            cache_len: 0,
+            rope_delta: 0,
+            max_seq_len,
+            last_position: 0,
+        })
+    }
+
+    fn fresh_caches(
+        config: &QwenDriveConfig,
+        cuda: &RuntimeBackend,
+        max_seq_len: usize,
+    ) -> Result<Vec<LayerCache>> {
+        let text = &config.text;
+        let device = cuda.device_id();
+        let mut caches = Vec::with_capacity(text.n_layers);
+        for index in 0..text.n_layers {
+            if text.is_full_attention(index) {
+                let bytes = max_seq_len * text.n_kv_heads * text.head_dim * DType::BF16.size_in_bytes();
+                let k = DeviceBuffer::alloc_zeros(bytes, device).map_err(Error::Cuda)?;
+                let v = DeviceBuffer::alloc_zeros(bytes, device).map_err(Error::Cuda)?;
+                let shape = Shape::new(vec![max_seq_len, text.n_kv_heads, text.head_dim]);
+                caches.push(LayerCache::FullAttention {
+                    k: k.as_tensor(shape.clone(), DType::BF16).map_err(Error::Cuda)?,
+                    v: v.as_tensor(shape, DType::BF16).map_err(Error::Cuda)?,
+                });
+            } else {
+                let conv_dim = 2 * text.linear_num_key_heads * text.linear_key_head_dim
+                    + text.linear_num_value_heads * text.linear_value_head_dim;
+                let conv_bytes = conv_dim * text.linear_conv_kernel_dim * DType::BF16.size_in_bytes();
+                let conv_shape = Shape::new(vec![conv_dim, text.linear_conv_kernel_dim]);
+                let conv_a = DeviceBuffer::alloc_zeros(conv_bytes, device).map_err(Error::Cuda)?;
+                let conv_b = DeviceBuffer::alloc_zeros(conv_bytes, device).map_err(Error::Cuda)?;
+                let rec_bytes = text.linear_num_value_heads
+                    * text.linear_key_head_dim
+                    * text.linear_value_head_dim
+                    * DType::F32.size_in_bytes();
+                let recurrent = DeviceBuffer::alloc_zeros(rec_bytes, device).map_err(Error::Cuda)?;
+                caches.push(LayerCache::Gdn {
+                    conv_state_a: conv_a
+                        .as_tensor(conv_shape.clone(), DType::BF16)
+                        .map_err(Error::Cuda)?,
+                    conv_state_b: conv_b
+                        .as_tensor(conv_shape, DType::BF16)
+                        .map_err(Error::Cuda)?,
+                    flip: false,
+                    recurrent: recurrent
+                        .as_tensor(
+                            Shape::new(vec![
+                                text.linear_num_value_heads,
+                                text.linear_key_head_dim,
+                                text.linear_value_head_dim,
+                            ]),
+                            DType::F32,
+                        )
+                        .map_err(Error::Cuda)?,
+                });
+            }
+        }
+        Ok(caches)
+    }
+
+    fn reset_state(&mut self) -> Result<()> {
+        self.caches = Self::fresh_caches(&self.config, &self.cuda, self.max_seq_len)?;
+        self.cache_len = 0;
+        self.rope_delta = 0;
+        self.last_position = 0;
+        Ok(())
+    }
+
+    fn ctx(&self) -> &Context {
+        self.cuda.context()
+    }
+
+    pub fn device(&self) -> Device {
+        Device::Cuda(self.cuda.device_id())
+    }
+
+    pub fn has_planner(&self) -> bool {
+        self.weights.expert.is_some()
+    }
+
+    pub fn config(&self) -> &QwenDriveConfig {
+        &self.config
+    }
+
+    // ---- positions / rope tables ------------------------------------------
+
+    /// Qwen3.5 `get_rope_index`: text tokens take continuing linear
+    /// positions; image-token runs take 3D grid positions (T, H/merge,
+    /// W/merge) offset by the running position, which then advances by
+    /// `max(H, W) // merge`.
+    fn rope_index(&self, token_ids: &[u32], grid_thw: &[[u32; 3]]) -> Result<Vec<[u32; 3]>> {
+        let merge = self.config.vision.spatial_merge_size as u32;
+        let image_tok = self.config.image_token_id;
+        let mut out: Vec<[u32; 3]> = Vec::with_capacity(token_ids.len());
+        let mut grids = grid_thw.iter();
+        let mut current_pos: u32 = 0;
+        let mut index = 0usize;
+        while index < token_ids.len() {
+            if token_ids[index] == image_tok {
+                let start = index;
+                while index < token_ids.len() && token_ids[index] == image_tok {
+                    index += 1;
+                }
+                let run = index - start;
+                let grid = grids.next().ok_or_else(|| {
+                    Error::Other("qwen_drive: more image-token runs than image grids".into())
+                })?;
+                let (t, h, w) = (grid[0], grid[1] / merge, grid[2] / merge);
+                if run != (t * h * w) as usize {
+                    return Err(Error::Other(format!(
+                        "qwen_drive: image-token run of {run} != grid tokens {}",
+                        t * h * w
+                    )));
+                }
+                for ti in 0..t {
+                    for hi in 0..h {
+                        for wi in 0..w {
+                            out.push([current_pos + ti, current_pos + hi, current_pos + wi]);
+                        }
+                    }
+                }
+                current_pos += grid[1].max(grid[2]) / merge;
+            } else {
+                out.push([current_pos, current_pos, current_pos]);
+                current_pos += 1;
+                index += 1;
+            }
+        }
+        if grids.next().is_some() {
+            return Err(Error::Other(
+                "qwen_drive: more image grids than image-token runs".into(),
+            ));
+        }
+        Ok(out)
+    }
+
+    /// Interleaved mRoPE cos/sin tables for a position list, computed on the
+    /// host in fp32 and rounded to bf16 on upload (the reference's rounding).
+    fn mrope_tables(&self, positions: &[[u32; 3]]) -> Result<(Tensor, Tensor)> {
+        let rotary = self.config.text.rotary_dim();
+        let pairs = rotary / 2;
+        let theta = self.config.text.rope_theta;
+        let section = self.config.text.mrope_section;
+        let mut inv_freq = vec![0.0f32; pairs];
+        for (i, slot) in inv_freq.iter_mut().enumerate() {
+            *slot = 1.0 / theta.powf(2.0 * i as f32 / rotary as f32);
+        }
+        let mut cos = Vec::with_capacity(positions.len() * rotary);
+        let mut sin = Vec::with_capacity(positions.len() * rotary);
+        for token in positions {
+            let mut merged = vec![0.0f32; pairs];
+            for p in 0..pairs {
+                let axis = if p % 3 == 1 && p < section[1] * 3 {
+                    1
+                } else if p % 3 == 2 && p < section[2] * 3 {
+                    2
+                } else {
+                    0
+                };
+                merged[p] = token[axis] as f32 * inv_freq[p];
+            }
+            let mut cos_row = vec![0.0f32; rotary];
+            let mut sin_row = vec![0.0f32; rotary];
+            for p in 0..pairs {
+                cos_row[p] = bf16_round(merged[p].cos());
+                cos_row[pairs + p] = cos_row[p];
+                sin_row[p] = bf16_round(merged[p].sin());
+                sin_row[pairs + p] = sin_row[p];
+            }
+            cos.extend_from_slice(&cos_row);
+            sin.extend_from_slice(&sin_row);
+        }
+        let ctx = self.ctx();
+        let cos_t = {
+            let rounded: Vec<half::bf16> = cos.iter().map(|&v| half::bf16::from_f32(v)).collect();
+            transfers::to_cuda(&Tensor::from_bf16(vec![positions.len(), rotary], &rounded)?, ctx.device_id())?
+        };
+        let sin_t = {
+            let rounded: Vec<half::bf16> = sin.iter().map(|&v| half::bf16::from_f32(v)).collect();
+            transfers::to_cuda(&Tensor::from_bf16(vec![positions.len(), rotary], &rounded)?, ctx.device_id())?
+        };
+        Ok((cos_t, sin_t))
+    }
+
+    // ---- text stack --------------------------------------------------------
+
+    fn lm_head(&self, x: &Tensor) -> Result<Tensor> {
+        let ctx = self.ctx();
+        let (m, k) = {
+            let dims = x.shape().dims();
+            if dims.len() != 2 {
+                return Err(Error::Other("qwen_drive: lm_head input must be 2D".into()));
+            }
+            (dims[0], dims[1])
+        };
+        let vocab = self.config.text.vocab_size;
+        let out = device_tensor(ctx, &[m, vocab], DType::BF16)?;
+        let a = DeviceBuffer::from_tensor(x).map_err(Error::Cuda)?;
+        let b = DeviceBuffer::from_tensor(&self.weights.embed_tokens).map_err(Error::Cuda)?;
+        let c = DeviceBuffer::from_tensor(&out).map_err(Error::Cuda)?;
+        gemm::write_ex(
+            ctx,
+            DType::BF16,
+            CublasTranspose::None,
+            CublasTranspose::Transpose,
+            m,
+            vocab,
+            k,
+            1.0,
+            &a,
+            k as i32,
+            &b,
+            k as i32,
+            0.0,
+            &c,
+            vocab as i32,
+        )?;
+        Ok(out)
+    }
+
+    fn forward_mlp(&self, x: Tensor, post_norm: &Tensor, gate_up_w: &Tensor, down_w: &Tensor) -> Result<Tensor> {
+        let ctx = self.ctx();
+        let eps = self.config.text.rms_norm_eps;
+        let normed = la::rms_norm_plus1(ctx, &x, post_norm, eps)?;
+        let gu = gemm::matmul(ctx, &normed, gate_up_w)?;
+        let act = activation::swiglu_bf16(ctx, &gu)?;
+        let down = gemm::matmul(ctx, &act, down_w)?;
+        elementwise::add(ctx, &x, &down)
+    }
+
+    fn forward_full_attention(
+        &mut self,
+        x: Tensor,
+        layer_idx: usize,
+        cos: &Tensor,
+        sin: &Tensor,
+        seq: usize,
+    ) -> Result<Tensor> {
+        let cuda = Arc::clone(&self.cuda);
+        let ctx = cuda.context();
+        let text = &self.config.text;
+        let w = match &self.weights.layers[layer_idx] {
+            MixerWeights::FullAttention(w) => w,
+            _ => return Err(Error::Other("qwen_drive: layer kind mismatch".into())),
+        };
+        let eps = text.rms_norm_eps;
+        let heads = text.n_heads;
+        let kv_heads = text.n_kv_heads;
+        let head_dim = text.head_dim;
+        let rotary = text.rotary_dim();
+        let normed = la::rms_norm_plus1(ctx, &x, &w.input_norm, eps)?;
+        let fused = gemm::matmul(ctx, &normed, &w.qkv_w)?;
+        let q_out = device_tensor(ctx, &[seq, heads, head_dim], DType::BF16)?;
+        let (k_cache, v_cache) = match &self.caches[layer_idx] {
+            LayerCache::FullAttention { k, v } => (k.clone(), v.clone()),
+            _ => return Err(Error::Other("qwen_drive: cache kind mismatch".into())),
+        };
+        la::full_attn_prepare(
+            ctx,
+            &fused,
+            &w.q_norm,
+            &w.k_norm,
+            cos,
+            sin,
+            &q_out,
+            &k_cache,
+            &v_cache,
+            self.cache_len,
+            heads,
+            kv_heads,
+            head_dim,
+            rotary,
+            eps,
+        )?;
+        let kv_len = self.cache_len + seq;
+        let k_view = cache_view(&k_cache, kv_len)?;
+        let v_view = cache_view(&v_cache, kv_len)?;
+        let attn = attention::causal_gqa_bf16(ctx, &q_out, &k_view, &v_view, kv_len)?;
+        let attn = attn.reshape(vec![seq, heads * head_dim])?;
+        la::sigmoid_gate_mul(ctx, &attn, &fused, heads, head_dim)?;
+        let proj = gemm::matmul(ctx, &attn, &w.o_w)?;
+        let hidden = elementwise::add(ctx, &x, &proj)?;
+        self.forward_mlp(hidden, &w.post_norm, &w.gate_up_w, &w.down_w)
+    }
+
+    fn forward_gdn(
+        &mut self,
+        x: Tensor,
+        layer_idx: usize,
+        seq: usize,
+    ) -> Result<Tensor> {
+        let cuda = Arc::clone(&self.cuda);
+        let ctx = cuda.context();
+        let text = &self.config.text;
+        let w = match &self.weights.layers[layer_idx] {
+            MixerWeights::Gdn(w) => w,
+            _ => return Err(Error::Other("qwen_drive: layer kind mismatch".into())),
+        };
+        let eps = text.rms_norm_eps;
+        let num_k_heads = text.linear_num_key_heads;
+        let num_v_heads = text.linear_num_value_heads;
+        let head_k = text.linear_key_head_dim;
+        let head_v = text.linear_value_head_dim;
+        let key_dim = num_k_heads * head_k;
+        let value_dim = num_v_heads * head_v;
+        let conv_dim = 2 * key_dim + value_dim;
+        let z_col = conv_dim;
+        let b_col = conv_dim + value_dim;
+        let a_col = b_col + num_v_heads;
+        let kernel = text.linear_conv_kernel_dim;
+        let has_state = self.cache_len > 0;
+
+        let normed = la::rms_norm_plus1(ctx, &x, &w.input_norm, eps)?;
+        let zba = gemm::matmul(ctx, &normed, &w.qkvzba_w)?;
+        let conv_out = device_tensor(ctx, &[seq, conv_dim], DType::BF16)?;
+        let (state_current, state_next) = match &self.caches[layer_idx] {
+            LayerCache::Gdn { conv_state_a, conv_state_b, flip, .. } => {
+                if *flip {
+                    (conv_state_b.clone(), conv_state_a.clone())
+                } else {
+                    (conv_state_a.clone(), conv_state_b.clone())
+                }
+            }
+            _ => return Err(Error::Other("qwen_drive: cache kind mismatch".into())),
+        };
+        la::causal_conv1d_silu_bf16(
+            ctx,
+            &zba,
+            &w.conv_w,
+            if has_state { Some(&state_current) } else { None },
+            &conv_out,
+            &state_next,
+            kernel,
+        )?;
+        if let LayerCache::Gdn { flip, .. } = &mut self.caches[layer_idx] {
+            *flip = !*flip;
+        }
+
+        let recurrent_decode = has_state && seq == 1;
+        let seq_pad = if recurrent_decode { 1 } else { seq.div_ceil(GDN_CHUNK) * GDN_CHUNK };
+        let q_buf = alloc_zeros(ctx, num_v_heads * seq_pad * head_k * DType::F32.size_in_bytes())?;
+        let k_buf = alloc_zeros(ctx, num_v_heads * seq_pad * head_k * DType::F32.size_in_bytes())?;
+        let v_buf = alloc_zeros(ctx, num_v_heads * seq_pad * head_v * DType::F32.size_in_bytes())?;
+        let beta_buf = alloc_zeros(ctx, num_v_heads * seq_pad * DType::F32.size_in_bytes())?;
+        let g_buf = alloc_zeros(ctx, num_v_heads * seq_pad * DType::F32.size_in_bytes())?;
+        la::gdn_qk_prep(ctx, &conv_out, &q_buf, &k_buf, seq_pad, num_k_heads, num_v_heads, head_k, key_dim, 1e-6)?;
+        la::gdn_vb_prep(
+            ctx,
+            &conv_out,
+            &zba,
+            b_col,
+            a_col,
+            &w.dt_bias,
+            &w.a_log,
+            &v_buf,
+            &beta_buf,
+            &g_buf,
+            seq_pad,
+            num_v_heads,
+            head_v,
+            2 * key_dim,
+        )?;
+        let gdn_out = device_tensor(ctx, &[seq, value_dim], DType::BF16)?;
+        let rec_state = match &self.caches[layer_idx] {
+            LayerCache::Gdn { recurrent, .. } => recurrent.clone(),
+            _ => return Err(Error::Other("qwen_drive: cache kind mismatch".into())),
+        };
+        let rec_buf = DeviceBuffer::from_tensor(&rec_state).map_err(Error::Cuda)?;
+        if recurrent_decode {
+            la::gdn_recurrent(
+                ctx,
+                &q_buf,
+                &k_buf,
+                &v_buf,
+                &beta_buf,
+                &g_buf,
+                &rec_buf,
+                &gdn_out,
+                num_v_heads,
+                head_k,
+                head_v,
+            )?;
+        } else {
+            let chunks = seq_pad / GDN_CHUNK;
+            let g_cum = alloc_zeros(ctx, num_v_heads * seq_pad * DType::F32.size_in_bytes())?;
+            let a_buf = alloc_zeros(ctx, num_v_heads * chunks * GDN_CHUNK * GDN_CHUNK * DType::F32.size_in_bytes())?;
+            let t_buf = alloc_zeros(ctx, num_v_heads * chunks * GDN_CHUNK * GDN_CHUNK * DType::F32.size_in_bytes())?;
+            let vt_buf = alloc_zeros(ctx, num_v_heads * chunks * GDN_CHUNK * head_v * DType::F32.size_in_bytes())?;
+            let kcd_buf = alloc_zeros(ctx, num_v_heads * chunks * GDN_CHUNK * head_k * DType::F32.size_in_bytes())?;
+            la::gdn_cumsum(ctx, &g_buf, &g_cum, seq_pad, num_v_heads, GDN_CHUNK)?;
+            la::gdn_attn_raw(ctx, &q_buf, &k_buf, &beta_buf, &g_cum, &a_buf, &t_buf, seq_pad, num_v_heads, head_k, GDN_CHUNK)?;
+            la::gdn_tri_solve(ctx, &a_buf, num_v_heads * chunks, GDN_CHUNK)?;
+            la::gdn_chunk_gemm(ctx, &a_buf, &v_buf, &k_buf, &beta_buf, &g_cum, &vt_buf, &kcd_buf, seq_pad, num_v_heads, head_k, head_v, GDN_CHUNK)?;
+            la::gdn_chunk_state(
+                ctx,
+                &q_buf,
+                &k_buf,
+                &g_cum,
+                &t_buf,
+                &vt_buf,
+                &kcd_buf,
+                &rec_buf,
+                &gdn_out,
+                seq_pad,
+                num_v_heads,
+                head_k,
+                head_v,
+                GDN_CHUNK,
+            )?;
+        }
+        let gated = la::gated_rms_silu(
+            ctx,
+            &gdn_out.reshape(vec![seq * num_v_heads, head_v])?,
+            &zba,
+            z_col,
+            num_v_heads,
+            &w.gated_norm,
+            1e-6,
+        )?;
+        let gated = gated.reshape(vec![seq, value_dim])?;
+        let proj = gemm::matmul(ctx, &gated, &w.out_w)?;
+        let hidden = elementwise::add(ctx, &x, &proj)?;
+        self.forward_mlp(hidden, &w.post_norm, &w.gate_up_w, &w.down_w)
+    }
+
+    /// Run the text transformer over one token span, appending to the hybrid
+    /// cache. `positions` is the per-token mRoPE position triple.
+    fn run_text(&mut self, x: Tensor, positions: &[[u32; 3]]) -> Result<Tensor> {
+        let seq = positions.len();
+        if seq == 0 {
+            return Err(Error::Other("qwen_drive: empty forward span".into()));
+        }
+        let last = positions[seq - 1];
+        self.last_position = last[0].max(last[1]).max(last[2]) as i64;
+        let (cos, sin) = self.mrope_tables(positions)?;
+        let mut hidden = x;
+        for layer_idx in 0..self.config.text.n_layers {
+            let is_full = matches!(
+                &self.weights.layers[layer_idx],
+                MixerWeights::FullAttention(_)
+            );
+            // TEMP-DIAG (implement_r2): per-layer prefill heartbeat; the last printed k names the hanging layer; revert in the acceptance-bound revision.
+            eprintln!("[qwen_drive] prefill_layer k={} kind={}", layer_idx, if is_full { "full" } else { "gdn" });
+            hidden = if is_full {
+                self.forward_full_attention(hidden, layer_idx, &cos, &sin, seq)?
+            } else {
+                self.forward_gdn(hidden, layer_idx, seq)?
+            };
+        }
+        self.cache_len += seq;
+        let normed = la::rms_norm_plus1(self.ctx(), &hidden, &self.weights.final_norm, self.config.text.rms_norm_eps)?;
+        self.lm_head(&normed)
+    }
+
+    fn embed_tokens(&self, token_ids: &[u32]) -> Result<Tensor> {
+        let ids = upload_u32(self.ctx(), token_ids)?;
+        embedding::lookup_bf16(self.ctx(), &self.weights.embed_tokens, &ids, token_ids.len())
+    }
+
+    fn upload_pixels(&self, pixels: &Tensor) -> Result<Tensor> {
+        let ctx = self.ctx();
+        let on_device = if pixels.device() != Device::Cuda(ctx.device_id()) {
+            transfers::to_cuda(pixels, ctx.device_id())?
+        } else {
+            pixels.clone()
+        };
+        match on_device.dtype() {
+            DType::BF16 => Ok(on_device),
+            DType::F32 => {
+                let dims = on_device.shape().dims().to_vec();
+                let out = device_tensor(ctx, &dims, DType::BF16)?;
+                la::cast_f32_to_bf16(ctx, &on_device, &out)?;
+                Ok(out)
+            }
+            dtype => Err(Error::Other(format!(
+                "qwen_drive: pixel_values must be f32 or bf16, got {dtype}"
+            ))),
+        }
+    }
+
+    /// Multimodal prefill: vision tower, image-embedding scatter, text stack.
+    fn prefill_impl(
+        &mut self,
+        token_ids: &[u32],
+        image: Option<(&Tensor, &[[u32; 3]])>,
+    ) -> Result<Tensor> {
+        if token_ids.is_empty() {
+            return Err(Error::Other("qwen_drive: empty prompt".into()));
+        }
+        if self.cache_len != 0 {
+            return Err(Error::Other(
+                "qwen_drive: prefill requires a fresh cache (call reset first)".into(),
+            ));
+        }
+        let mut x = self.embed_tokens(token_ids)?;
+        let empty_grids: &[[u32; 3]] = &[];
+        let grids = if let Some((pixels, grid_thw)) = image {
+            let pixels = self.upload_pixels(pixels)?;
+            let vis = vision::forward(&self.config, &self.weights.vision, self.ctx(), &pixels, grid_thw)?;
+            // TEMP-DIAG (implement_r2): vision-tower completion marker; revert in the acceptance-bound revision.
+            eprintln!("[qwen_drive] vision_done vision_rows={}", vis.primary.shape().dims()[0]);
+            let image_tok = self.config.image_token_id;
+            let image_positions = token_ids
+                .iter()
+                .filter(|&&token| token == image_tok)
+                .count();
+            let vision_rows = vis.primary.shape().dims()[0];
+            if image_positions != vision_rows {
+                return Err(Error::Other(format!(
+                    "qwen_drive: {image_positions} image tokens but vision produced {vision_rows} rows"
+                )));
+            }
+            let mut ordinal = 0u32;
+            let row_map: Vec<u32> = token_ids
+                .iter()
+                .map(|&token| {
+                    if token == image_tok {
+                        let row = ordinal;
+                        ordinal += 1;
+                        row
+                    } else {
+                        u32::MAX
+                    }
+                })
+                .collect();
+            let row_map_dev = upload_u32(self.ctx(), &row_map)?;
+            x = elementwise::replace_rows_bf16(self.ctx(), &x, &vis.primary, &row_map_dev)?;
+            // TEMP-DIAG (implement_r2): image-embedding scatter completion marker; revert in the acceptance-bound revision.
+            eprintln!("[qwen_drive] embed_scatter_done");
+            grid_thw
+        } else {
+            empty_grids
+        };
+        let positions = self.rope_index(token_ids, grids)?;
+        let max_pos = positions
+            .iter()
+            .map(|triple| triple[0].max(triple[1]).max(triple[2]))
+            .max()
+            .unwrap_or(0) as i64;
+        self.rope_delta = max_pos + 1 - token_ids.len() as i64;
+        if self.cache_len + token_ids.len() > self.max_seq_len {
+            return Err(Error::Other("qwen_drive: prompt exceeds the cache capacity".into()));
+        }
+        self.run_text(x, &positions)
+    }
+
+    /// Continuation/decode forward over already-tokenized ids.
+    fn forward_tokens(&mut self, token_ids: &[u32]) -> Result<Tensor> {
+        if token_ids.is_empty() {
+            return Err(Error::Other("qwen_drive: empty continuation".into()));
+        }
+        if self.cache_len + token_ids.len() > self.max_seq_len {
+            return Err(Error::Other("qwen_drive: sequence exceeds the cache capacity".into()));
+        }
+        let positions: Vec<[u32; 3]> = (0..token_ids.len())
+            .map(|i| {
+                let p = (self.cache_len + i) as i64 + self.rope_delta;
+                [p.max(0) as u32; 3]
+            })
+            .collect();
+        let x = self.embed_tokens(token_ids)?;
+        self.run_text(x, &positions)
+    }
+
+    fn scene_caches(&self) -> Result<Vec<(Tensor, Tensor)>> {
+        let mut out = Vec::new();
+        for layer_idx in self.config.text.full_attention_layers() {
+            match &self.caches[layer_idx] {
+                LayerCache::FullAttention { k, v } => {
+                    out.push((cache_view(k, self.cache_len)?, cache_view(v, self.cache_len)?));
+                }
+                _ => return Err(Error::Other("qwen_drive: cache kind mismatch".into())),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Greedy generation with optional min-new-token EOS suppression. Returns
+    /// the generated token ids (including any terminator, like HF generate).
+    pub fn generate(
+        &mut self,
+        token_ids: &[u32],
+        pixel_values: Option<(&Tensor, &[[u32; 3]])>,
+        max_new_tokens: usize,
+        min_new_tokens: usize,
+        eos_token_ids: &[u32],
+    ) -> Result<Vec<u32>> {
+        // TEMP-DIAG (implement_r2): generate() entry marker (channel vs pre-entry stall disambiguator); revert in the acceptance-bound revision.
+        eprintln!("[qwen_drive] gen_entry prompt_tokens={} has_pixels={} max_new_tokens={}", token_ids.len(), pixel_values.is_some(), max_new_tokens);
+        self.reset_state()?;
+        // TEMP-DIAG (implement_r1): generation-entry clock for prefill/decode timing; revert in the acceptance-bound revision.
+        let diag_start = std::time::Instant::now();
+        let mut sampler = self.backend.create_token_sampler(TokenSamplingSpec {
+            vocab_size: self.config.text.vocab_size,
+            max_sequence_len: token_ids.len() + max_new_tokens + 1,
+        })?;
+        sampler.begin(TokenSamplingInit {
+            prompt_token_ids: token_ids,
+            params: &TokenSamplingParams::greedy(),
+            rng: RngKey::default(),
+        })?;
+        let mut logits = self.prefill_impl(token_ids, pixel_values)?;
+        // TEMP-DIAG (implement_r1): prefill completion marker + decode heartbeat clock; revert in the acceptance-bound revision.
+        eprintln!("[qwen_drive] prefill_done prompt_tokens={} elapsed_ms={:.1}", token_ids.len(), diag_start.elapsed().as_secs_f64() * 1000.0);
+        let mut diag_last_step = std::time::Instant::now();
+        let eos_dev = upload_u32(self.ctx(), eos_token_ids)?;
+        let mut generated = Vec::new();
+        let mut diag_eos = false;
+        for step in 0..max_new_tokens {
+            if step < min_new_tokens {
+                let row = logits.shape().dims()[0] - 1;
+                la::suppress_logits(self.ctx(), &logits, row, &eos_dev)?;
+            }
+            let sample = sampler.sample(NextTokenLogits::last(&logits, self.config.text.vocab_size)?)?;
+            generated.push(sample.token_id);
+            // TEMP-DIAG (implement_r1): heartbeat at step 0 and every 25 steps; revert in the acceptance-bound revision.
+            if step % 25 == 0 {
+                eprintln!("[qwen_drive] decode_step k={} token_id={} ms_since_last={:.1}", step, sample.token_id, diag_last_step.elapsed().as_secs_f64() * 1000.0);
+                diag_last_step = std::time::Instant::now();
+            }
+            if eos_token_ids.contains(&sample.token_id) || step + 1 == max_new_tokens {
+                diag_eos = eos_token_ids.contains(&sample.token_id);
+                break;
+            }
+            logits = self.forward_tokens(&[sample.token_id])?;
+        }
+        // TEMP-DIAG (implement_r1): exit summary with the first 8 generated ids; revert in the acceptance-bound revision.
+        eprintln!("[qwen_drive] decode_exit steps={} eos={} first_ids={:?}", generated.len(), diag_eos, &generated[..generated.len().min(8)]);
+        Ok(generated)
+    }
+
+    fn require_expert(&self) -> Result<&super::device_weights::ExpertDeviceWeights> {
+        self.weights.expert.as_ref().ok_or_else(|| {
+            Error::Other(
+                "qwen_drive: no planning expert loaded; pass a planner directory at load".into(),
+            )
+        })
+    }
+
+    /// Direct planning: prefill the closed-empty-assistant prompt and run the
+    /// flow-matching sampler against its scene caches.
+    pub fn plan_direct(
+        &mut self,
+        token_ids: &[u32],
+        pixel_values: &Tensor,
+        grid_thw: &[[u32; 3]],
+        cond: &ExpertConditioning,
+        noise: &[f32],
+        num_steps: Option<usize>,
+    ) -> Result<Vec<f32>> {
+        self.reset_state()?;
+        self.prefill_impl(token_ids, Some((pixel_values, grid_thw)))?;
+        let anchor = self.last_position;
+        let scene = self.scene_caches()?;
+        let weights = self.require_expert()?;
+        expert::plan(
+            &self.config,
+            weights,
+            self.ctx(),
+            &ExpertPlan {
+                scene: &scene,
+                scene_len: self.cache_len,
+                anchor,
+                cond,
+                noise,
+                num_steps: num_steps.unwrap_or(self.config.num_inference_steps),
+            },
+        )
+    }
+
+    /// Reasoning planning: greedy assistant turn with min/max token bounds,
+    /// cache completion to the trained turn ending, then the sampler. Returns
+    /// `(generated_token_ids, normalized_trajectory)`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_reasoning(
+        &mut self,
+        token_ids: &[u32],
+        pixel_values: &Tensor,
+        grid_thw: &[[u32; 3]],
+        max_new_tokens: usize,
+        min_new_tokens: usize,
+        terminator_ids: &[u32],
+        im_end_id: u32,
+        newline_ids: &[u32],
+        cond: &ExpertConditioning,
+        noise: &[f32],
+        num_steps: Option<usize>,
+    ) -> Result<(Vec<u32>, Vec<f32>)> {
+        self.reset_state()?;
+        let mut sampler = self.backend.create_token_sampler(TokenSamplingSpec {
+            vocab_size: self.config.text.vocab_size,
+            max_sequence_len: token_ids.len() + max_new_tokens + 1,
+        })?;
+        sampler.begin(TokenSamplingInit {
+            prompt_token_ids: token_ids,
+            params: &TokenSamplingParams::greedy(),
+            rng: RngKey::default(),
+        })?;
+        let mut logits = self.prefill_impl(token_ids, Some((pixel_values, grid_thw)))?;
+        let prompt_anchor = self.last_position;
+        let eos_dev = upload_u32(self.ctx(), terminator_ids)?;
+        let mut generated: Vec<u32> = Vec::new();
+        for step in 0..max_new_tokens {
+            if step < min_new_tokens {
+                let row = logits.shape().dims()[0] - 1;
+                la::suppress_logits(self.ctx(), &logits, row, &eos_dev)?;
+            }
+            let sample = sampler.sample(NextTokenLogits::last(&logits, self.config.text.vocab_size)?)?;
+            generated.push(sample.token_id);
+            if terminator_ids.contains(&sample.token_id) || step + 1 == max_new_tokens {
+                break;
+            }
+            logits = self.forward_tokens(&[sample.token_id])?;
+        }
+        // Close the turn in the cache exactly like the reference.
+        let mut content = generated.clone();
+        for (position, token) in generated.iter().enumerate() {
+            if terminator_ids.contains(token) {
+                content.truncate(position);
+                break;
+            }
+        }
+        let mut closed_turn = content;
+        closed_turn.push(im_end_id);
+        closed_turn.extend_from_slice(newline_ids);
+        let already_cached = generated.len().saturating_sub(1);
+        if already_cached < closed_turn.len() {
+            let pending = closed_turn[already_cached..].to_vec();
+            self.forward_tokens(&pending)?;
+        }
+        let anchor = prompt_anchor + closed_turn.len() as i64;
+        let scene = self.scene_caches()?;
+        let weights = self.require_expert()?;
+        let trajectory = expert::plan(
+            &self.config,
+            weights,
+            self.ctx(),
+            &ExpertPlan {
+                scene: &scene,
+                scene_len: self.cache_len,
+                anchor,
+                cond,
+                noise,
+                num_steps: num_steps.unwrap_or(self.config.num_inference_steps),
+            },
+        )?;
+        Ok((generated, trajectory))
+    }
+}
+
+impl LlmTrait for QwenDriveModel {
+    fn load(
+        _config: ModelConfig,
+        _weights: HashMap<String, Tensor>,
+        _device: Device,
+    ) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Err(Error::Other(
+            "QwenDriveModel::load(ModelConfig) is not supported; use \
+             QwenDriveModel::load(dir, planner, device) or the registry loader"
+                .into(),
+        ))
+    }
+
+    /// Token-level forward over the internal hybrid cache. `start_pos` is
+    /// advisory: positions derive from the model-owned cache length plus the
+    /// multimodal rope delta, matching the shared generation loop's usage.
+    fn forward(&mut self, token_ids: &[u32], _start_pos: u32) -> Result<Tensor> {
+        self.forward_tokens(token_ids)
+    }
+
+    fn backend(&self) -> &dyn Backend {
+        &*self.backend
+    }
+
+    fn capabilities(&self) -> LlmCapabilities {
+        LlmCapabilities::VISION
+    }
+
+    fn prefill(&mut self, input: LlmInput<'_>) -> Result<Tensor> {
+        self.reset_state()?;
+        match input.image {
+            Some(image) => self.prefill_impl(input.token_ids, Some((image.pixel_values, image.grid_thw))),
+            None => self.prefill_impl(input.token_ids, None),
+        }
+    }
+
+    fn reset(&mut self) {
+        let _ = self.reset_state();
+    }
+
+    fn vocab_size(&self) -> usize {
+        self.config.text.vocab_size
+    }
+}

--- a/crates/apxinf-model/src/qwen_drive/mod.rs
+++ b/crates/apxinf-model/src/qwen_drive/mod.rs
@@ -1,24 +1,46 @@
 //! Qwen-Drive-1.0 model family: checkpoint configuration, weight mapping,
-//! and the planning-expert executor.
+//! the native CUDA VLM executor, and the planning-expert device executor.
 //!
 //! Model family isolation: every Qwen-Drive-specific type lives behind this
-//! module; nothing here is mixed into the generic llama / qwen3vl paths.
+//! module; nothing here is mixed into the generic llama / qwen3vl / pi05
+//! paths.
 //!
 //! Device status (honest accounting):
 //!
-//! * `planner` is an explicitly host-side f32 correctness scaffold (bf16
-//!   rounding at the reference's semantic rounding sites), not native GPU
-//!   deployment; its device exit criterion is the CUDA executor gate from the
-//!   execution ledger.
-//! * The VLM scene-cache producer is pending reference qualification, so
-//!   end-to-end planning activates only when both halves land.
+//! * `general` is the native CUDA VLM: hybrid gated-delta (linear attention)
+//!   and gated full-attention layers with partial interleaved mRoPE, a ViT
+//!   vision tower, the LlmTrait surface, and the VQA / direct-planning /
+//!   reasoning-planning flows. All layer mathematics run on device through
+//!   the model-neutral kernel facade plus the new linear-attention operators.
+//! * `expert` is the native CUDA planning-expert executor (flow matching,
+//!   adaLN, joint attention over the VLM's exported post-rotary scene caches).
+//! * `planner` is the retained CPU f32 correctness scaffold from the saved K3
+//!   base; it is the replay oracle for the device executor, not a deployment
+//!   path.
+//! * Perception (BEV stack) is a declared pending gap: it needs the conv2d /
+//!   conv3d / GroupNorm / grid_sample / deformable-attention / voxel-pool
+//!   kernel families, which are not in this revision (see the execution
+//!   ledger in the implementation artifact).
 
 pub mod config;
 pub mod planner;
 pub mod weights;
+
+#[cfg(feature = "cuda")]
+pub mod backend;
+#[cfg(feature = "cuda")]
+pub mod device_weights;
+#[cfg(feature = "cuda")]
+pub mod expert;
+#[cfg(feature = "cuda")]
+pub mod general;
+#[cfg(feature = "cuda")]
+pub mod vision;
 
 pub use config::{
     PlanningExpertConfig, QwenDriveConfig, QwenDriveTextConfig, QwenDriveVisionConfig,
 };
 pub use planner::{ExpertConditioning, PlanningExpertModel, SceneCache};
 pub use weights::{QwenDriveExpertWeights, QwenDriveVlmWeights};
+#[cfg(feature = "cuda")]
+pub use general::QwenDriveModel;

--- a/crates/apxinf-model/src/qwen_drive/mod.rs
+++ b/crates/apxinf-model/src/qwen_drive/mod.rs
@@ -1,0 +1,24 @@
+//! Qwen-Drive-1.0 model family: checkpoint configuration, weight mapping,
+//! and the planning-expert executor.
+//!
+//! Model family isolation: every Qwen-Drive-specific type lives behind this
+//! module; nothing here is mixed into the generic llama / qwen3vl paths.
+//!
+//! Device status (honest accounting):
+//!
+//! * `planner` is an explicitly host-side f32 correctness scaffold (bf16
+//!   rounding at the reference's semantic rounding sites), not native GPU
+//!   deployment; its device exit criterion is the CUDA executor gate from the
+//!   execution ledger.
+//! * The VLM scene-cache producer is pending reference qualification, so
+//!   end-to-end planning activates only when both halves land.
+
+pub mod config;
+pub mod planner;
+pub mod weights;
+
+pub use config::{
+    PlanningExpertConfig, QwenDriveConfig, QwenDriveTextConfig, QwenDriveVisionConfig,
+};
+pub use planner::{ExpertConditioning, PlanningExpertModel, SceneCache};
+pub use weights::{QwenDriveExpertWeights, QwenDriveVlmWeights};

--- a/crates/apxinf-model/src/qwen_drive/planner.rs
+++ b/crates/apxinf-model/src/qwen_drive/planner.rs
@@ -1,0 +1,848 @@
+//! Planning Expert executor: the flow-matching diffusion transformer that
+//! turns VLM scene caches into waypoints.
+//!
+//! The mathematics here are a line-level port of the pinned reference
+//! (`src/qwen_drive/planning_expert.py`, revision 28091c1):
+//!
+//! * joint attention: every layer attends over
+//!   `concat(scene_K_from_VLM, waypoint_K)` (same for V), non-causal, GQA
+//!   with 4 KV heads and a per-head sigmoid output gate;
+//! * adaLN conditioning: `condition = time_mlp(t) + nav_mlp + ego_mlp`,
+//!   modulated as `norm(x) * (1 + scale) + shift` and
+//!   `residual + (1 + gate) * proj(...)`;
+//! * waypoint queries fuse 7 signals (noisy waypoint, Fourier features, flow
+//!   time, history poses, waypoint-index embedding, history velocity, history
+//!   acceleration);
+//! * partial interleaved mRoPE at positions `anchor + 1 ..= anchor + 50`,
+//!   with the reference's bfloat16-rounded inverse-frequency table AND
+//!   bfloat16-rounded positions (rounding above position 256 is semantic);
+//! * the Fourier frequency table is likewise rebuilt in bf16 every call.
+//!
+//! ## Device status (honest accounting)
+//!
+//! This executor currently computes `predict_endpoint` on the host in f32
+//! with bf16-rounded inputs, as the named correctness scaffold for the CUDA
+//! port. It is numerically structured (every op is a pure function of the
+//! same tensors the reference multiplies on GPU) but it is not bit-exact
+//! bf16 arithmetic: the reference accumulates GEMMs in f32 and rounds on
+//! store, which this scaffold does not reproduce. The device replacement
+//! plan is the execution ledger L-10..L-17 (safe bf16 GEMM composition, the
+//! L-12 QKV split, the L-13 bf16 rope table, the L-14 joint-attention
+//! wrapper), landing with the CUDA executor gate. The VLM scene-cache source
+//! is likewise pending (see `mod.rs`), so end-to-end planning activates when
+//! both halves land. Nothing here fabricates a trajectory.
+
+use apxinf_core::{Error, Result, Tensor};
+
+use super::config::{PlanningExpertConfig, QwenDriveConfig};
+use super::weights::QwenDriveExpertWeights;
+
+/// Post-rotary scene K/V exported by the VLM, one entry per expert KV source
+/// (8 for the 32-layer expert with `layers_per_kv = 4`). Each entry is the
+/// `[seq, kv_heads, head_dim]` cache of one VLM full-attention layer.
+pub struct SceneCache {
+    pub keys: Vec<Tensor>,
+    pub values: Vec<Tensor>,
+}
+
+/// Conditioning that the processor produces once per planning request.
+pub struct ExpertConditioning {
+    /// Normalized history poses re-referenced to the oldest pose, flattened
+    /// `[num_history_points - 1, 3]` (the dropped origin row is implied).
+    pub history: Vec<f32>,
+    /// Raw history velocity `[num_history_points, 2]`, flattened.
+    pub history_velocity: Vec<f32>,
+    /// Raw history acceleration `[num_history_points, 2]`, flattened.
+    pub history_acceleration: Vec<f32>,
+    /// Navigation command index; out-of-range maps to an all-zero one-hot,
+    /// exactly like the reference `_one_hot`.
+    pub nav_command: i64,
+    /// `[ego_status_dim]` velocity + acceleration + one-hot driving command.
+    pub ego_status: Vec<f32>,
+}
+
+impl ExpertConditioning {
+    pub fn validate(&self, config: &QwenDriveConfig) -> Result<()> {
+        let poses = (config.num_history_points - 1) * config.trajectory_point_dim;
+        if self.history.len() != poses {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: history has {} values, expected {poses}",
+                self.history.len()
+            )));
+        }
+        let dynamics = config.num_history_points * config.expert.history_dynamics_dim;
+        if self.history_velocity.len() != dynamics {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: history_velocity has {} values, expected {dynamics}",
+                self.history_velocity.len()
+            )));
+        }
+        if self.history_acceleration.len() != dynamics {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: history_acceleration has {} values, expected {dynamics}",
+                self.history_acceleration.len()
+            )));
+        }
+        if self.ego_status.len() != config.expert.ego_status_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: ego_status has {} values, expected {}",
+                self.ego_status.len(),
+                config.expert.ego_status_dim
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// The planning expert with host-mirrored f32 copies of its bf16 weights.
+///
+/// Weight tensors are cloned to host f32 once at load: the scaffold executor
+/// runs on the host, and the future device executor will upload the same
+/// transposed tensors. `weights` is retained so both paths share one store.
+pub struct PlanningExpertModel {
+    config: PlanningExpertConfig,
+    num_future_points: usize,
+    trajectory_point_dim: usize,
+    weights: QwenDriveExpertWeights,
+}
+
+/// bf16 rounding of one f32 value, returned as f32 (the value a bf16 tensor
+/// would hold). Central so every semantic rounding site is greppable.
+fn bf16_round(value: f32) -> f32 {
+    half::bf16::from_f32(value).to_f32()
+}
+
+/// Sinusoidal time embedding (dim 128, scale 1000) computed in f32 with the
+/// output rounded to bf16 (the reference casts the table to the module dtype
+/// before the time MLP). decay = ln(10000) / (half - 1).
+fn time_embedding(dim: usize, scale: f32, t: f32) -> Vec<f32> {
+    let half = dim / 2;
+    let decay = (10000.0f64).ln() as f32 / (half.max(2) - 1) as f32;
+    let mut out = Vec::with_capacity(dim);
+    for i in 0..half {
+        let freq = (-(i as f32) * decay).exp();
+        out.push(bf16_round((scale * t * freq).sin()));
+    }
+    for i in 0..half {
+        let freq = (-(i as f32) * decay).exp();
+        out.push(bf16_round((scale * t * freq).cos()));
+    }
+    out
+}
+
+impl PlanningExpertModel {
+    pub fn new(config: &QwenDriveConfig, weights: QwenDriveExpertWeights) -> Result<Self> {
+        let expert = config.expert.clone();
+        expert.validate()?;
+        let model = Self {
+            config: expert,
+            num_future_points: config.num_future_points,
+            trajectory_point_dim: config.trajectory_point_dim,
+            weights,
+        };
+        Ok(model)
+    }
+
+    pub fn num_kv_sources(&self) -> usize {
+        self.config.num_kv_sources()
+    }
+
+    // ---- host scalar helpers (scaffold arithmetic) ---------------------
+
+    fn tensor_f32(tensor: &Tensor, name: &str) -> Result<Vec<f32>> {
+        tensor
+            .to_f32_vec()
+            .map_err(|e| Error::Other(format!("qwen_drive planner: {name} to f32: {e}")))
+    }
+
+    /// RMSNorm over the last axis, computed in f32 like the reference's
+    /// `RMSNorm.forward` (x.float() ... .to(dtype)); the result is rounded to
+    /// bf16 to mirror storing back into the bf16 activation stream.
+    fn rms_norm(x: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>> {
+        let hidden = weight.len();
+        if hidden == 0 || x.len() % hidden != 0 {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: rms_norm got {} values for hidden {hidden}",
+                x.len()
+            )));
+        }
+        let mut out = vec![0.0f32; x.len()];
+        for (row, chunk) in x.chunks(hidden).enumerate() {
+            let mean_sq = chunk.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+            let inv = 1.0f32 / (mean_sq + eps).sqrt();
+            for (c, value) in chunk.iter().enumerate() {
+                out[row * hidden + c] = bf16_round(value * inv * weight[c]);
+            }
+        }
+        Ok(out)
+    }
+
+    /// y = x @ w + b over `[rows, in] * [in, out]`; f32 accumulation (the
+    /// reference's cuBLAS bf16 GEMM also accumulates in f32) with the output
+    /// rounded to bf16 on store.
+    fn linear(x: &[f32], rows: usize, w: &[f32], b: Option<&[f32]>, in_dim: usize, out_dim: usize) -> Result<Vec<f32>> {
+        if x.len() != rows * in_dim || w.len() != in_dim * out_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: linear shape mismatch (x {} vs {rows}x{in_dim}, w {} vs {in_dim}x{out_dim})",
+                x.len(),
+                w.len()
+            )));
+        }
+        let mut out = vec![0.0f32; rows * out_dim];
+        for r in 0..rows {
+            let xr = &x[r * in_dim..(r + 1) * in_dim];
+            for o in 0..out_dim {
+                let mut acc = 0.0f32;
+                for (i, value) in xr.iter().enumerate() {
+                    acc += value * w[i * out_dim + o];
+                }
+                if let Some(bias) = b {
+                    acc += bias[o];
+                }
+                out[r * out_dim + o] = bf16_round(acc);
+            }
+        }
+        Ok(out)
+    }
+
+    fn silu(x: &[f32]) -> Vec<f32> {
+        x.iter()
+            .map(|v| bf16_round(*v / (1.0 + (-*v).exp())))
+            .collect()
+    }
+
+    fn add(a: &[f32], b: &[f32]) -> Result<Vec<f32>> {
+        if a.len() != b.len() {
+            return Err(Error::Other("qwen_drive planner: add shape mismatch".into()));
+        }
+        Ok(a.iter().zip(b.iter()).map(|(x, y)| bf16_round(*x + *y)).collect())
+    }
+
+    /// `_mlp(in, hidden)`: Linear -> SiLU -> Linear.
+    fn mlp(x: &[f32], rows: usize, mlp: &super::weights::ExpertMlp, in_dim: usize, hidden: usize) -> Result<Vec<f32>> {
+        let fc1_w = Self::tensor_f32(&mlp.fc1_w, "mlp.fc1_w")?;
+        let fc1_b = Self::tensor_f32(&mlp.fc1_b, "mlp.fc1_b")?;
+        let fc2_w = Self::tensor_f32(&mlp.fc2_w, "mlp.fc2_w")?;
+        let fc2_b = Self::tensor_f32(&mlp.fc2_b, "mlp.fc2_b")?;
+        let h = Self::linear(x, rows, &fc1_w, Some(&fc1_b), in_dim, hidden)?;
+        let h = Self::silu(&h);
+        Self::linear(&h, rows, &fc2_w, Some(&fc2_b), hidden, hidden)
+    }
+
+    /// One-hot encode the nav command; out-of-range maps to all zeros,
+    /// matching the reference `_one_hot`.
+    fn one_hot(classes: usize, index: i64) -> Vec<f32> {
+        let mut out = vec![0.0f32; classes];
+        if index >= 0 && (index as usize) < classes {
+            out[index as usize] = 1.0;
+        }
+        out
+    }
+
+    /// Sinusoidal time embedding, matching `SinusoidalTimeEmbedding.forward`.
+    fn time_embedding(&self, t: f32) -> Vec<f32> {
+        time_embedding(self.config.time_embed_dim, self.config.time_embed_scale, t)
+    }
+
+    /// Fourier features of the noisy waypoints: per-channel logspace
+    /// frequencies built in the bf16 compute dtype (rounding is semantic),
+    /// angles in f32, sin/cos concatenated, then the encoder MLP.
+    fn fourier_features(&self, waypoints: &[f32], length: usize) -> Result<Vec<f32>> {
+        let point = self.trajectory_point_dim;
+        let features = self.config.fourier_num_features;
+        let hidden = self.config.hidden_size;
+        // torch.logspace(0, log10(max), steps=features, dtype=bf16).
+        let log_max = (self.config.fourier_max_frequency as f64).log10() as f32;
+        let mut freq = Vec::with_capacity(features);
+        for i in 0..features {
+            let exponent = if features > 1 {
+                log_max * i as f32 / (features - 1) as f32
+            } else {
+                0.0
+            };
+            freq.push(bf16_round(10f32.powf(exponent)));
+        }
+        let two_pi = 2.0 * std::f32::consts::PI;
+        let mut encoded = vec![0.0f32; length * point * features * 2];
+        for l in 0..length {
+            for c in 0..point {
+                let waypoint = waypoints[l * point + c];
+                for (f, frequency) in freq.iter().enumerate() {
+                    let angle = waypoint * frequency * two_pi;
+                    let base = ((l * point + c) * features + f) * 2;
+                    encoded[base] = bf16_round(angle.sin());
+                    encoded[base + 1] = bf16_round(angle.cos());
+                }
+            }
+        }
+        Self::mlp(
+            &encoded,
+            length,
+            &self.weights.fourier_encoder,
+            point * features * 2,
+            hidden,
+        )
+    }
+
+    /// Waypoint rope tables: positions `anchor + 1 ..= anchor + length` cast
+    /// to bf16, multiplied with the bf16-rounded inverse-frequency table, and
+    /// merged section-wise exactly like `WaypointRotaryEmbedding.forward`.
+    /// Returns `(cos, sin)`, each `[length, rotary_dim]` in f32 (bf16-rounded).
+    fn waypoint_rope_tables(&self, anchor: i64, length: usize) -> Result<(Vec<f32>, Vec<f32>)> {
+        let rotary_dim = self.config.rotary_dim();
+        let pairs = rotary_dim / 2;
+        let theta = self.config.rope_theta;
+        // inv_freq = 1 / theta^(arange(0, dim, 2) / dim), rounded to bf16.
+        let mut inv_freq = Vec::with_capacity(pairs);
+        for i in 0..pairs {
+            let exponent = (2 * i) as f32 / rotary_dim as f32;
+            inv_freq.push(bf16_round(1.0 / theta.powf(exponent)));
+        }
+        let mut angles = vec![[0.0f32; 3].map(|_| vec![0.0f32; pairs]); length];
+        let mut cos = vec![0.0f32; length * rotary_dim];
+        let mut sin = vec![0.0f32; length * rotary_dim];
+        for l in 0..length {
+            // The position is the same scalar on all three mRoPE sections
+            // (the anchor is a text token), rounded to bf16 as training did.
+            let position = bf16_round((anchor + 1 + l as i64) as f32);
+            for p in 0..pairs {
+                let angle = bf16_round(position * inv_freq[p]);
+                for section in &mut angles[l] {
+                    section[p] = angle;
+                }
+            }
+            // Section merge: pair p takes section s = p % 3 at indices
+            // offset..length*3 step 3, exactly the reference slice semantics.
+            let mut merged = angles[l][0].clone();
+            let mut offset = 1usize;
+            for (section_index, section_length) in self.config.mrope_section.iter().enumerate().skip(1) {
+                let mut p = offset;
+                let mut taken = 0usize;
+                while p < pairs && taken < *section_length {
+                    merged[p] = angles[l][section_index][p];
+                    taken += 1;
+                    p += 3;
+                }
+                offset += 1;
+            }
+            for p in 0..pairs {
+                cos[l * rotary_dim + p] = bf16_round(merged[p].cos());
+                cos[l * rotary_dim + pairs + p] = cos[l * rotary_dim + p];
+                sin[l * rotary_dim + p] = bf16_round(merged[p].sin());
+                sin[l * rotary_dim + pairs + p] = sin[l * rotary_dim + p];
+            }
+        }
+        Ok((cos, sin))
+    }
+
+    /// Apply partial rotary to one `[length, heads, head_dim]` tensor: rotate
+    /// the leading `rotary_dim` channels with the bf16-rounded cos/sin table,
+    /// leave the remainder untouched (`_apply_rotary` in the reference).
+    fn apply_rotary(&self, x: &[f32], length: usize, heads: usize, cos: &[f32], sin: &[f32]) -> Result<Vec<f32>> {
+        let head_dim = self.config.head_dim;
+        let rotary_dim = self.config.rotary_dim();
+        if x.len() != length * heads * head_dim {
+            return Err(Error::Other("qwen_drive planner: rotary input shape mismatch".into()));
+        }
+        let mut out = x.to_vec();
+        let half = rotary_dim / 2;
+        for l in 0..length {
+            for h in 0..heads {
+                let base = (l * heads + h) * head_dim;
+                for p in 0..half {
+                    let first = x[base + p];
+                    let second = x[base + half + p];
+                    let c = cos[l * rotary_dim + p];
+                    let s = sin[l * rotary_dim + p];
+                    out[base + p] = bf16_round(first * c - second * s);
+                    out[base + half + p] = bf16_round(second * c + first * s);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// `encode_history`: history poses + nav one-hot, velocity, acceleration.
+    fn encode_history(&self, cond: &ExpertConditioning) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>)> {
+        let hidden = self.config.hidden_size;
+        let nav = Self::one_hot(self.config.nav_command_classes, cond.nav_command);
+        let mut history_in = cond.history.clone();
+        history_in.extend_from_slice(&nav);
+        let pose = Self::mlp(
+            &history_in,
+            1,
+            &self.weights.history_encoder,
+            history_in.len(),
+            hidden,
+        )?;
+        let velocity = Self::mlp(
+            &cond.history_velocity,
+            1,
+            &self.weights.history_velocity_encoder,
+            cond.history_velocity.len(),
+            hidden,
+        )?;
+        let acceleration = Self::mlp(
+            &cond.history_acceleration,
+            1,
+            &self.weights.history_acceleration_encoder,
+            cond.history_acceleration.len(),
+            hidden,
+        )?;
+        Ok((pose, velocity, acceleration))
+    }
+
+    /// Split one fused QKV row into (query, gate, key, value), following the
+    /// reference `_split_qkv` group-major layout. Input is the transposed
+    /// `[length, qkv_out]` projection output.
+    fn split_qkv(&self, fused: &[f32], length: usize) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>)> {
+        let heads = self.config.n_heads;
+        let groups = self.config.n_kv_heads;
+        let head_dim = self.config.head_dim;
+        let per_group = heads / groups;
+        let group_width = (per_group * 2 + 2) * head_dim;
+        if fused.len() != length * groups * group_width {
+            return Err(Error::Other("qwen_drive planner: qkv width mismatch".into()));
+        }
+        let mut query = vec![0.0f32; length * heads * head_dim];
+        let mut gate = vec![0.0f32; length * heads * head_dim];
+        let mut key = vec![0.0f32; length * groups * head_dim];
+        let mut value = vec![0.0f32; length * groups * head_dim];
+        for l in 0..length {
+            for g in 0..groups {
+                let src = (l * groups + g) * group_width;
+                for h in 0..per_group {
+                    let head = g * per_group + h;
+                    // Within a group: query heads, then their gate heads, then K, V.
+                    let q_src = src + h * head_dim;
+                    let g_src = src + (per_group + h) * head_dim;
+                    query[(l * heads + head) * head_dim..(l * heads + head + 1) * head_dim]
+                        .copy_from_slice(&fused[q_src..q_src + head_dim]);
+                    gate[(l * heads + head) * head_dim..(l * heads + head + 1) * head_dim]
+                        .copy_from_slice(&fused[g_src..g_src + head_dim]);
+                }
+                let k_src = src + per_group * 2 * head_dim;
+                let v_src = k_src + head_dim;
+                key[(l * groups + g) * head_dim..(l * groups + g + 1) * head_dim]
+                    .copy_from_slice(&fused[k_src..k_src + head_dim]);
+                value[(l * groups + g) * head_dim..(l * groups + g + 1) * head_dim]
+                    .copy_from_slice(&fused[v_src..v_src + head_dim]);
+            }
+        }
+        Ok((query, gate, key, value))
+    }
+
+    /// Non-causal GQA joint attention over `concat(scene_kv, waypoint_kv)`.
+    /// fp32 softmax (as SDPA), bf16-rounded output. Shapes: q `[length,
+    /// heads, head_dim]`; scene k/v `[scene_len, kv_heads, head_dim]`; self
+    /// k/v `[length, kv_heads, head_dim]`. Returns `[length, heads*head_dim]`.
+    fn joint_attention(
+        &self,
+        query: &[f32],
+        scene_k: &[f32],
+        scene_v: &[f32],
+        self_k: &[f32],
+        self_v: &[f32],
+        length: usize,
+        scene_len: usize,
+    ) -> Result<Vec<f32>> {
+        let heads = self.config.n_heads;
+        let groups = self.config.n_kv_heads;
+        let head_dim = self.config.head_dim;
+        let per_group = heads / groups;
+        let kv_len = scene_len + length;
+        let scale = 1.0f32 / (head_dim as f32).sqrt();
+        let mut out = vec![0.0f32; length * heads * head_dim];
+        let mut scores = vec![0.0f32; kv_len];
+        for l in 0..length {
+            for h in 0..heads {
+                let kv_head = h / per_group;
+                let q_base = (l * heads + h) * head_dim;
+                for s in 0..kv_len {
+                    let k_base = if s < scene_len {
+                        (s * groups + kv_head) * head_dim
+                    } else {
+                        ((s - scene_len) * groups + kv_head) * head_dim
+                    };
+                    let k_src = if s < scene_len { scene_k } else { self_k };
+                    let mut acc = 0.0f32;
+                    for d in 0..head_dim {
+                        acc += query[q_base + d] * k_src[k_base + d];
+                    }
+                    scores[s] = acc * scale;
+                }
+                // fp32 softmax.
+                let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                let mut sum = 0.0f32;
+                for s in scores.iter_mut() {
+                    *s = (*s - max).exp();
+                    sum += *s;
+                }
+                if sum > 0.0 {
+                    for s in scores.iter_mut() {
+                        *s /= sum;
+                    }
+                }
+                let o_base = (l * heads + h) * head_dim;
+                for d in 0..head_dim {
+                    let mut acc = 0.0f32;
+                    for (s, score) in scores.iter().enumerate() {
+                        let v_base = if s < scene_len {
+                            (s * groups + kv_head) * head_dim
+                        } else {
+                            ((s - scene_len) * groups + kv_head) * head_dim
+                        };
+                        let v_src = if s < scene_len { scene_v } else { self_v };
+                        acc += score * v_src[v_base + d];
+                    }
+                    out[o_base + d] = bf16_round(acc);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// One diffusion-transformer layer (`PlanningExpertLayer.forward`).
+    #[allow(clippy::too_many_arguments)]
+    fn layer_forward(
+        &self,
+        layer: &super::weights::QwenDriveExpertLayer,
+        hidden_states: &[f32],
+        scene_key: &[f32],
+        scene_value: &[f32],
+        scene_len: usize,
+        cos: &[f32],
+        sin: &[f32],
+        condition: &[f32],
+        length: usize,
+    ) -> Result<Vec<f32>> {
+        let hidden = self.config.hidden_size;
+        let head_dim = self.config.head_dim;
+        let heads = self.config.n_heads;
+        let eps = self.config.rms_norm_eps;
+
+        // adaLN: SiLU then Linear, split into 6 chunks of `hidden`.
+        let mod_w = Self::tensor_f32(&layer.modulation_w, "adaln_modulation.weight")?;
+        let mod_b = Self::tensor_f32(&layer.modulation_b, "adaln_modulation.bias")?;
+        let modulation = Self::linear(&Self::silu(condition), 1, &mod_w, Some(&mod_b), hidden, 6 * hidden)?;
+        let shift_attn = &modulation[0..hidden];
+        let scale_attn = &modulation[hidden..2 * hidden];
+        let gate_attn = &modulation[2 * hidden..3 * hidden];
+        let shift_ffn = &modulation[3 * hidden..4 * hidden];
+        let scale_ffn = &modulation[4 * hidden..5 * hidden];
+        let gate_ffn = &modulation[5 * hidden..6 * hidden];
+
+        // Attention branch: x = rms(h) * (1 + scale) + shift.
+        let norm_w = Self::tensor_f32(&layer.input_layernorm, "input_layernorm")?;
+        let normed = Self::rms_norm(hidden_states, &norm_w, eps)?;
+        let mut modulated = vec![0.0f32; length * hidden];
+        for l in 0..length {
+            for c in 0..hidden {
+                let idx = l * hidden + c;
+                modulated[idx] = bf16_round(normed[idx] * (1.0 + scale_attn[c]) + shift_attn[c]);
+            }
+        }
+        let qkv_w = Self::tensor_f32(&layer.qkv_w, "qkv_proj")?;
+        let qkv = Self::linear(&modulated, length, &qkv_w, None, hidden, qkv_w.len() / hidden)?;
+        let (query, gate, key, value) = self.split_qkv(&qkv, length)?;
+
+        let q_norm = Self::tensor_f32(&layer.q_norm, "q_norm")?;
+        let k_norm = Self::tensor_f32(&layer.k_norm, "k_norm")?;
+        // Per-head RMSNorm over head_dim rows.
+        let mut query_heads = vec![0.0f32; length * heads * head_dim];
+        for h in 0..heads {
+            let mut head = vec![0.0f32; length * head_dim];
+            for l in 0..length {
+                let base = (l * heads + h) * head_dim;
+                head[l * head_dim..(l + 1) * head_dim].copy_from_slice(&query[base..base + head_dim]);
+            }
+            let normed_head = Self::rms_norm(&head, &q_norm, eps)?;
+            for l in 0..length {
+                let base = (l * heads + h) * head_dim;
+                query_heads[base..base + head_dim]
+                    .copy_from_slice(&normed_head[l * head_dim..(l + 1) * head_dim]);
+            }
+        }
+        let groups = self.config.n_kv_heads;
+        let mut key_heads = vec![0.0f32; length * groups * head_dim];
+        for h in 0..groups {
+            let mut head = vec![0.0f32; length * head_dim];
+            for l in 0..length {
+                let base = (l * groups + h) * head_dim;
+                head[l * head_dim..(l + 1) * head_dim].copy_from_slice(&key[base..base + head_dim]);
+            }
+            let normed_head = Self::rms_norm(&head, &k_norm, eps)?;
+            for l in 0..length {
+                let base = (l * groups + h) * head_dim;
+                key_heads[base..base + head_dim]
+                    .copy_from_slice(&normed_head[l * head_dim..(l + 1) * head_dim]);
+            }
+        }
+
+        let query_rot = self.apply_rotary(&query_heads, length, heads, cos, sin)?;
+        let key_rot = self.apply_rotary(&key_heads, length, groups, cos, sin)?;
+
+        let attn = self.joint_attention(&query_rot, scene_key, scene_value, &key_rot, &value, length, scene_len)?;
+        // Output gate: attn * sigmoid(gate).
+        let o_w = Self::tensor_f32(&layer.o_w, "o_proj")?;
+        let mut gated = vec![0.0f32; length * heads * head_dim];
+        for i in 0..gated.len() {
+            let sigmoid = 1.0 / (1.0 + (-gate[i]).exp());
+            gated[i] = bf16_round(attn[i] * sigmoid);
+        }
+        let projected = Self::linear(&gated, length, &o_w, None, heads * head_dim, hidden)?;
+        // residual + (1 + gate_attn) * proj
+        let mut h = vec![0.0f32; length * hidden];
+        for l in 0..length {
+            for c in 0..hidden {
+                let idx = l * hidden + c;
+                h[idx] = bf16_round(hidden_states[idx] + (1.0 + gate_attn[c]) * projected[idx]);
+            }
+        }
+
+        // FFN branch: x = rms(h) * (1 + scale_ffn) + shift_ffn; SwiGLU.
+        let ffn_norm_w = Self::tensor_f32(&layer.post_attention_layernorm, "post_attention_layernorm")?;
+        let normed = Self::rms_norm(&h, &ffn_norm_w, eps)?;
+        for l in 0..length {
+            for c in 0..hidden {
+                let idx = l * hidden + c;
+                modulated[idx] = bf16_round(normed[idx] * (1.0 + scale_ffn[c]) + shift_ffn[c]);
+            }
+        }
+        let gate_up_w = Self::tensor_f32(&layer.gate_up_w, "gate_up_proj")?;
+        let inter = self.config.intermediate_size;
+        let gate_up = Self::linear(&modulated, length, &gate_up_w, None, hidden, 2 * inter)?;
+        let mut swiglu = vec![0.0f32; length * inter];
+        for l in 0..length {
+            for c in 0..inter {
+                let g = gate_up[l * 2 * inter + c];
+                let u = gate_up[l * 2 * inter + inter + c];
+                let silu_g = g / (1.0 + (-g).exp());
+                swiglu[l * inter + c] = bf16_round(silu_g * u);
+            }
+        }
+        let down_w = Self::tensor_f32(&layer.down_w, "down_proj")?;
+        let ffn = Self::linear(&swiglu, length, &down_w, None, inter, hidden)?;
+        let mut out = vec![0.0f32; length * hidden];
+        for l in 0..length {
+            for c in 0..hidden {
+                let idx = l * hidden + c;
+                out[idx] = bf16_round(h[idx] + (1.0 + gate_ffn[c]) * ffn[idx]);
+            }
+        }
+        Ok(out)
+    }
+
+    /// `predict_endpoint`: the clean-trajectory prediction for one flow time.
+    /// `waypoints` is `[length, 3]` f32 (unrounded solver state, cast to bf16
+    /// on entry like the reference's `.to(dtype)`).
+    pub fn predict_endpoint(
+        &self,
+        waypoints: &[f32],
+        flow_time: f32,
+        cond: &ExpertConditioning,
+        history_queries: &(Vec<f32>, Vec<f32>, Vec<f32>),
+        scene: &SceneCache,
+        anchor: i64,
+    ) -> Result<Vec<f32>> {
+        let hidden = self.config.hidden_size;
+        let length = self.num_future_points;
+        if waypoints.len() != length * self.trajectory_point_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: waypoints has {} values, expected {}",
+                waypoints.len(),
+                length * self.trajectory_point_dim
+            )));
+        }
+        if scene.keys.len() != self.num_kv_sources() || scene.values.len() != self.num_kv_sources() {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: scene cache has {}/{} entries, expected {}",
+                scene.keys.len(),
+                scene.values.len(),
+                self.num_kv_sources()
+            )));
+        }
+
+        // bf16 cast on entry (reference: `waypoints.to(dtype)`).
+        let waypoints_bf16: Vec<f32> = waypoints.iter().map(|v| bf16_round(*v)).collect();
+
+        // The seven fused signals.
+        let traj_w = Self::tensor_f32(&self.weights.trajectory_proj_w, "trajectory_proj.weight")?;
+        let traj_b = Self::tensor_f32(&self.weights.trajectory_proj_b, "trajectory_proj.bias")?;
+        let traj = Self::linear(&waypoints_bf16, length, &traj_w, Some(&traj_b), self.trajectory_point_dim, hidden)?;
+        let fourier = self.fourier_features(&waypoints_bf16, length)?;
+        let time_condition = Self::mlp(
+            &self.time_embedding(flow_time),
+            1,
+            &self.weights.time_mlp,
+            self.config.time_embed_dim,
+            hidden,
+        )?;
+        let (pose_query, velocity_query, acceleration_query) = history_queries;
+        let embed_table = Self::tensor_f32(&self.weights.waypoint_embed, "waypoint_embed")?;
+
+        let mut fused = vec![0.0f32; length * 7 * hidden];
+        for l in 0..length {
+            let row = &mut fused[l * 7 * hidden..(l + 1) * 7 * hidden];
+            row[0..hidden].copy_from_slice(&traj[l * hidden..(l + 1) * hidden]);
+            row[hidden..2 * hidden].copy_from_slice(&fourier[l * hidden..(l + 1) * hidden]);
+            row[2 * hidden..3 * hidden].copy_from_slice(&time_condition);
+            row[3 * hidden..4 * hidden].copy_from_slice(pose_query);
+            row[4 * hidden..5 * hidden]
+                .copy_from_slice(&embed_table[l * hidden..(l + 1) * hidden]);
+            row[5 * hidden..6 * hidden].copy_from_slice(velocity_query);
+            row[6 * hidden..7 * hidden].copy_from_slice(acceleration_query);
+        }
+        let mut hidden_states = Self::mlp(&fused, length, &self.weights.query_fusion, 7 * hidden, hidden)?;
+
+        // adaLN condition = time + nav + ego.
+        let nav = Self::one_hot(self.config.nav_command_classes, cond.nav_command);
+        let nav_out = Self::mlp(&nav, 1, &self.weights.nav_mlp, self.config.nav_command_classes, hidden)?;
+        let ego_out = Self::mlp(&cond.ego_status, 1, &self.weights.ego_mlp, self.config.ego_status_dim, hidden)?;
+        let mut condition = Self::add(&time_condition, &nav_out)?;
+        condition = Self::add(&condition, &ego_out)?;
+
+        let (cos, sin) = self.waypoint_rope_tables(anchor, length)?;
+        let layers_per_kv = self.config.layers_per_kv;
+        for (index, layer) in self.weights.layers.iter().enumerate() {
+            let scene_index = index / layers_per_kv;
+            let scene_k = Self::tensor_f32(&scene.keys[scene_index], "scene key")?;
+            let scene_v = Self::tensor_f32(&scene.values[scene_index], "scene value")?;
+            let scene_len = scene_k.len() / (self.config.n_kv_heads * self.config.head_dim);
+            hidden_states = self.layer_forward(
+                layer,
+                &hidden_states,
+                &scene_k,
+                &scene_v,
+                scene_len,
+                &cos,
+                &sin,
+                &condition,
+                length,
+            )?;
+        }
+
+        let final_norm = Self::tensor_f32(&self.weights.final_layernorm, "final_layernorm")?;
+        let normed = Self::rms_norm(&hidden_states, &final_norm, self.config.rms_norm_eps)?;
+        let out_w = Self::tensor_f32(&self.weights.out_proj_w, "out_proj.weight")?;
+        let out_b = Self::tensor_f32(&self.weights.out_proj_b, "out_proj.bias")?;
+        // `.float()` output: the reference returns fp32 endpoint predictions.
+        Self::linear(&normed, length, &out_w, Some(&out_b), hidden, self.trajectory_point_dim)
+    }
+
+    /// `sample`: flow matching with clean-endpoint parameterization — 10
+    /// Euler steps, `x += (x1_hat - x) / max(1 - t, min_one_minus_t) * step`,
+    /// solver state in fp32 exactly like the reference.
+    pub fn sample(
+        &self,
+        scene: &SceneCache,
+        anchor: i64,
+        cond: &ExpertConditioning,
+        noise: &[f32],
+        num_steps: usize,
+        min_one_minus_t: f32,
+    ) -> Result<Vec<f32>> {
+        let length = self.num_future_points;
+        if noise.len() != length * self.trajectory_point_dim {
+            return Err(Error::Other(format!(
+                "qwen_drive planner: noise has {} values, expected {}",
+                noise.len(),
+                length * self.trajectory_point_dim
+            )));
+        }
+        if num_steps == 0 {
+            return Err(Error::Other("qwen_drive planner: num_steps must be positive".into()));
+        }
+        let history_queries = self.encode_history(cond)?;
+        let mut waypoints: Vec<f32> = noise.to_vec();
+        let step = 1.0f32 / num_steps as f32;
+        for index in 0..num_steps {
+            let t = index as f32 * step;
+            let endpoint = self.predict_endpoint(&waypoints, t, cond, &history_queries, scene, anchor)?;
+            let remaining = (1.0f32 - t).max(min_one_minus_t);
+            for (w, e) in waypoints.iter_mut().zip(endpoint.iter()) {
+                *w += (*e - *w) / remaining * step;
+            }
+        }
+        Ok(waypoints)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bf16_rounding_is_semantic() {
+        // pi/2 rounds to 1.5703125 in bf16 (the trajectory heading scale).
+        assert_eq!(bf16_round(std::f32::consts::FRAC_PI_2), 1.5703125);
+        // Integers above 256 round to the bf16 grid (rope position rounding).
+        assert_eq!(bf16_round(300.0), 300.0); // 300 is representable
+        assert_ne!(bf16_round(257.0), 257.0);
+    }
+
+    #[test]
+    fn one_hot_maps_out_of_range_to_zero() {
+        assert_eq!(PlanningExpertModel::one_hot(3, 1), vec![0.0, 1.0, 0.0]);
+        assert_eq!(PlanningExpertModel::one_hot(3, 7), vec![0.0, 0.0, 0.0]);
+        assert_eq!(PlanningExpertModel::one_hot(3, -1), vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn sinusoidal_time_embedding_matches_reference_formula() {
+        let emb = time_embedding(8, 1000.0, 0.5);
+        assert_eq!(emb.len(), 8);
+        // First channel: sin(1000 * 0.5 * exp(0)) = sin(500) rounded to bf16.
+        let expected = bf16_round((500.0f32).sin());
+        assert_eq!(emb[0], expected);
+        // Decay: freqs[1] = exp(-ln(10000) / 3).
+        let freq1 = (-(10000.0f64).ln() as f32 / 3.0).exp();
+        let expected1 = bf16_round((1000.0 * 0.5 * freq1).sin());
+        assert_eq!(emb[1], expected1);
+    }
+
+    /// Zero-initialized expert weights with the shapes the executor expects;
+    /// only used where the test never reads them.
+    #[allow(dead_code)]
+    fn dummy_weights() -> super::super::weights::QwenDriveExpertWeights {
+        use super::super::weights::{ExpertMlp, QwenDriveExpertLayer, QwenDriveExpertWeights};
+        let z = |rows: usize, cols: usize| Tensor::from_f32(vec![rows, cols], &vec![0.0; rows * cols]).unwrap();
+        let mlp = |input: usize, hidden: usize| ExpertMlp {
+            fc1_w: z(input, hidden),
+            fc1_b: z(hidden, 1),
+            fc2_w: z(hidden, hidden),
+            fc2_b: z(hidden, 1),
+        };
+        let hidden = 8;
+        QwenDriveExpertWeights {
+            trajectory_proj_w: z(3, hidden),
+            trajectory_proj_b: z(hidden, 1),
+            fourier_encoder: mlp(24, hidden),
+            waypoint_embed: z(4, hidden),
+            time_mlp: mlp(8, hidden),
+            nav_mlp: mlp(3, hidden),
+            ego_mlp: mlp(8, hidden),
+            history_encoder: mlp(12, hidden),
+            history_velocity_encoder: mlp(8, hidden),
+            history_acceleration_encoder: mlp(8, hidden),
+            query_fusion: mlp(56, hidden),
+            layers: (0..4)
+                .map(|_| QwenDriveExpertLayer {
+                    input_layernorm: z(hidden, 1),
+                    qkv_w: z(hidden, hidden),
+                    q_norm: z(8, 1),
+                    k_norm: z(8, 1),
+                    o_w: z(16, hidden),
+                    post_attention_layernorm: z(hidden, 1),
+                    gate_up_w: z(hidden, 16),
+                    down_w: z(8, hidden),
+                    modulation_w: z(hidden, 6 * hidden),
+                    modulation_b: z(6 * hidden, 1),
+                })
+                .collect(),
+            final_layernorm: z(hidden, 1),
+            out_proj_w: z(hidden, 3),
+            out_proj_b: z(3, 1),
+        }
+    }
+}

--- a/crates/apxinf-model/src/qwen_drive/vision.rs
+++ b/crates/apxinf-model/src/qwen_drive/vision.rs
@@ -1,0 +1,236 @@
+//! Qwen-Drive vision tower (Qwen3.5 ViT) forward path on the CUDA executor.
+//!
+//! Structure and canonical rewrites follow the maintained qwen3vl vision
+//! tower (copied with provenance, renamed, no cross-family import): patch
+//! GEMM, bilinear-interpolated position embeddings computed on the host
+//! (checkpoint-lifetime table; the host copy is refreshed per request in this
+//! revision - recorded as optimization debt), 2D RoPE via the maintained
+//! split_vision_qkv_rope kernel, per-image segmented attention, and the
+//! merger (LayerNorm -> row merge -> fc1 -> exact erf GELU -> fc2). Qwen3.5
+//! has no deepstack mergers.
+
+use apxinf_core::{Error, Result, Tensor};
+
+use super::backend::{kernels, transfers, Context, DeviceBuffer};
+use kernels::{activation, attention, elementwise, gemm, linear_attention as la, norm};
+
+use super::config::QwenDriveConfig;
+use super::device_weights::VisionDeviceWeights;
+
+pub struct VisionOutput {
+    /// Merged image embeddings `[tokens, out_hidden]` scattered into the
+    /// text stream at the image-token positions.
+    pub primary: Tensor,
+    /// Pre-merger patch features `[patches, hidden]` (perception tap).
+    pub pre_merger: Tensor,
+}
+
+fn upload_u32(ctx: &Context, values: &[u32]) -> Result<DeviceBuffer> {
+    let bytes: Vec<u8> = values.iter().flat_map(|value| value.to_ne_bytes()).collect();
+    let buffer = DeviceBuffer::alloc(bytes.len().max(1), ctx.device_id()).map_err(Error::Cuda)?;
+    buffer.copy_from_host(&bytes).map_err(Error::Cuda)?;
+    Ok(buffer)
+}
+
+/// Run the vision tower over the concatenated per-image patch stream.
+/// `pixel_values` is `[patches, 3 * temporal * patch * patch]` BF16 on device;
+/// `grid_thw` holds one `[T, H, W]` entry per image.
+pub fn forward(
+    config: &QwenDriveConfig,
+    weights: &VisionDeviceWeights,
+    ctx: &Context,
+    pixel_values: &Tensor,
+    grid_thw: &[[u32; 3]],
+) -> Result<VisionOutput> {
+    let vc = &config.vision;
+    let hidden = vc.hidden_size;
+    let heads = vc.num_heads;
+    let head_dim = vc.head_dim();
+    let merge = vc.spatial_merge_size;
+    let eps = 1e-6f32;
+
+    let dims = pixel_values.shape().dims();
+    let patch_vec = vc.in_channels * vc.temporal_patch_size * vc.patch_size * vc.patch_size;
+    if grid_thw.is_empty() || dims.len() != 2 || dims[1] != patch_vec {
+        return Err(Error::Other(format!(
+            "qwen_drive vision: pixel_values must be [patches, {patch_vec}], got {dims:?}"
+        )));
+    }
+    let total_patches = dims[0];
+    let mut offsets = vec![0u32];
+    let mut max_tokens = 0usize;
+    for grid in grid_thw {
+        let (t, h, w) = (grid[0] as usize, grid[1] as usize, grid[2] as usize);
+        if t == 0 || h == 0 || w == 0 || h % merge != 0 || w % merge != 0 {
+            return Err(Error::Other(format!(
+                "qwen_drive vision: invalid grid [{t}, {h}, {w}] for merge {merge}"
+            )));
+        }
+        let patches = t * h * w;
+        max_tokens = max_tokens.max(patches);
+        offsets.push(offsets[offsets.len() - 1] + patches as u32);
+    }
+    if offsets[offsets.len() - 1] as usize != total_patches {
+        return Err(Error::Other(format!(
+            "qwen_drive vision: grids cover {} patches but pixel_values has {total_patches}",
+            offsets[offsets.len() - 1]
+        )));
+    }
+    // TEMP-DIAG (implement_r3): vision-entry geometry; revert in the acceptance-bound revision.
+    eprintln!("[qwen_drive] vision_entry total_patches={} segments={} offsets_len={} offsets_max={} max_tokens={} heads={} head_dim={} n={} grids={:?}", total_patches, grid_thw.len(), offsets.len(), offsets.last().copied().unwrap_or(0), max_tokens, heads, head_dim, weights.blocks.len(), grid_thw);
+    // TEMP-DIAG (implement_r4): per-op elapsed-ms reference; revert in the acceptance-bound revision.
+    let vis_t0 = std::time::Instant::now();
+    let offsets_dev = upload_u32(ctx, &offsets)?;
+
+    // Patch embedding: [N, patch_vec] @ [patch_vec, hidden] + bias.
+    let mut x = gemm::matmul(ctx, pixel_values, &weights.patch_w)?;
+    x = elementwise::bias_bf16(ctx, &x, Some(&weights.patch_b))?;
+
+    // Bilinear-interpolated learned position embeddings (host canonicalization).
+    let pos_embeds = compute_pos_embeds(config, weights, ctx, grid_thw)?;
+    x = elementwise::add(ctx, &x, &pos_embeds)?;
+
+    // 2D rope position ids in the merge-block-major patch order.
+    let pos_ids = compute_vision_pos_ids(grid_thw, merge);
+    let pos_ids_dev = upload_u32(ctx, &pos_ids)?;
+
+    for (block_idx, block) in weights.blocks.iter().enumerate() {
+        // TEMP-DIAG (implement_r2, ungated in implement_r3): vision-block heartbeat every block; revert in the acceptance-bound revision.
+        eprintln!("[qwen_drive] vision_block k={} n={} ms={}", block_idx, weights.blocks.len(), vis_t0.elapsed().as_millis());
+        let normed = norm::layer_bf16(ctx, &x, &block.norm1_w, &block.norm1_b, eps)?;
+        let qkv = gemm::matmul(ctx, &normed, &block.qkv_w)?;
+        let qkv = attention::split_vision_qkv_rope_bf16(
+            ctx,
+            &qkv,
+            Some(&block.qkv_b),
+            &pos_ids_dev,
+            heads,
+            head_dim,
+            10000.0,
+        )?;
+        let attn = attention::segmented_mha_bf16(
+            ctx,
+            &qkv.q,
+            &qkv.k,
+            &qkv.v,
+            &offsets_dev,
+            &offsets,
+            grid_thw.len(),
+            max_tokens,
+        )?;
+        let attn = attn.reshape(vec![total_patches, hidden])?;
+        let proj = gemm::matmul(ctx, &attn, &block.proj_w)?;
+        let proj = elementwise::bias_bf16(ctx, &proj, Some(&block.proj_b))?;
+        x = elementwise::add(ctx, &x, &proj)?;
+
+        let normed = norm::layer_bf16(ctx, &x, &block.norm2_w, &block.norm2_b, eps)?;
+        let h = gemm::matmul(ctx, &normed, &block.fc1_w)?;
+        let h = activation::bias_gelu_bf16(ctx, &h, Some(&block.fc1_b))?;
+        let h2 = gemm::matmul(ctx, &h, &block.fc2_w)?;
+        let h2 = elementwise::bias_bf16(ctx, &h2, Some(&block.fc2_b))?;
+        x = elementwise::add(ctx, &x, &h2)?;
+    }
+
+    // Merger: LayerNorm(1024) -> merge 4 rows -> fc1 -> exact erf GELU -> fc2.
+    let normed = norm::layer_bf16(ctx, &x, &weights.merger_norm_w, &weights.merger_norm_b, eps)?;
+    let merged = la::merge_rows(ctx, &normed, merge * merge)?;
+    let h = gemm::matmul(ctx, &merged, &weights.merger_fc1_w)?;
+    let h = elementwise::bias_bf16(ctx, &h, Some(&weights.merger_fc1_b))?;
+    let h = la::gelu_exact(ctx, &h)?;
+    let out = gemm::matmul(ctx, &h, &weights.merger_fc2_w)?;
+    let primary = elementwise::bias_bf16(ctx, &out, Some(&weights.merger_fc2_b))?;
+    Ok(VisionOutput { primary, pre_merger: x })
+}
+
+/// Bilinear-interpolate the learned 48x48 position table to each image's
+/// patch grid and permute to the merge-block-major layout. Copied with
+/// provenance from qwen3vl's vision tower (HF `fast_pos_embed_interpolate` +
+/// the spatial-merge shuffle); the table is read back per request (debt).
+fn compute_pos_embeds(
+    config: &QwenDriveConfig,
+    weights: &VisionDeviceWeights,
+    ctx: &Context,
+    grid_thw: &[[u32; 3]],
+) -> Result<Tensor> {
+    let vc = &config.vision;
+    let hidden = vc.hidden_size;
+    let merge = vc.spatial_merge_size;
+    let grid_side = (vc.num_position_embeddings as f64).sqrt().round() as usize;
+    let cpu = transfers::to_cpu(&weights.pos_embed)?;
+    let table = cpu
+        .to_f32_vec()
+        .map_err(|e| Error::Other(format!("qwen_drive vision pos_embed table: {e}")))?;
+    if table.len() != grid_side * grid_side * hidden {
+        return Err(Error::Other("qwen_drive vision: pos_embed table shape mismatch".into()));
+    }
+    let total: usize = grid_thw
+        .iter()
+        .map(|grid| grid[0] as usize * grid[1] as usize * grid[2] as usize)
+        .sum();
+    let mut out = vec![0.0f32; total * hidden];
+    let mut dst_token = 0usize;
+    for grid in grid_thw {
+        let (t, h, w) = (grid[0] as usize, grid[1] as usize, grid[2] as usize);
+        let merged_h = h / merge;
+        let merged_w = w / merge;
+        for _ti in 0..t {
+            for mh in 0..merged_h {
+                for mw in 0..merged_w {
+                    for ih in 0..merge {
+                        for iw in 0..merge {
+                            let hi = mh * merge + ih;
+                            let wi = mw * merge + iw;
+                            let hf = hi as f32 * (grid_side - 1) as f32 / (h - 1).max(1) as f32;
+                            let h0 = hf.floor() as usize;
+                            let h1 = (h0 + 1).min(grid_side - 1);
+                            let dh = hf - h0 as f32;
+                            let wf = wi as f32 * (grid_side - 1) as f32 / (w - 1).max(1) as f32;
+                            let w0 = wf.floor() as usize;
+                            let w1 = (w0 + 1).min(grid_side - 1);
+                            let dw = wf - w0 as f32;
+                            let dst = dst_token * hidden;
+                            for c in 0..hidden {
+                                let v00 = table[(h0 * grid_side + w0) * hidden + c];
+                                let v01 = table[(h0 * grid_side + w1) * hidden + c];
+                                let v10 = table[(h1 * grid_side + w0) * hidden + c];
+                                let v11 = table[(h1 * grid_side + w1) * hidden + c];
+                                out[dst + c] = (1.0 - dh) * (1.0 - dw) * v00
+                                    + (1.0 - dh) * dw * v01
+                                    + dh * (1.0 - dw) * v10
+                                    + dh * dw * v11;
+                            }
+                            dst_token += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let rounded: Vec<half::bf16> = out.iter().map(|&v| half::bf16::from_f32(v)).collect();
+    let tensor = Tensor::from_bf16(vec![total, hidden], &rounded)?;
+    transfers::to_cuda(&tensor, ctx.device_id())
+}
+
+/// Vision 2D-RoPE position ids `(h, w)` per patch in the merge-block-major
+/// layout (copied with provenance from qwen3vl's `compute_vision_pos_ids`).
+fn compute_vision_pos_ids(grid_thw: &[[u32; 3]], merge: usize) -> Vec<u32> {
+    let mut ids = Vec::new();
+    for grid in grid_thw {
+        let (t, h, w) = (grid[0] as usize, grid[1] as usize, grid[2] as usize);
+        let merged_h = h / merge;
+        let merged_w = w / merge;
+        for _ti in 0..t {
+            for mh in 0..merged_h {
+                for mw in 0..merged_w {
+                    for ih in 0..merge {
+                        for iw in 0..merge {
+                            ids.push((mh * merge + ih) as u32);
+                            ids.push((mw * merge + iw) as u32);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ids
+}

--- a/crates/apxinf-model/src/qwen_drive/weights.rs
+++ b/crates/apxinf-model/src/qwen_drive/weights.rs
@@ -2,8 +2,11 @@
 //!
 //! Two weight stores are supported:
 //!
-//! * the VLM directory (the Qwen3.5 release root), whose safetensors keys are
-//!   `model.language_model.*` and `model.visual.*`; and
+//! * the VLM directory (the Drive checkpoint root), whose safetensors keys
+//!   are `vlm.model.language_model.*` and `vlm.model.visual.*`: the reference
+//!   saves the outer QwenDrive module, so every VLM tensor carries exactly
+//!   one leading `vlm.` prefix that `QwenDriveVlmWeights::from_map` strips
+//!   before classification (bare `model.*` maps are accepted too); and
 //! * a planning-expert head directory (planner-sft / planner-rl), whose keys
 //!   carry an optional `planning_expert.` prefix that the reference strips at
 //!   load time (`load_planner`).
@@ -35,7 +38,18 @@ pub struct QwenDriveVlmWeights {
 }
 
 impl QwenDriveVlmWeights {
-    pub fn from_map(mut tensors: HashMap<String, Tensor>) -> Result<Self> {
+    pub fn from_map(tensors: HashMap<String, Tensor>) -> Result<Self> {
+        // The Drive checkpoint saves the outer QwenDrive module, so every VLM
+        // tensor carries exactly one leading `vlm.` prefix (the reference wraps
+        // the VLM as `self.vlm` and saves the outer module). Strip it once
+        // before classification; bare `model.*` maps are accepted too.
+        let mut tensors: HashMap<String, Tensor> = tensors
+            .into_iter()
+            .map(|(key, tensor)| {
+                let stripped = key.strip_prefix("vlm.").unwrap_or(key.as_str());
+                (stripped.to_owned(), tensor)
+            })
+            .collect();
         let mut language = HashMap::new();
         let mut visual = HashMap::new();
         let mut ignored: Vec<String> = tensors
@@ -70,11 +84,18 @@ impl QwenDriveVlmWeights {
             }
         }
         if language.is_empty() {
-            return Err(Error::Other(
+            // Self-diagnosing in truncated remote logs: surface the first
+            // unmatched keys so a key-layout mismatch is visible directly.
+            let sample = if ignored.is_empty() {
+                "<none>".to_string()
+            } else {
+                ignored[..ignored.len().min(3)].join(", ")
+            };
+            return Err(Error::Other(format!(
                 "qwen_drive weights: no model.language_model.* tensors found; \
                  pass the VLM checkpoint directory (or attach a planner head \
-                 through QwenDriveExpertWeights::from_map)".into(),
-            ));
+                 through QwenDriveExpertWeights::from_map). First unmatched keys: {sample}"
+            )));
         }
         if !language.contains_key("model.language_model.embed_tokens.weight") {
             return Err(Error::Other(
@@ -307,13 +328,24 @@ pub fn transpose_2d(tensor: &Tensor) -> Result<Tensor> {
         )));
     }
     let [rows, cols] = [dims[0], dims[1]];
+    const TILE: usize = 32;
     match tensor.dtype() {
         apxinf_core::DType::F32 => {
             let data = tensor.as_f32()?;
             let mut out = vec![0.0f32; rows * cols];
-            for i in 0..rows {
-                for j in 0..cols {
-                    out[j * rows + i] = data[i * cols + j];
+            // Tiled permutation: the naive elementwise loop is cache-hostile
+            // on the multi-GB checkpoint matrices and starved the remote load
+            // stage; 32x32 tiles keep the strided writes cache-local. Same
+            // output permutation, memory-speed.
+            for ii in (0..rows).step_by(TILE) {
+                for jj in (0..cols).step_by(TILE) {
+                    let i_end = (ii + TILE).min(rows);
+                    let j_end = (jj + TILE).min(cols);
+                    for i in ii..i_end {
+                        for j in jj..j_end {
+                            out[j * rows + i] = data[i * cols + j];
+                        }
+                    }
                 }
             }
             Tensor::from_f32(vec![cols, rows], &out)
@@ -321,9 +353,15 @@ pub fn transpose_2d(tensor: &Tensor) -> Result<Tensor> {
         apxinf_core::DType::BF16 => {
             let data = tensor.as_bf16()?;
             let mut out = vec![half::bf16::from_f32(0.0); rows * cols];
-            for i in 0..rows {
-                for j in 0..cols {
-                    out[j * rows + i] = data[i * cols + j];
+            for ii in (0..rows).step_by(TILE) {
+                for jj in (0..cols).step_by(TILE) {
+                    let i_end = (ii + TILE).min(rows);
+                    let j_end = (jj + TILE).min(cols);
+                    for i in ii..i_end {
+                        for j in jj..j_end {
+                            out[j * rows + i] = data[i * cols + j];
+                        }
+                    }
                 }
             }
             Tensor::from_bf16(vec![cols, rows], &out)
@@ -414,7 +452,7 @@ mod tests {
         let history_dim = (config.num_history_points - 1) * config.trajectory_point_dim
             + config.expert.nav_command_classes;
         mlp(&mut map, "planning_expert.history_encoder", history_dim);
-        let dynamics_dim = config.num_history_points * config.expert.history_dynamics_dim;
+        let dynamics_dim = config.num_history_points * expert.history_dynamics_dim;
         mlp(&mut map, "planning_expert.history_velocity_encoder", dynamics_dim);
         mlp(&mut map, "planning_expert.history_acceleration_encoder", dynamics_dim);
         mlp(&mut map, "planning_expert.query_fusion", 7 * hidden);

--- a/crates/apxinf-model/src/qwen_drive/weights.rs
+++ b/crates/apxinf-model/src/qwen_drive/weights.rs
@@ -1,0 +1,434 @@
+//! Qwen-Drive-1.0 checkpoint weight mapping.
+//!
+//! Two weight stores are supported:
+//!
+//! * the VLM directory (the Qwen3.5 release root), whose safetensors keys are
+//!   `model.language_model.*` and `model.visual.*`; and
+//! * a planning-expert head directory (planner-sft / planner-rl), whose keys
+//!   carry an optional `planning_expert.` prefix that the reference strips at
+//!   load time (`load_planner`).
+//!
+//! HF `Linear` weights are `[out, in]`; every projection is transposed once at
+//! load to the `[in, out]` row-major layout the matmul path expects. The
+//! expert's fused QKV weight keeps the reference's group-major row order
+//! (per KV group: query heads, then their output-gate heads, then K, V) and
+//! the split is applied at inference exactly as `PlanningExpertLayer._split_qkv`.
+//!
+//! The VLM weight struct deliberately holds tensors by name: the Qwen3.5
+//! linear-attention (gated delta net) layer geometry is parsed and validated,
+//! but its device execution is pending reference qualification. The named map
+//! keeps the loader honest and reusable for the follow-up executor instead of
+//! a hardcoded stub schema that would silently drop the GDN projections.
+
+use std::collections::HashMap;
+
+use apxinf_core::{Error, Result, Tensor};
+
+use super::config::QwenDriveConfig;
+
+/// VLM (Qwen3.5) weights, keyed by their checkpoint names.
+pub struct QwenDriveVlmWeights {
+    /// Every `model.language_model.*` tensor, untransposed.
+    pub language: HashMap<String, Tensor>,
+    /// Every `model.visual.*` tensor, untransposed.
+    pub visual: HashMap<String, Tensor>,
+}
+
+impl QwenDriveVlmWeights {
+    pub fn from_map(mut tensors: HashMap<String, Tensor>) -> Result<Self> {
+        let mut language = HashMap::new();
+        let mut visual = HashMap::new();
+        let mut ignored: Vec<String> = tensors
+            .keys()
+            .filter(|key| {
+                !key.starts_with("model.language_model.") && !key.starts_with("model.visual.")
+            })
+            .cloned()
+            .collect();
+        ignored.sort_unstable();
+        for (key, tensor) in tensors.drain() {
+            if key.starts_with("model.language_model.") {
+                language.insert(key, tensor);
+            } else if key.starts_with("model.visual.") {
+                visual.insert(key, tensor);
+            }
+        }
+        if !ignored.is_empty() {
+            // Strictly informational: MTP/auxiliary tensors are allowed to be
+            // present (the reference ignores them too), but we surface them in
+            // the error channel only when they look like expert keys, which
+            // means the caller passed a planner head instead of the VLM.
+            let expert_like = ignored
+                .iter()
+                .any(|key| key.starts_with("planning_expert.") || key.contains("adaln_modulation"));
+            if expert_like {
+                return Err(Error::Other(format!(
+                    "qwen_drive weights: the map looks like a planning-expert head \
+                     (e.g. {}); load VLM and planner weights separately",
+                    ignored[0]
+                )));
+            }
+        }
+        if language.is_empty() {
+            return Err(Error::Other(
+                "qwen_drive weights: no model.language_model.* tensors found; \
+                 pass the VLM checkpoint directory (or attach a planner head \
+                 through QwenDriveExpertWeights::from_map)".into(),
+            ));
+        }
+        if !language.contains_key("model.language_model.embed_tokens.weight") {
+            return Err(Error::Other(
+                "qwen_drive weights: missing model.language_model.embed_tokens.weight".into(),
+            ));
+        }
+        if !language.contains_key("model.language_model.norm.weight") {
+            return Err(Error::Other(
+                "qwen_drive weights: missing model.language_model.norm.weight".into(),
+            ));
+        }
+        if visual.is_empty() {
+            return Err(Error::Other(
+                "qwen_drive weights: no model.visual.* tensors found; the vision \
+                 tower is required for VQA and planning scene encoding".into(),
+            ));
+        }
+        Ok(Self { language, visual })
+    }
+
+    /// Total number of language-model tensors (diagnostics/tests).
+    pub fn language_tensor_count(&self) -> usize {
+        self.language.len()
+    }
+
+    /// Total number of vision-tower tensors (diagnostics/tests).
+    pub fn visual_tensor_count(&self) -> usize {
+        self.visual.len()
+    }
+}
+
+/// One MLP of the form Linear(in, hidden) -> SiLU -> Linear(hidden, hidden),
+/// used by the expert's time/nav/ego/history encoders and query fusion.
+/// Weights are transposed to `[in, out]`; biases are `[out]`.
+pub struct ExpertMlp {
+    pub fc1_w: Tensor,
+    pub fc1_b: Tensor,
+    pub fc2_w: Tensor,
+    pub fc2_b: Tensor,
+}
+
+/// One expert diffusion-transformer layer.
+pub struct QwenDriveExpertLayer {
+    pub input_layernorm: Tensor,
+    /// Fused `[hidden, groups*(2*heads_per_group + 2)*head_dim]` (transposed),
+    /// keeping the reference's group-major row order.
+    pub qkv_w: Tensor,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+    /// `[heads*head_dim, hidden]` (transposed).
+    pub o_w: Tensor,
+    pub post_attention_layernorm: Tensor,
+    /// `[hidden, 2*intermediate]` (transposed).
+    pub gate_up_w: Tensor,
+    /// `[intermediate, hidden]` (transposed).
+    pub down_w: Tensor,
+    /// adaLN modulation: `[hidden, 6*hidden]` (transposed) plus bias.
+    pub modulation_w: Tensor,
+    pub modulation_b: Tensor,
+}
+
+/// Planning-expert weights (the planner-sft / planner-rl head).
+pub struct QwenDriveExpertWeights {
+    /// `[trajectory_point_dim, hidden]` (transposed).
+    pub trajectory_proj_w: Tensor,
+    pub trajectory_proj_b: Tensor,
+    pub fourier_encoder: ExpertMlp,
+    /// `[num_future_points, hidden]` waypoint-index embedding table.
+    pub waypoint_embed: Tensor,
+    pub time_mlp: ExpertMlp,
+    pub nav_mlp: ExpertMlp,
+    pub ego_mlp: ExpertMlp,
+    pub history_encoder: ExpertMlp,
+    pub history_velocity_encoder: ExpertMlp,
+    pub history_acceleration_encoder: ExpertMlp,
+    /// query_fusion: first Linear maps `[7*hidden, hidden]` (transposed).
+    pub query_fusion: ExpertMlp,
+    pub layers: Vec<QwenDriveExpertLayer>,
+    pub final_layernorm: Tensor,
+    /// `[hidden, trajectory_point_dim]` (transposed).
+    pub out_proj_w: Tensor,
+    pub out_proj_b: Tensor,
+}
+
+fn take(map: &mut HashMap<String, Tensor>, name: &str) -> Result<Tensor> {
+    map.remove(name)
+        .ok_or_else(|| Error::Other(format!("qwen_drive expert weights: missing {name}")))
+}
+
+fn take_linear(map: &mut HashMap<String, Tensor>, name: &str) -> Result<(Tensor, Tensor)> {
+    let weight = take(map, &format!("{name}.weight"))?;
+    let bias = take(map, &format!("{name}.bias"))?;
+    Ok((transpose_2d(&weight)?, bias))
+}
+
+fn take_mlp(map: &mut HashMap<String, Tensor>, prefix: &str) -> Result<ExpertMlp> {
+    // Reference `_mlp` = nn.Sequential(Linear, SiLU, Linear), i.e. `.0` and `.2`.
+    let (fc1_w, fc1_b) = take_linear(map, &format!("{prefix}.0"))?;
+    let (fc2_w, fc2_b) = take_linear(map, &format!("{prefix}.2"))?;
+    Ok(ExpertMlp { fc1_w, fc1_b, fc2_w, fc2_b })
+}
+
+impl QwenDriveExpertWeights {
+    pub fn from_map(
+        config: &QwenDriveConfig,
+        tensors: &HashMap<String, Tensor>,
+    ) -> Result<Self> {
+        // Strip the optional `planning_expert.` prefix exactly like the
+        // reference `load_planner`, cloning tensors (the planner head is 1.0B
+        // parameters; the clone happens once at load, not on the hot path).
+        let prefix = "planning_expert.";
+        let mut map: HashMap<String, Tensor> = tensors
+            .iter()
+            .map(|(key, tensor)| {
+                let stripped = key.strip_prefix(prefix).unwrap_or(key.as_str());
+                (stripped.to_owned(), tensor.clone())
+            })
+            .collect();
+
+        let mut layers = Vec::with_capacity(config.expert.n_layers);
+        for index in 0..config.expert.n_layers {
+            let p = format!("layers.{index}");
+            let qkv = take(&mut map, &format!("{p}.qkv_proj.weight"))?;
+            let gate_up = take(&mut map, &format!("{p}.gate_up_proj.weight"))?;
+            let down = take(&mut map, &format!("{p}.down_proj.weight"))?;
+            let o = take(&mut map, &format!("{p}.o_proj.weight"))?;
+            let modulation = take(&mut map, &format!("{p}.adaln_modulation.1.weight"))?;
+            layers.push(QwenDriveExpertLayer {
+                input_layernorm: take(&mut map, &format!("{p}.input_layernorm.weight"))?,
+                qkv_w: transpose_2d(&qkv)?,
+                q_norm: take(&mut map, &format!("{p}.q_norm.weight"))?,
+                k_norm: take(&mut map, &format!("{p}.k_norm.weight"))?,
+                o_w: transpose_2d(&o)?,
+                post_attention_layernorm: take(
+                    &mut map,
+                    &format!("{p}.post_attention_layernorm.weight"),
+                )?,
+                gate_up_w: transpose_2d(&gate_up)?,
+                down_w: transpose_2d(&down)?,
+                modulation_w: transpose_2d(&modulation)?,
+                modulation_b: take(&mut map, &format!("{p}.adaln_modulation.1.bias"))?,
+            });
+        }
+
+        let (trajectory_proj_w, trajectory_proj_b) = take_linear(&mut map, "trajectory_proj")?;
+        let (out_proj_w, out_proj_b) = take_linear(&mut map, "out_proj")?;
+        let weights = Self {
+            trajectory_proj_w,
+            trajectory_proj_b,
+            fourier_encoder: take_mlp(&mut map, "fourier_encoder.net")?,
+            waypoint_embed: take(&mut map, "waypoint_embed.weight")?,
+            time_mlp: take_mlp(&mut map, "time_mlp")?,
+            nav_mlp: take_mlp(&mut map, "nav_mlp")?,
+            ego_mlp: take_mlp(&mut map, "ego_mlp")?,
+            history_encoder: take_mlp(&mut map, "history_encoder")?,
+            history_velocity_encoder: take_mlp(&mut map, "history_velocity_encoder")?,
+            history_acceleration_encoder: take_mlp(&mut map, "history_acceleration_encoder")?,
+            query_fusion: take_mlp(&mut map, "query_fusion")?,
+            layers,
+            final_layernorm: take(&mut map, "final_layernorm.weight")?,
+            out_proj_w,
+            out_proj_b,
+        };
+        weights.validate(config, &map)?;
+        Ok(weights)
+    }
+
+    /// Shape-level validation. Runs once at load; the first tuple element of
+    /// every 2D weight is its input width after the load-time transpose.
+    pub fn validate(&self, config: &QwenDriveConfig, leftover: &HashMap<String, Tensor>) -> Result<()> {
+        let expert = &config.expert;
+        let hidden = expert.hidden_size;
+        let heads_per_group = expert.n_heads / expert.n_kv_heads;
+        let qkv_out = expert.n_kv_heads * (2 * heads_per_group + 2) * expert.head_dim;
+        for (index, layer) in self.layers.iter().enumerate() {
+            expect_shape(&layer.qkv_w, &[hidden, qkv_out], &format!("layers.{index}.qkv_proj"))?;
+            expect_shape(&layer.o_w, &[expert.n_heads * expert.head_dim, hidden], &format!("layers.{index}.o_proj"))?;
+            expect_shape(&layer.gate_up_w, &[hidden, 2 * expert.intermediate_size], &format!("layers.{index}.gate_up_proj"))?;
+            expect_shape(&layer.down_w, &[expert.intermediate_size, hidden], &format!("layers.{index}.down_proj"))?;
+            expect_shape(&layer.modulation_w, &[hidden, 6 * hidden], &format!("layers.{index}.adaln_modulation"))?;
+            expect_shape(&layer.q_norm, &[expert.head_dim], &format!("layers.{index}.q_norm"))?;
+            expect_shape(&layer.k_norm, &[expert.head_dim], &format!("layers.{index}.k_norm"))?;
+        }
+        expect_shape(&self.trajectory_proj_w, &[config.trajectory_point_dim, hidden], "trajectory_proj")?;
+        expect_shape(&self.waypoint_embed, &[config.num_future_points, hidden], "waypoint_embed")?;
+        expect_shape(&self.out_proj_w, &[hidden, config.trajectory_point_dim], "out_proj")?;
+        let history_dim = (config.num_history_points - 1) * config.trajectory_point_dim
+            + expert.nav_command_classes;
+        expect_shape(&self.history_encoder.fc1_w, &[history_dim, hidden], "history_encoder.0")?;
+        let dynamics_dim = config.num_history_points * expert.history_dynamics_dim;
+        expect_shape(&self.history_velocity_encoder.fc1_w, &[dynamics_dim, hidden], "history_velocity_encoder.0")?;
+        expect_shape(&self.history_acceleration_encoder.fc1_w, &[dynamics_dim, hidden], "history_acceleration_encoder.0")?;
+        expect_shape(&self.query_fusion.fc1_w, &[7 * hidden, hidden], "query_fusion.0")?;
+        expect_shape(&self.time_mlp.fc1_w, &[expert.time_embed_dim, hidden], "time_mlp.0")?;
+        expect_shape(&self.nav_mlp.fc1_w, &[expert.nav_command_classes, hidden], "nav_mlp.0")?;
+        expect_shape(&self.ego_mlp.fc1_w, &[expert.ego_status_dim, hidden], "ego_mlp.0")?;
+        let fourier_in = config.trajectory_point_dim * expert.fourier_num_features * 2;
+        expect_shape(&self.fourier_encoder.fc1_w, &[fourier_in, hidden], "fourier_encoder.net.0")?;
+        if !leftover.is_empty() {
+            let mut names: Vec<&String> = leftover.keys().collect();
+            names.sort_unstable();
+            return Err(Error::Other(format!(
+                "qwen_drive expert weights: {} unconsumed tensors (strict load), first: {}",
+                names.len(),
+                names[0]
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn expect_shape(tensor: &Tensor, dims: &[usize], name: &str) -> Result<()> {
+    let actual = tensor.shape().dims();
+    if actual != dims {
+        return Err(Error::Other(format!(
+            "qwen_drive expert weights: {name} has shape {actual:?}, expected {dims:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Transpose a 2D HF projection weight `[out, in]` to `[in, out]` for the
+/// row-major matmul path. Handles f32 and bf16 (the checkpoint is bf16).
+pub fn transpose_2d(tensor: &Tensor) -> Result<Tensor> {
+    let dims = tensor.shape().dims();
+    if dims.len() != 2 {
+        return Err(Error::Other(format!(
+            "qwen_drive transpose_2d expected 2D tensor, got {}D",
+            dims.len()
+        )));
+    }
+    let [rows, cols] = [dims[0], dims[1]];
+    match tensor.dtype() {
+        apxinf_core::DType::F32 => {
+            let data = tensor.as_f32()?;
+            let mut out = vec![0.0f32; rows * cols];
+            for i in 0..rows {
+                for j in 0..cols {
+                    out[j * rows + i] = data[i * cols + j];
+                }
+            }
+            Tensor::from_f32(vec![cols, rows], &out)
+        }
+        apxinf_core::DType::BF16 => {
+            let data = tensor.as_bf16()?;
+            let mut out = vec![half::bf16::from_f32(0.0); rows * cols];
+            for i in 0..rows {
+                for j in 0..cols {
+                    out[j * rows + i] = data[i * cols + j];
+                }
+            }
+            Tensor::from_bf16(vec![cols, rows], &out)
+        }
+        dtype => Err(Error::Other(format!(
+            "qwen_drive weight transpose does not support {dtype}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use apxinf_core::DType;
+
+    fn tensor(rows: usize, cols: usize, fill: f32) -> Tensor {
+        Tensor::from_f32(vec![rows, cols], &vec![fill; rows * cols]).unwrap()
+    }
+
+    #[test]
+    fn transpose_swaps_dimensions() {
+        let a = Tensor::from_f32(vec![2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let t = transpose_2d(&a).unwrap();
+        assert_eq!(t.shape().dims(), &[3, 2]);
+        assert_eq!(t.as_f32().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn vlm_weights_reject_expert_head_maps() {
+        let mut map = HashMap::new();
+        map.insert("planning_expert.layers.0.qkv_proj.weight".to_string(), tensor(4, 4, 0.0));
+        let err = QwenDriveVlmWeights::from_map(map).err().unwrap();
+        assert!(format!("{err}").contains("planning-expert"));
+    }
+
+    #[test]
+    fn expert_weights_strip_prefix_and_transpose() {
+        // Minimal 1-layer expert geometry over a synthetic config; checks the
+        // key mapping, prefix stripping, transpose and strict consumption.
+        let config_json = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../experiment/qwen-drive-k3/checkpoint-configs/config.json"),
+        );
+        // The experiment fixture is not shipped with the crate; fall back to a
+        // synthetic config when it is absent so `cargo test` works from a
+        // bare checkout of the product tree.
+        let config = if let Ok(raw) = config_json {
+            QwenDriveConfig::from_json_str(&raw).unwrap()
+        } else {
+            return; // covered by the integration environment
+        };
+        let mut map: HashMap<String, Tensor> = HashMap::new();
+        let hidden = config.expert.hidden_size;
+        let inter = config.expert.intermediate_size;
+        let heads_per_group = config.expert.n_heads / config.expert.n_kv_heads;
+        let qkv_out = config.expert.n_kv_heads * (2 * heads_per_group + 2) * config.expert.head_dim;
+        for index in 0..config.expert.n_layers {
+            let p = format!("planning_expert.layers.{index}");
+            map.insert(format!("{p}.input_layernorm.weight"), tensor(1, hidden, 1.0));
+            map.insert(format!("{p}.qkv_proj.weight"), tensor(qkv_out, hidden, 0.0));
+            // RMSNorm weights are 1D `[head_dim]` in the real checkpoint.
+            map.insert(
+                format!("{p}.q_norm.weight"),
+                Tensor::from_f32(vec![config.expert.head_dim], &vec![1.0; config.expert.head_dim]).unwrap(),
+            );
+            map.insert(
+                format!("{p}.k_norm.weight"),
+                Tensor::from_f32(vec![config.expert.head_dim], &vec![1.0; config.expert.head_dim]).unwrap(),
+            );
+            map.insert(format!("{p}.o_proj.weight"), tensor(hidden, config.expert.n_heads * config.expert.head_dim, 0.0));
+            map.insert(format!("{p}.post_attention_layernorm.weight"), tensor(1, hidden, 1.0));
+            map.insert(format!("{p}.gate_up_proj.weight"), tensor(2 * inter, hidden, 0.0));
+            map.insert(format!("{p}.down_proj.weight"), tensor(hidden, inter, 0.0));
+            map.insert(format!("{p}.adaln_modulation.1.weight"), tensor(6 * hidden, hidden, 0.0));
+            map.insert(format!("{p}.adaln_modulation.1.bias"), tensor(1, 6 * hidden, 0.0));
+        }
+        let mlp = |map: &mut HashMap<String, Tensor>, prefix: &str, input: usize| {
+            map.insert(format!("{prefix}.0.weight"), tensor(hidden, input, 0.0));
+            map.insert(format!("{prefix}.0.bias"), tensor(1, hidden, 0.0));
+            map.insert(format!("{prefix}.2.weight"), tensor(hidden, hidden, 0.0));
+            map.insert(format!("{prefix}.2.bias"), tensor(1, hidden, 0.0));
+        };
+        let fourier_in = config.trajectory_point_dim * config.expert.fourier_num_features * 2;
+        mlp(&mut map, "planning_expert.fourier_encoder.net", fourier_in);
+        mlp(&mut map, "planning_expert.time_mlp", config.expert.time_embed_dim);
+        mlp(&mut map, "planning_expert.nav_mlp", config.expert.nav_command_classes);
+        mlp(&mut map, "planning_expert.ego_mlp", config.expert.ego_status_dim);
+        let history_dim = (config.num_history_points - 1) * config.trajectory_point_dim
+            + config.expert.nav_command_classes;
+        mlp(&mut map, "planning_expert.history_encoder", history_dim);
+        let dynamics_dim = config.num_history_points * config.expert.history_dynamics_dim;
+        mlp(&mut map, "planning_expert.history_velocity_encoder", dynamics_dim);
+        mlp(&mut map, "planning_expert.history_acceleration_encoder", dynamics_dim);
+        mlp(&mut map, "planning_expert.query_fusion", 7 * hidden);
+        map.insert("planning_expert.trajectory_proj.weight".to_string(), tensor(hidden, config.trajectory_point_dim, 0.0));
+        map.insert("planning_expert.trajectory_proj.bias".to_string(), tensor(1, hidden, 0.0));
+        map.insert("planning_expert.waypoint_embed.weight".to_string(), tensor(config.num_future_points, hidden, 0.0));
+        map.insert("planning_expert.final_layernorm.weight".to_string(), tensor(1, hidden, 1.0));
+        map.insert("planning_expert.out_proj.weight".to_string(), tensor(config.trajectory_point_dim, hidden, 0.0));
+        map.insert("planning_expert.out_proj.bias".to_string(), tensor(1, config.trajectory_point_dim, 0.0));
+
+        let weights = QwenDriveExpertWeights::from_map(&config, &map).unwrap();
+        assert_eq!(weights.layers.len(), config.expert.n_layers);
+        assert_eq!(weights.layers[0].qkv_w.shape().dims(), &[hidden, qkv_out]);
+        assert_eq!(weights.query_fusion.fc1_w.shape().dims(), &[7 * hidden, hidden]);
+        assert_eq!(weights.waypoint_embed.dtype(), DType::F32);
+    }
+}

--- a/crates/apxinf-py/src/lib.rs
+++ b/crates/apxinf-py/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! The public inference tier is numpy-in / numpy-out (host):
 //!
-//! * **L1** [`Model::infer_rgb`] — caller supplies resized RGB `uint8` images;
-//!   vision→patches runs inside the Rust CUDA graph.
+//! * **L1** [`Model::infer_rgb`] - caller supplies resized RGB `uint8` images;
+//!   vision->patches runs inside the Rust CUDA graph.
 //!
 //! **L0** [`Model::infer_patches`] (caller supplies pre-computed `patches`,
 //! equivalent to a Rust `Observation(Patches)`) is exposed under the private
@@ -25,6 +25,9 @@
 //! The VLA runtimes are only registered on CUDA devices, so real inference
 //! requires the `cuda` feature and a CUDA machine; without it the module still
 //! imports and reports shape contracts, but model loading errors.
+//!
+//! [`QwenDriveModel`] is the Qwen-Drive surface: VQA generation plus the two
+//! planning flows (direct and reasoning) against the native CUDA executor.
 
 use std::cell::Cell;
 use std::collections::BTreeMap;
@@ -43,6 +46,8 @@ use apxinf_model::{
     AutoModel, ImageLayout, LoadOptions, LoadedModel, ModelPrecision, Observation, Pi05Config,
     SyntheticWeights, VisionObservation, VlaContract, VlaRequest,
 };
+#[cfg(feature = "cuda")]
+use apxinf_model::qwen_drive::ExpertConditioning;
 
 /// Map any Rust error into a Python `RuntimeError`.
 fn runtime_err<E: std::fmt::Display>(error: E) -> PyErr {
@@ -264,28 +269,28 @@ impl Model {
 impl Model {
     /// Load a VLA checkpoint through the unified `AutoModel` frontend.
     ///
-    /// * `model` — model name, e.g. `"pi05"`.
-    /// * `path` — checkpoint directory or index file.
-    /// * `device` — `cuda:N` (default) or `cpu`.
-    /// * `precision` — `auto` (default), `fp8`, `bf16`, or `int8`.
-    /// * `calibration` — optional FP8 calibration json.
-    /// * `tactics` — optional hardware-wide GEMM tactics json.
-    /// * `autotune` — tune missing exact GEMM keys from the first real request.
-    /// * `sampling_seed` — seed for the implicit device-side noise stream used
+    /// * `model` - model name, e.g. `"pi05"`.
+    /// * `path` - checkpoint directory or index file.
+    /// * `device` - `cuda:N` (default) or `cpu`.
+    /// * `precision` - `auto` (default), `fp8`, `bf16`, or `int8`.
+    /// * `calibration` - optional FP8 calibration json.
+    /// * `tactics` - optional hardware-wide GEMM tactics json.
+    /// * `autotune` - tune missing exact GEMM keys from the first real request.
+    /// * `sampling_seed` - seed for the implicit device-side noise stream used
     ///   when inference is called without `noise`.
-    /// * `config_json` — optional `config.json`-shaped architecture JSON.
+    /// * `config_json` - optional `config.json`-shaped architecture JSON.
     ///   `None` delegates config loading to AutoModel.
-    /// * `action_horizon` — override the checkpoint's chunk length. `None`
+    /// * `action_horizon` - override the checkpoint's chunk length. `None`
     ///   (default) runs the native `config.json` value; an explicit value wins
     ///   over it. The horizon is a sequence length, not a weight dimension, so
     ///   the same weights load and run at the requested chunk length.
-    /// * `num_views` — serve fewer cameras than the checkpoint declares.
+    /// * `num_views` - serve fewer cameras than the checkpoint declares.
     ///
     /// `num_views` exists because a deployment often has fewer cameras than the
     /// checkpoint was trained with. Dropping the trailing views is numerically
-    /// equivalent to openpi zero-padding and masking them — a masked view is
-    /// excluded from attention and consumes no RoPE position, and the vision
-    /// tower has no per-slot parameters — while saving one view's worth of patch
+    /// equivalent to openpi zero-padding and masking them - a masked view is
+    /// excluded from attention, consumes no RoPE position, and the vision
+    /// tower has no per-slot parameters - while saving one view's worth of patch
     /// tokens per step. Nothing weight-shaped depends on the count; it only sizes
     /// the prefix, so this is a load-time constant, not a per-request one.
     #[staticmethod]
@@ -369,15 +374,15 @@ impl Model {
     /// architecture is `Pi05Config::default()` overlaid with the given shape
     /// parameters, letting one call sweep 2/3-view, image size, horizon, etc.
     ///
-    /// * `model` — model name, e.g. `"pi05"`.
-    /// * `device` — `cuda:N` (default) or `cpu`.
-    /// * `precision` — `bf16` (default), `fp8`, or `int8`.
-    /// * `calibration` — for FP8: `"uniform:<scale>"` for a uniform activation
+    /// * `model` - model name, e.g. `"pi05"`.
+    /// * `device` - `cuda:N` (default) or `cpu`.
+    /// * `precision` - `bf16` (default), `fp8`, or `int8`.
+    /// * `calibration` - for FP8: `"uniform:<scale>"` for a uniform activation
     ///   scale (no calibration file), or a path to a calibration json.
-    /// * `tactics` — optional hardware-wide GEMM tactics json.
-    /// * `autotune` — tune missing exact GEMM keys from the first real request.
-    /// * `seed` — RNG seed for reproducible weights.
-    /// * `sampling_seed` — independent seed for implicit device-side noise.
+    /// * `tactics` - optional hardware-wide GEMM tactics json.
+    /// * `autotune` - tune missing exact GEMM keys from the first real request.
+    /// * `seed` - RNG seed for reproducible weights.
+    /// * `sampling_seed` - independent seed for implicit device-side noise.
     #[staticmethod]
     #[pyo3(signature = (
         model,
@@ -463,13 +468,13 @@ impl Model {
         })
     }
 
-    /// **L0** (internal, not public API) — infer from pre-computed patches. No
+    /// **L0** (internal, not public API) - infer from pre-computed patches. No
     /// processor is applied. Exposed to Python as the private `_infer_patches`
     /// for L0/L1 consistency tests only; may change or be removed without notice.
     ///
-    /// * `patches` — `float32` `[num_views * patches_per_view, 3 * patch_size^2]`.
-    /// * `token_ids` — `uint32` `[token_count]` (1..=max_token_len).
-    /// * `noise` — optional `float32` `[action_horizon, action_dim]`; omission
+    /// * `patches` - `float32` `[num_views * patches_per_view, 3 * patch_size^2]`.
+    /// * `token_ids` - `uint32` `[token_count]` (1..=max_token_len).
+    /// * `noise` - optional `float32` `[action_horizon, action_dim]`; omission
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
@@ -568,14 +573,14 @@ impl Model {
         self.run_generated(py, observation, RngKey::new(seed, sequence, draw))
     }
 
-    /// **L1** — infer from resized RGB `uint8` images; vision→patches runs in the
+    /// **L1** - infer from resized RGB `uint8` images; vision->patches runs in the
     /// Rust CUDA graph.
     ///
-    /// * `rgb_u8` — `uint8` images, `num_views * image_size * image_size * 3`
+    /// * `rgb_u8` - `uint8` images, `num_views * image_size * image_size * 3`
     ///   bytes total, in `layout` order.
-    /// * `layout` — `"nhwc"` or `"nchw"`.
-    /// * `token_ids` — `uint32` `[token_count]`.
-    /// * `noise` — optional `float32` `[action_horizon, action_dim]`; omission
+    /// * `layout` - `"nhwc"` or `"nchw"`.
+    /// * `token_ids` - `uint32` `[token_count]`.
+    /// * `noise` - optional `float32` `[action_horizon, action_dim]`; omission
     ///   uses the model's internal device-side sampling stream.
     ///
     /// Returns the normalized-domain action, `float32` `[action_horizon, action_dim]`.
@@ -799,9 +804,264 @@ impl Model {
     }
 }
 
+// ── Qwen-Drive native model surface ────────────────────────────────────────
+
+#[cfg(feature = "cuda")]
+fn qwen_pixels_tensor(pixels: &PyReadonlyArray2<'_, f32>) -> PyResult<Tensor> {
+    let shape = pixels.shape();
+    let data = pixels.as_slice().map_err(|_| {
+        PyValueError::new_err(
+            "apxinf_py.QwenDriveModel: pixel_values must be C-contiguous float32",
+        )
+    })?;
+    Tensor::from_f32(shape.to_vec(), data).map_err(runtime_err)
+}
+
+#[cfg(feature = "cuda")]
+fn qwen_vector(array: &PyReadonlyArray1<'_, f32>, name: &str) -> PyResult<Vec<f32>> {
+    Ok(array
+        .as_slice()
+        .map_err(|_| {
+            PyValueError::new_err(format!(
+                "apxinf_py.QwenDriveModel: {name} must be C-contiguous float32"
+            ))
+        })?
+        .to_vec())
+}
+
+#[cfg(feature = "cuda")]
+fn qwen_noise(
+    noise: &PyReadonlyArrayDyn<'_, f32>,
+    points: usize,
+    point_dim: usize,
+) -> PyResult<Vec<f32>> {
+    let data = noise.as_slice().map_err(|_| {
+        PyValueError::new_err("apxinf_py.QwenDriveModel: noise must be C-contiguous float32")
+    })?;
+    if data.len() != points * point_dim {
+        return Err(PyValueError::new_err(format!(
+            "apxinf_py.QwenDriveModel: noise has {} values, expected {} ({}x{})",
+            data.len(),
+            points * point_dim,
+            points,
+            point_dim
+        )));
+    }
+    Ok(data.to_vec())
+}
+
+#[cfg(feature = "cuda")]
+fn qwen_trajectory<'py>(py: Python<'py>, flat: Vec<f32>) -> PyResult<Bound<'py, PyArray2<f32>>> {
+    if flat.len() != 150 {
+        return Err(PyRuntimeError::new_err(format!(
+            "apxinf_py.QwenDriveModel: model returned {} trajectory values, expected 150",
+            flat.len()
+        )));
+    }
+    if let Some(bad) = flat.iter().find(|value| !value.is_finite()) {
+        return Err(PyRuntimeError::new_err(format!(
+            "apxinf_py.QwenDriveModel: model produced non-finite trajectory value {bad}"
+        )));
+    }
+    let array = Array2::from_shape_vec((50, 3), flat).map_err(runtime_err)?;
+    Ok(array.into_pyarray_bound(py))
+}
+
+#[cfg(feature = "cuda")]
+fn qwen_conditioning(
+    history: &PyReadonlyArray1<'_, f32>,
+    history_velocity: &PyReadonlyArray1<'_, f32>,
+    history_acceleration: &PyReadonlyArray1<'_, f32>,
+    ego_status: &PyReadonlyArray1<'_, f32>,
+    nav_command: i64,
+) -> PyResult<ExpertConditioning> {
+    Ok(ExpertConditioning {
+        history: qwen_vector(history, "history")?,
+        history_velocity: qwen_vector(history_velocity, "history_velocity")?,
+        history_acceleration: qwen_vector(history_acceleration, "history_acceleration")?,
+        nav_command,
+        ego_status: qwen_vector(ego_status, "ego_status")?,
+    })
+}
+
+/// A loaded Qwen-Drive native model (Qwen3.5 VLM + optional planning expert).
+///
+/// VQA generation plus the direct/reasoning planning flows against the native
+/// CUDA executor. Tokenization and image preprocessing live in the Python
+/// policy layer; this class accepts canonical tensors.
+#[cfg(feature = "cuda")]
+#[pyclass(unsendable)]
+pub struct QwenDriveModel {
+    model: apxinf_model::qwen_drive::QwenDriveModel,
+    device: Device,
+}
+
+#[cfg(feature = "cuda")]
+#[pymethods]
+impl QwenDriveModel {
+    /// Load the VLM from `path` and optionally a planning-expert head from
+    /// `planner`. Precision is fixed to the checkpoint's native bf16.
+    #[staticmethod]
+    #[pyo3(signature = (path, planner=None, device="cuda:0", precision="bf16"))]
+    fn load(
+        path: PathBuf,
+        planner: Option<PathBuf>,
+        device: &str,
+        precision: &str,
+    ) -> PyResult<Self> {
+        if precision != "bf16" && precision != "auto" {
+            return Err(PyValueError::new_err(format!(
+                "apxinf_py.QwenDriveModel.load: qwen_drive is bf16-native (got `{precision}`)"
+            )));
+        }
+        let device = parse_device(device)?;
+        let model = apxinf_model::qwen_drive::QwenDriveModel::load(
+            &path,
+            planner.as_deref(),
+            device,
+        )
+        .map_err(runtime_err)?;
+        Ok(Self { model, device })
+    }
+
+    /// VQA / free-form generation (greedy; the reference's top_k=1 sampling is
+    /// equivalent). Returns the generated token ids, terminator included.
+    #[pyo3(signature = (token_ids, pixel_values, grid_thw, max_new_tokens, min_new_tokens=0, eos_token_ids=None))]
+    fn generate_tokens(
+        &mut self,
+        token_ids: Vec<u32>,
+        pixel_values: PyReadonlyArray2<'_, f32>,
+        grid_thw: Vec<[u32; 3]>,
+        max_new_tokens: usize,
+        min_new_tokens: usize,
+        eos_token_ids: Option<Vec<u32>>,
+    ) -> PyResult<Vec<u32>> {
+        let pixel_tensor = qwen_pixels_tensor(&pixel_values)?;
+        let eos = eos_token_ids.unwrap_or_else(|| vec![248044, 248045]);
+        self.model
+            .generate(
+                &token_ids,
+                Some((&pixel_tensor, &grid_thw)),
+                max_new_tokens,
+                min_new_tokens,
+                &eos,
+            )
+            .map_err(runtime_err)
+    }
+
+    /// Direct planning from a closed empty assistant turn. Returns the
+    /// normalized fp32 trajectory `[50, 3]` (the policy denormalizes).
+    #[pyo3(signature = (token_ids, pixel_values, grid_thw, history, history_velocity, history_acceleration, ego_status, nav_command, noise, num_steps=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn plan_direct<'py>(
+        &mut self,
+        py: Python<'py>,
+        token_ids: Vec<u32>,
+        pixel_values: PyReadonlyArray2<'py, f32>,
+        grid_thw: Vec<[u32; 3]>,
+        history: PyReadonlyArray1<'py, f32>,
+        history_velocity: PyReadonlyArray1<'py, f32>,
+        history_acceleration: PyReadonlyArray1<'py, f32>,
+        ego_status: PyReadonlyArray1<'py, f32>,
+        nav_command: i64,
+        noise: PyReadonlyArrayDyn<'py, f32>,
+        num_steps: Option<usize>,
+    ) -> PyResult<Bound<'py, PyArray2<f32>>> {
+        let pixel_tensor = qwen_pixels_tensor(&pixel_values)?;
+        let cond = qwen_conditioning(
+            &history,
+            &history_velocity,
+            &history_acceleration,
+            &ego_status,
+            nav_command,
+        )?;
+        let noise_vec = qwen_noise(&noise, 50, 3)?;
+        let flat = self
+            .model
+            .plan_direct(&token_ids, &pixel_tensor, &grid_thw, &cond, &noise_vec, num_steps)
+            .map_err(runtime_err)?;
+        qwen_trajectory(py, flat)
+    }
+
+    /// Reasoning planning: greedy assistant turn (min/max bounds), trained
+    /// turn completion in the cache, then the sampler. Returns
+    /// `(generated_token_ids, normalized_trajectory[50, 3])`.
+    #[pyo3(signature = (token_ids, pixel_values, grid_thw, history, history_velocity, history_acceleration, ego_status, nav_command, noise, max_new_tokens, min_new_tokens, terminator_ids, im_end_id, newline_ids, num_steps=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn plan_reasoning<'py>(
+        &mut self,
+        py: Python<'py>,
+        token_ids: Vec<u32>,
+        pixel_values: PyReadonlyArray2<'py, f32>,
+        grid_thw: Vec<[u32; 3]>,
+        history: PyReadonlyArray1<'py, f32>,
+        history_velocity: PyReadonlyArray1<'py, f32>,
+        history_acceleration: PyReadonlyArray1<'py, f32>,
+        ego_status: PyReadonlyArray1<'py, f32>,
+        nav_command: i64,
+        noise: PyReadonlyArrayDyn<'py, f32>,
+        max_new_tokens: usize,
+        min_new_tokens: usize,
+        terminator_ids: Vec<u32>,
+        im_end_id: u32,
+        newline_ids: Vec<u32>,
+        num_steps: Option<usize>,
+    ) -> PyResult<(Vec<u32>, Bound<'py, PyArray2<f32>>)> {
+        let pixel_tensor = qwen_pixels_tensor(&pixel_values)?;
+        let cond = qwen_conditioning(
+            &history,
+            &history_velocity,
+            &history_acceleration,
+            &ego_status,
+            nav_command,
+        )?;
+        let noise_vec = qwen_noise(&noise, 50, 3)?;
+        let (generated, flat) = self
+            .model
+            .plan_reasoning(
+                &token_ids,
+                &pixel_tensor,
+                &grid_thw,
+                max_new_tokens,
+                min_new_tokens,
+                &terminator_ids,
+                im_end_id,
+                &newline_ids,
+                &cond,
+                &noise_vec,
+                num_steps,
+            )
+            .map_err(runtime_err)?;
+        Ok((generated, qwen_trajectory(py, flat)?))
+    }
+
+    #[getter]
+    fn device(&self) -> String {
+        match self.device {
+            Device::Cuda(index) => format!("cuda:{index}"),
+            Device::Cpu => "cpu".to_string(),
+        }
+    }
+
+    #[getter]
+    fn has_planner(&self) -> bool {
+        self.model.has_planner()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "QwenDriveModel(device={}, planner={})",
+            self.device(),
+            self.model.has_planner(),
+        )
+    }
+}
+
 #[pymodule]
 fn apxinf_py(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<Model>()?;
+    #[cfg(feature = "cuda")]
+    module.add_class::<QwenDriveModel>()?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,3 +3,9 @@
 This directory contains user-facing guides, current architecture references,
 API documentation, and regression procedures that are maintained together with
 the ApxInf source code.
+
+## Current model-port records
+
+- [Qwen-Drive on ApxInf with KerSor and DSH](kersor-qwen-drive-4090.md) —
+  draft integration, RTX 4090 evidence, and the agent-driven development
+  boundary.

--- a/doc/kersor-qwen-drive-4090.md
+++ b/doc/kersor-qwen-drive-4090.md
@@ -94,10 +94,11 @@ does not claim that this repair has passed until a new RTX 4090 receipt exists.
 
 ## Development skill and review boundary
 
-The ApxInf model-porting skill supplies the semantic contract: read the official
-reference, preserve checkpoint names and public behavior, add the native model
-registration, keep CPU scaffolds separate from device implementation, and use
-the fixed Host verifier for acceptance. KerSor supplies the long-running plan,
+The ApxInf [model-porting skill](../skills/model-port-workflow/SKILL.md)
+supplies the semantic contract: read the official reference, preserve checkpoint
+names and public behavior, add the native model registration, keep CPU scaffolds
+separate from device implementation, and use the fixed Host verifier for
+acceptance. KerSor supplies the long-running plan,
 resume and evidence loop around that skill. DSH supplies the model activation
 and SSH-capable Host handoff; it does not become the correctness authority.
 

--- a/doc/kersor-qwen-drive-4090.md
+++ b/doc/kersor-qwen-drive-4090.md
@@ -1,0 +1,127 @@
+# Qwen-Drive on ApxInf with KerSor and DSH
+
+Status: draft integration and optimization record.
+
+This document describes an ongoing model-porting effort for
+[Qwen-Drive-1.0-4B](https://huggingface.co/Qwen/Qwen-Drive-1.0-4B) in ApxInf.
+The target is a native BF16 deployment on an NVIDIA RTX 4090, with the public
+VQA, planning and perception paths kept behind ApxInf's normal policy and model
+registration boundaries.
+
+The code in this pull request is the current K3 candidate snapshot. It has been
+compiled and executed on a real RTX 4090, but the complete four-mode acceptance
+gate is still pending. This is intentionally a draft PR: it records the
+integration surface and the agent-driven development method while the remaining
+text-prefill path is being optimized.
+
+## What this work adds
+
+The port follows ApxInf's model-porting contract instead of adding a separate
+runner or a model-specific service. The current candidate includes:
+
+- Qwen-Drive model registration and `AutoPolicy` dispatch;
+- checkpoint key normalization and mixed-dtype weight loading;
+- device-resident language, vision, expert and planner state;
+- the Python policy entry point and the existing PyO3 boundary;
+- CUDA attention and linear-attention integration through ApxInf's kernel and
+  FFI layers;
+- the public Qwen-Drive inference path used by the Host-owned verifier.
+
+The candidate preserves the official checkpoint and reference outputs. The
+Host owns the checkpoint, test inputs, GPU allocation, timing limits and final
+`native_deployment_valid` decision. A local build or a successful model import
+does not satisfy that decision.
+
+## How KerSor and DSH are used
+
+[KerSor](https://github.com/qhy991/KerSor) is the workflow controller. Its
+Mission-v1 runtime gives the model a bounded set of capabilities, compiles each
+FuturePlan into a finite DAG, records immutable completed history, and asks for
+a new plan only after a node exposes new evidence. The planner is guided by a
+small set of composable topology principles: serial dependencies, logical
+fork/join, fact-based routing, evidence checkpoints and frontier continuation.
+The source workflow catalog is reference material; the planner designs the
+current graph from the task and evidence.
+
+DSH provides the model activation path. In this experiment the DSH application
+uses the Infini-AI K3 route, while the KerSor Host keeps the write surface and
+the remote evaluator separate. The model writes one complete `proposal.json`
+candidate. The Host materializes that candidate into an isolated ApxInf
+worktree, submits it through the GPU broker to the RTX 4090, and writes the
+terminal receipt back to the same Mission.
+
+```mermaid
+flowchart LR
+    A[Mission goal and ApxInf skill] --> B[KerSor planner]
+    B --> C[FuturePlan DAG]
+    C --> D[DSH K3 agent]
+    D --> E[proposal.json]
+    E --> F[Host candidate snapshot]
+    F --> G[GPU broker]
+    G --> H[RTX 4090 build and verifier]
+    H --> I[terminal receipt]
+    I --> B
+    I --> J{native_deployment_valid}
+```
+
+Each revision has one proposal writer. Independent read-only analyses may be
+represented as separate branches and joined by an evidence-review node, but the
+current DSH Host serializes native calls. `await_lab` is an external checkpoint:
+it returns `waiting` while the immutable remote job is running and resumes the
+same Mission when a terminal receipt arrives.
+
+## Evidence from the RTX 4090 run
+
+The latest candidate was submitted to the exclusive GPU broker as a VQA
+candidate. The evidence shows that the model is genuinely executing on the
+target GPU:
+
+| Stage | Observed result |
+| --- | --- |
+| GPU boundary check | Passed on RTX 4090, `sm_89` |
+| CUDA build | Passed; the optimized release build completed in about 43 minutes |
+| Native extension | Imported successfully |
+| Model loading | 723 tensors loaded; 426 language tensors and 297 vision tensors became device resident in about 60 seconds |
+| Vision path | All 24 vision blocks completed; `vision_done` and `embed_scatter_done` were emitted |
+| Text prefill | Reached `prefill_layer k=3`; the first missing heartbeat was the following causal hdim256 path |
+| VQA acceptance | Failed the fixed 300-second run limit before `inference_returned` |
+| Four-mode deployment | Not yet accepted; the Host has not produced `native_deployment_valid=true` |
+
+The timeout is therefore a real performance and integration boundary, not a
+DSH connection failure or a model-load failure. The current follow-up revision
+uses the measured vision result and targets the causal text-prefill route. It
+does not claim that this repair has passed until a new RTX 4090 receipt exists.
+
+## Development skill and review boundary
+
+The ApxInf model-porting skill supplies the semantic contract: read the official
+reference, preserve checkpoint names and public behavior, add the native model
+registration, keep CPU scaffolds separate from device implementation, and use
+the fixed Host verifier for acceptance. KerSor supplies the long-running plan,
+resume and evidence loop around that skill. DSH supplies the model activation
+and SSH-capable Host handoff; it does not become the correctness authority.
+
+This division makes failures reviewable:
+
+1. A planner decision is recorded with its dependencies and consumed evidence.
+2. A source candidate is content-addressed before the Host submits it.
+3. The broker receipt identifies the exact GPU job and candidate.
+4. Build, load, inference and complete-mode results remain separate evidence
+   layers.
+5. Only the independent Host verifier can close the Mission.
+
+The companion KerSor planning changes and their tests are in
+[KerSor PR #117](https://github.com/qhy991/KerSor/pull/117). The parallel Codex
+experiment reached native build/load and VQA diagnosis, but then stopped on
+provider quota exhaustion; it has no new accepted ApxInf result to include in a
+second PR at this time.
+
+## Current next step
+
+The next candidate replaces only the measured causal text-prefill bottleneck,
+retains the working vision route and diagnostic markers, and reruns the same
+Host-owned VQA gate. If that candidate reaches `inference_returned`, the
+Mission can use the resulting evidence to decide whether to measure decode,
+planning and perception modes. The PR should remain draft until the fixed
+four-mode acceptance gate passes or the experiment is explicitly closed as a
+negative result.

--- a/python/apxinf/apxinf/policies/__init__.py
+++ b/python/apxinf/apxinf/policies/__init__.py
@@ -4,12 +4,12 @@ This package owns everything policy-related, mirroring how :mod:`apxinf.processo
 owns its own steps and :class:`~apxinf.processors.base.ProcessorStep`. It is split
 into a **stable** outer layer and a **volatile** inner one:
 
-* :mod:`~apxinf.policies.base` — the :class:`Policy` / :class:`BareModel` contracts,
+* :mod:`~apxinf.policies.base` - the :class:`Policy` / :class:`BareModel` contracts,
   plus :class:`ComposablePolicy` (the opt-in seam a robot adapter wraps) and
   :data:`VIEW_SLOTS` (the camera slot names the weights consume, in order).
-* :mod:`~apxinf.policies.registry` — the ``model_type -> policy class`` registry.
-* :mod:`~apxinf.policies.auto` — :class:`AutoPolicy`, dispatch by ``config.json`` type.
-* :mod:`~apxinf.policies.impls` — the concrete per-model policies (``pi05``, ...),
+* :mod:`~apxinf.policies.registry` - the ``model_type -> policy class`` registry.
+* :mod:`~apxinf.policies.auto` - :class:`AutoPolicy`, dispatch by ``config.json`` type.
+* :mod:`~apxinf.policies.impls` - the concrete per-model policies (``pi05``, ...),
   the only part that grows as models are added.
 
 Importing this package imports :mod:`~apxinf.policies.impls`, whose modules
@@ -19,8 +19,8 @@ register themselves under a ``model_type`` via :func:`register_policy` so
 ``@register_policy("<name>")``), then re-export it from
 :mod:`apxinf.policies.impls`.
 
-None of this imports ``apxinf_py`` — policy classes load the CUDA binding lazily,
-inside ``from_pretrained`` — so importing the package stays offline-friendly.
+None of this imports ``apxinf_py`` - policy classes load the CUDA binding lazily,
+inside ``from_pretrained`` - so importing the package stays offline-friendly.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ from .base import VIEW_SLOTS, BareModel, ComposablePolicy, Policy
 from .registry import available_policies, get_policy, register_policy
 
 # Concrete model policies (importing registers them under their model_type).
-from .impls import Pi05Policy, WallossPolicy
+from .impls import Pi05Policy, QwenDrivePolicy, WallossPolicy
 
 __all__ = [
     "Policy",
@@ -42,5 +42,6 @@ __all__ = [
     "get_policy",
     "available_policies",
     "Pi05Policy",
+    "QwenDrivePolicy",
     "WallossPolicy",
 ]

--- a/python/apxinf/apxinf/policies/impls/__init__.py
+++ b/python/apxinf/apxinf/policies/impls/__init__.py
@@ -1,7 +1,7 @@
-"""Concrete per-model L2 policies — the volatile part of the policy layer.
+"""Concrete per-model L2 policies - the volatile part of the policy layer.
 
 One module per model family (:mod:`~apxinf.policies.impls.pi05`, and future
-``groot``, ...). The stable machinery — contracts, registry, dispatch — lives one
+``groot``, ...). The stable machinery - contracts, registry, dispatch - lives one
 level up in :mod:`apxinf.policies`; only this package grows as models are added.
 
 Importing this package imports every model module for its side effect: each
@@ -18,6 +18,7 @@ inside ``from_pretrained``, so importing the package stays offline-friendly.
 from __future__ import annotations
 
 from .pi05 import Pi05Policy
+from .qwen_drive import QwenDrivePolicy
 from .walloss import WallossPolicy
 
-__all__ = ["Pi05Policy", "WallossPolicy"]
+__all__ = ["Pi05Policy", "QwenDrivePolicy", "WallossPolicy"]

--- a/python/apxinf/apxinf/policies/impls/qwen_drive.py
+++ b/python/apxinf/apxinf/policies/impls/qwen_drive.py
@@ -1,0 +1,598 @@
+"""Qwen-Drive L2 policy: driving-scene preprocessing + native model calls.
+
+Registers ``QwenDrivePolicy`` under ``model_type="qwen_drive"`` so
+:class:`~apxinf.policies.auto.AutoPolicy` can dispatch to it.
+
+The policy owns canonical preprocessing and postprocessing, mirroring the
+reference ``QwenDriveProcessor`` contract exactly: PIL bicubic resize
+(torchvision dispatches PIL inputs to PIL resize), ``smart_resize`` factor
+snapping with Python ``round()``, pixel normalization ``(x/255 - 0.5) / 0.5``,
+block-ordered patchify (permute ``(1,3,6,4,7,0,2,5,8)``), ChatML prompt
+composition, history re-referencing/normalization, detokenization with
+think-block stripping, and trajectory denormalization with heading wrap.
+
+All model computation runs in the Rust/CUDA executor through
+``apxinf_py.QwenDriveModel``. No torch/Transformers model execution, no CPU
+model hot path, no subprocess or remote inference fallback happens here.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from ..registry import register_policy
+
+__all__ = ["QwenDrivePolicy"]
+
+CAMERA_VIEWS = ("<FRONT VIEW>", "<FRONT LEFT VIEW>", "<FRONT RIGHT VIEW>")
+NAV_COMMANDS = ("GO STRAIGHT", "TURN LEFT", "TURN RIGHT")
+HISTORY_FRAME_LABELS = ("t-1.5s", "t-1.0s", "t-0.5s", "t-0s")
+REASONING_REQUEST = (
+    "\n\nGive a one-sentence brief reasoning of the ego's future driving decision ONLY."
+)
+THINK_CLOSE = "</think>"
+
+_INSTRUCTION_HEADER = (
+    "The input images are organized by camera view. Each view contains {num_frames} temporal "
+    "frames captured at {interval:g}s intervals (frame 0 at {first_label}, frame {last_frame} is "
+    "the current frame at t=0s).\n"
+    "1. Historical trajectories (x, y, heading) in the current frame's ego coordinate system. "
+    "Positive x points forward, positive y points left, and a positive heading indicates a left "
+    "turn\uff1a\n"
+)
+
+
+def _strip_thinking(text: str) -> str:
+    """Drop a leading thinking block, keeping the answer that follows it."""
+    return text.split(THINK_CLOSE)[-1].strip()
+
+
+def _round_by_factor(value: float, factor: int) -> int:
+    return round(value / factor) * factor
+
+
+def smart_resize(
+    height: int, width: int, factor: int, min_pixels: int, max_pixels: int
+) -> Tuple[int, int]:
+    """Snap a resolution to a multiple of ``factor`` inside a pixel budget.
+
+    Bit-identical to the reference: Python ``round()`` is banker's rounding,
+    and the shrink/enlarge branches match its floor/ceil behavior.
+    """
+    bar_h = _round_by_factor(height, factor)
+    bar_w = _round_by_factor(width, factor)
+    pixels = bar_h * bar_w
+    if pixels > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        bar_h = math.floor(height / beta / factor) * factor
+        bar_w = math.floor(width / beta / factor) * factor
+    elif pixels < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        bar_h = math.ceil(height * beta / factor) * factor
+        bar_w = math.ceil(width * beta / factor) * factor
+    return bar_h, bar_w
+
+
+def _wrap_heading(trajectory: np.ndarray) -> np.ndarray:
+    heading = np.remainder(trajectory[..., 2:3] + math.pi, 2 * math.pi) - math.pi
+    return np.concatenate([trajectory[..., :2], heading], axis=-1)
+
+
+class _Tokenizer:
+    """Uniform facade over the fast `tokenizers` backend or AutoTokenizer.
+
+    Tokenization is a preprocessing utility only; no model code is involved.
+    """
+
+    def __init__(self, model_dir: Path):
+        self._fast = None
+        self._slow = None
+        tokenizer_json = model_dir / "tokenizer.json"
+        if tokenizer_json.is_file():
+            try:
+                from tokenizers import Tokenizer
+
+                self._fast = Tokenizer.from_file(str(tokenizer_json))
+            except ImportError:
+                self._fast = None
+        if self._fast is None:
+            from transformers import AutoTokenizer
+
+            self._slow = AutoTokenizer.from_pretrained(str(model_dir))
+
+    def encode(self, text: str) -> list:
+        if self._fast is not None:
+            return list(self._fast.encode(text, add_special_tokens=False).ids)
+        return list(self._slow.encode(text, add_special_tokens=False))
+
+    def decode(self, ids: Sequence[int], skip_special_tokens: bool = True) -> str:
+        if self._fast is not None:
+            return self._fast.decode(list(ids), skip_special_tokens=skip_special_tokens)
+        return self._slow.decode(list(ids), skip_special_tokens=skip_special_tokens)
+
+    def token_id(self, token: str) -> int:
+        if self._fast is not None:
+            value = self._fast.token_to_id(token)
+        else:
+            value = self._slow.convert_tokens_to_ids(token)
+        if value is None:
+            raise KeyError(f"token {token!r} is not in the tokenizer vocabulary")
+        return int(value)
+
+
+@register_policy("qwen_drive")
+class QwenDrivePolicy:
+    """Scene dict -> native Qwen-Drive outputs, per the frozen public contract."""
+
+    def __init__(
+        self,
+        model,
+        *,
+        config: Mapping[str, Any],
+        tokenizer: _Tokenizer,
+        mode: str,
+        eos_token_ids: Sequence[int],
+        seed: int,
+        max_new_tokens: int,
+        min_new_tokens: int,
+        num_steps: int,
+    ):
+        self.model = model
+        self.config = dict(config)
+        self.tokenizer = tokenizer
+        self.mode = mode
+        self.eos_token_ids = list(eos_token_ids)
+        self.seed = int(seed)
+        self.max_new_tokens = int(max_new_tokens)
+        self.min_new_tokens = int(min_new_tokens)
+        self.num_steps = int(num_steps)
+
+        vlm = self.config["vlm_config"]
+        self.image_token_id = int(vlm["image_token_id"])
+        self.vision_start_id = int(vlm["vision_start_token_id"])
+        self.vision_end_id = int(vlm["vision_end_token_id"])
+        self.im_start_id = self.tokenizer.token_id("<|im_start|>")
+        self.im_end_id = self.tokenizer.token_id("<|im_end|>")
+        self.newline_ids = self.tokenizer.encode("\n")
+
+        self.patch_size = int(self.config["image_patch_size"])
+        self.merge = int(self.config["image_spatial_merge_size"])
+        self.temporal = int(self.config["image_temporal_patch_size"])
+        self.factor = self.patch_size * self.merge
+        self.min_pixels = 4 * self.factor**2
+        self.grid_pixel_limit = 12800 * self.factor**2
+        self.history_pixels = int(self.config["history_image_pixels"])
+        self.current_pixels = int(self.config["current_image_pixels"])
+        self.scale = np.asarray(self.config["trajectory_scale"], dtype=np.float32)
+        self.metadata = {
+            "model_type": "qwen_drive",
+            "mode": self.mode,
+            "action_horizon": int(self.config["num_future_points"]),
+            "action_dim": int(self.config["trajectory_point_dim"]),
+            "num_inference_steps": self.num_steps,
+            "native_executor": "apxinf-cuda",
+        }
+
+    # ------------------------------------------------------------------ construction
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_dir,
+        *,
+        precision: str = "bf16",
+        mode: str = "direct_planning",
+        planner=None,
+        device: str = "cuda:0",
+        seed: Optional[int] = None,
+        max_new_tokens: Optional[int] = None,
+        min_new_tokens: Optional[int] = None,
+        num_steps: Optional[int] = None,
+        eos_token_ids: Optional[Sequence[int]] = None,
+        **kwargs,
+    ) -> "QwenDrivePolicy":
+        if kwargs:
+            raise TypeError(
+                f"QwenDrivePolicy.from_pretrained: unexpected kwargs {sorted(kwargs)}"
+            )
+        if precision not in ("bf16", "auto"):
+            raise ValueError(
+                f"QwenDrivePolicy: qwen_drive is bf16-native, got precision={precision!r}"
+            )
+        import apxinf_py  # lazy: processor-only users never import the binding
+
+        model_dir = Path(model_dir)
+        config = json.loads((model_dir / "config.json").read_text())
+        planner_path = Path(planner) if planner is not None else None
+        model = apxinf_py.QwenDriveModel.load(
+            model_dir,
+            planner_path,
+            device=device,
+            precision="bf16",
+        )
+        tokenizer = _Tokenizer(model_dir)
+
+        if eos_token_ids is not None:
+            eos = list(eos_token_ids)
+        else:
+            # Exactly what the reference's generate() consumed: the checkpoint's
+            # own generation_config eos list (fall back to the text config eos).
+            eos = []
+            gen_cfg = model_dir / "generation_config.json"
+            if gen_cfg.is_file():
+                value = json.loads(gen_cfg.read_text()).get("eos_token_id")
+                if isinstance(value, list):
+                    eos = [int(v) for v in value]
+                elif value is not None:
+                    eos = [int(value)]
+            if not eos:
+                eos = [int(config["vlm_config"]["text_config"]["eos_token_id"])]
+
+        return cls(
+            model,
+            config=config,
+            tokenizer=tokenizer,
+            mode=mode,
+            eos_token_ids=eos,
+            seed=int(config.get("noise_seed", 42)) if seed is None else int(seed),
+            max_new_tokens=max_new_tokens
+            if max_new_tokens is not None
+            else int(config.get("max_reasoning_tokens", 256)),
+            min_new_tokens=min_new_tokens
+            if min_new_tokens is not None
+            else int(config.get("min_reasoning_tokens", 10)),
+            num_steps=num_steps
+            if num_steps is not None
+            else int(config.get("num_inference_steps", 10)),
+        )
+
+    # ------------------------------------------------------------------ preprocessing
+
+    def _patchify(self, image: np.ndarray, target_size, budget: int):
+        """Resize one frame onto the patch grid and flatten it into patches."""
+        from PIL import Image
+
+        array = np.ascontiguousarray(image, dtype=np.uint8)
+        if array.ndim != 3 or array.shape[2] != 3:
+            raise ValueError(
+                f"QwenDrivePolicy: expected an RGB uint8 image, got shape {array.shape}"
+            )
+        pil = Image.fromarray(array, mode="RGB")
+        max_pixels = budget
+        if target_size is not None:
+            width, height = int(target_size[0]), int(target_size[1])
+            pil = pil.resize((width, height), resample=Image.BICUBIC)
+            max_pixels = self.grid_pixel_limit
+        width, height = pil.size
+        grid_h, grid_w = smart_resize(
+            height, width, self.factor, self.min_pixels, max_pixels
+        )
+        if (grid_h, grid_w) != (height, width):
+            pil = pil.resize((grid_w, grid_h), resample=Image.BICUBIC)
+        pixels = np.asarray(pil, dtype=np.float32)
+        pixels = pixels / 255.0
+        pixels = (pixels - 0.5) / 0.5
+        rows = grid_h // self.patch_size
+        cols = grid_w // self.patch_size
+        merge = self.merge
+        x = pixels.transpose(2, 0, 1)[:, None, :, :]
+        x = np.broadcast_to(x, (3, self.temporal, grid_h, grid_w))
+        x = x.reshape(
+            3,
+            1,
+            self.temporal,
+            rows // merge,
+            merge,
+            self.patch_size,
+            cols // merge,
+            merge,
+            self.patch_size,
+        )
+        x = x.transpose(1, 3, 6, 4, 7, 0, 2, 5, 8)
+        patches = np.ascontiguousarray(x.reshape(rows * cols, -1), dtype=np.float32)
+        return patches, (rows, cols)
+
+    def _scene_views(self, observation: Mapping[str, Any]):
+        views = observation.get("views")
+        if views is None:
+            raise KeyError("QwenDrivePolicy: observation is missing 'views'")
+        if isinstance(views, Mapping):
+            names = [view for view in CAMERA_VIEWS if view in views]
+            names += [name for name in views.keys() if name not in names]
+            return [(name, views[name]) for name in names]
+        raise TypeError(
+            f"QwenDrivePolicy: 'views' must be a mapping of camera name -> frames, got {type(views)!r}"
+        )
+
+    def _scene_frames(self, views) -> list:
+        """All frames grouped by view then timestamp: (image, target_size, is_current)."""
+        frames = []
+        for _name, view_frames in views:
+            view_frames = list(view_frames)
+            per_view = len(view_frames)
+            for index, frame in enumerate(view_frames):
+                if isinstance(frame, Mapping):
+                    image = frame["image"]
+                    target = frame.get("target_size")
+                else:
+                    image = frame
+                    target = None
+                frames.append((image, target, index == per_view - 1))
+        return frames
+
+    def _instruction(self, observation, num_frames, history, nav_command) -> str:
+        text = observation.get("instruction_text")
+        if text is not None:
+            return str(text)
+        labels = HISTORY_FRAME_LABELS[-num_frames:]
+        stride = max(1, (len(history) - 1) // max(1, num_frames - 1))
+        lines = "".join(
+            " -{}: ({:.4f}, {:.4f}, {:.4f});\n".format(label, *history[index * stride])
+            for index, label in enumerate(labels)
+        )
+        header = _INSTRUCTION_HEADER.format(
+            num_frames=num_frames,
+            interval=1.5 / max(1, num_frames - 1),
+            first_label=labels[0],
+            last_frame=num_frames - 1,
+        )
+        command = NAV_COMMANDS[int(nav_command)]
+        return f"{header}{lines}2. Active navigation command: [{command}]"
+
+    def _build_scene_ids(self, observation, views, token_counts, with_reasoning) -> list:
+        per_view = len(views[0][1])
+        body: list = []
+        for view_index, (view_name, _frames) in enumerate(views):
+            body += self.tokenizer.encode(view_name)
+            for frame_index in range(per_view):
+                body += self.tokenizer.encode(f"frame: {frame_index}")
+                count = token_counts[view_index * per_view + frame_index]
+                body += [self.vision_start_id] + [self.image_token_id] * count + [self.vision_end_id]
+        nav_command = int(observation["nav_command"])
+        history = np.asarray(observation["history"], dtype=np.float64)
+        instruction = self._instruction(observation, per_view, history, nav_command)
+        if with_reasoning:
+            instruction = instruction + REASONING_REQUEST
+        body += self.tokenizer.encode(instruction)
+        assistant_header = [self.im_start_id] + self.tokenizer.encode("assistant") + self.newline_ids
+        prompt = (
+            [self.im_start_id]
+            + self.tokenizer.encode("user")
+            + self.newline_ids
+            + body
+            + [self.im_end_id]
+            + self.newline_ids
+            + assistant_header
+        )
+        if not with_reasoning:
+            prompt += [self.im_end_id] + self.newline_ids
+        return prompt
+
+    def _encode_vqa(self, observation) -> Tuple[list, np.ndarray, list]:
+        question = observation.get("question")
+        if not isinstance(question, str):
+            raise KeyError("QwenDrivePolicy: the VQA mode needs a 'question' string")
+        if "images" in observation:
+            raw_frames = []
+            for frame in observation["images"]:
+                if isinstance(frame, Mapping):
+                    raw_frames.append((frame["image"], None, True))
+                else:
+                    raw_frames.append((frame, None, True))
+        else:
+            views = self._scene_views(observation)
+            raw_frames = [
+                (image, None, True) for (image, _target, _cur) in self._scene_frames(views)
+            ]
+        # encode_vqa applies the current-frame budget to every frame and never
+        # uses the planning target sizes (reference CameraFrame(image)).
+        patch_list, grids, token_counts = [], [], []
+        for image, _target, _cur in raw_frames:
+            patches, (rows, cols) = self._patchify(image, None, self.current_pixels)
+            patch_list.append(patches)
+            grids.append([1, rows, cols])
+            token_counts.append(rows * cols // self.merge**2)
+        body: list = []
+        for count in token_counts:
+            body += [self.vision_start_id] + [self.image_token_id] * count + [self.vision_end_id]
+        body += self.tokenizer.encode(question)
+        prompt = (
+            [self.im_start_id]
+            + self.tokenizer.encode("user")
+            + self.newline_ids
+            + body
+            + [self.im_end_id]
+            + self.newline_ids
+            + [self.im_start_id]
+            + self.tokenizer.encode("assistant")
+            + self.newline_ids
+        )
+        return (
+            prompt,
+            np.ascontiguousarray(np.concatenate(patch_list, axis=0), dtype=np.float32),
+            grids,
+        )
+
+    def _conditioning(self, observation):
+        history = np.asarray(observation["history"], dtype=np.float32)
+        shifted = _wrap_heading(history - history[0:1, :])
+        normalized = _wrap_heading(shifted[1:, :]) / self.scale
+        velocity = np.asarray(observation["history_velocity"], dtype=np.float32)
+        acceleration = np.asarray(observation["history_acceleration"], dtype=np.float32)
+        ego = np.concatenate(
+            [
+                np.asarray(observation["ego_velocity"], dtype=np.float32),
+                np.asarray(observation["ego_acceleration"], dtype=np.float32),
+                np.asarray(observation["driving_command"], dtype=np.float32),
+            ]
+        )
+        return (
+            np.ascontiguousarray(normalized.reshape(-1), dtype=np.float32),
+            np.ascontiguousarray(velocity.reshape(-1), dtype=np.float32),
+            np.ascontiguousarray(acceleration.reshape(-1), dtype=np.float32),
+            np.ascontiguousarray(ego, dtype=np.float32),
+            int(observation["nav_command"]),
+        )
+
+    def _noise(self, observation, noise) -> np.ndarray:
+        selected = noise
+        if selected is None:
+            selected = observation.get("noise")
+        if selected is not None:
+            array = np.ascontiguousarray(selected, dtype=np.float32)
+        else:
+            # Non-reference fallback: the acceptance contract always supplies
+            # exact noise; without it we draw a deterministic numpy sample.
+            rng = np.random.default_rng(self.seed)
+            array = rng.standard_normal((1, 50, 3), dtype=np.float32)
+        if array.size != 150:
+            raise ValueError(
+                f"QwenDrivePolicy: noise must hold 50x3 values, got shape {array.shape}"
+            )
+        return array
+
+    # ------------------------------------------------------------------ inference
+
+    def infer(self, observation: Mapping[str, Any], *, noise: Optional[np.ndarray] = None) -> dict:
+        started = time.perf_counter()
+        mode = observation.get("mode", self.mode)
+        if mode == "vqa":
+            return self._infer_vqa(observation, started)
+        if mode in ("direct", "direct_planning"):
+            return self._infer_planning(observation, False, noise, started)
+        if mode in ("reasoning", "reasoning_planning"):
+            return self._infer_planning(observation, True, noise, started)
+        if mode == "perception":
+            raise RuntimeError(
+                "QwenDrivePolicy: perception is a declared pending gap in this revision - "
+                "the BEV stack (SimpleFPN/DepthNet/voxel pool/BEVFormer/deformable "
+                "attention/occupancy/map heads) requires the conv2d/conv3d/GroupNorm/"
+                "grid_sample/ms_deform_attn/voxel_pool kernel families, which are not "
+                "yet in the native kernel set"
+            )
+        raise ValueError(f"QwenDrivePolicy: unknown mode {mode!r}")
+
+    __call__ = infer
+
+    def _infer_vqa(self, observation, started) -> dict:
+        if bool(observation.get("do_sample", False)):
+            raise ValueError(
+                "QwenDrivePolicy: do_sample=True is unsupported; the frozen VQA protocol "
+                "is top_k=1 (greedy)"
+            )
+        token_ids, pixel_values, grid_thw = self._encode_vqa(observation)
+        max_new = int(observation.get("max_new_tokens", 2048))
+        # TEMP-DIAG (implement_r1): clamp the decode cap so the diagnostic receipt
+        # returns with heartbeat data under the 300s job limit; revert in the
+        # acceptance-bound revision (mode=all).
+        max_new = min(max_new, 64)
+        model_started = time.perf_counter()
+        generated = self.model.generate_tokens(
+            token_ids,
+            pixel_values,
+            grid_thw,
+            max_new,
+            0,
+            self.eos_token_ids,
+        )
+        model_ms = (time.perf_counter() - model_started) * 1000.0
+        text = _strip_thinking(self.tokenizer.decode(generated, skip_special_tokens=True))
+        return {
+            "token_ids": list(generated),
+            "text": text,
+            "timing": {"model_ms": model_ms, "total_ms": (time.perf_counter() - started) * 1000.0},
+            "metadata": self.metadata,
+        }
+
+    def _infer_planning(self, observation, with_reasoning: bool, noise, started) -> dict:
+        views = self._scene_views(observation)
+        frames = self._scene_frames(views)
+        patch_list, grids, token_counts = [], [], []
+        for image, target, is_current in frames:
+            budget = self.current_pixels if is_current else self.history_pixels
+            patches, (rows, cols) = self._patchify(image, target, budget)
+            patch_list.append(patches)
+            grids.append([1, rows, cols])
+            token_counts.append(rows * cols // self.merge**2)
+        pixel_values = np.ascontiguousarray(np.concatenate(patch_list, axis=0), dtype=np.float32)
+        token_ids = self._build_scene_ids(observation, views, token_counts, with_reasoning)
+        history, velocity, acceleration, ego, nav_command = self._conditioning(observation)
+        noise_array = self._noise(observation, noise)
+        model_started = time.perf_counter()
+        if with_reasoning:
+            terminators = [self.im_end_id] + [
+                token for token in self.eos_token_ids if token != self.im_end_id
+            ]
+            generated, trajectory = self.model.plan_reasoning(
+                token_ids,
+                pixel_values,
+                grids,
+                history,
+                velocity,
+                acceleration,
+                ego,
+                nav_command,
+                noise_array,
+                self.max_new_tokens,
+                self.min_new_tokens,
+                terminators,
+                self.im_end_id,
+                self.newline_ids,
+                None,
+            )
+            content = list(generated)
+            for position, token in enumerate(generated):
+                if token in terminators:
+                    content = list(generated[:position])
+                    break
+            reasoning = _strip_thinking(
+                self.tokenizer.decode(content, skip_special_tokens=True)
+            )
+        else:
+            generated = None
+            reasoning = None
+            trajectory = self.model.plan_direct(
+                token_ids,
+                pixel_values,
+                grids,
+                history,
+                velocity,
+                acceleration,
+                ego,
+                nav_command,
+                noise_array,
+                None,
+            )
+        model_ms = (time.perf_counter() - model_started) * 1000.0
+        actions = _wrap_heading(
+            np.asarray(trajectory, dtype=np.float32) * self.scale
+        )[None]
+        result = {
+            "actions": np.ascontiguousarray(actions, dtype=np.float32),
+            "timing": {"model_ms": model_ms, "total_ms": (time.perf_counter() - started) * 1000.0},
+            "metadata": self.metadata,
+        }
+        if with_reasoning:
+            result["reasoning"] = reasoning
+            result["token_ids"] = list(generated)
+        return result
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.config["trajectory_point_dim"])
+
+    @property
+    def action_horizon(self) -> int:
+        return int(self.config["num_future_points"])
+
+    def close(self) -> None:
+        self.model = None
+
+    def __repr__(self) -> str:
+        return f"QwenDrivePolicy(mode={self.mode!r}, steps={self.num_steps})"


### PR DESCRIPTION
## What this PR demonstrates

This draft adds the current Qwen-Drive-1.0-4B native ApxInf integration and documents the agent-driven development path used to build it. The integration is being developed with KerSor Mission-v1, DSH and the ApxInf model-porting skill, targeting BF16 inference on an NVIDIA RTX 4090.

KerSor supplies the bounded Mission planner, resumable FuturePlan DAG, transaction boundary and evidence-driven replanning. DSH supplies the Infini-AI/Kimi K3 model activation path. The ApxInf Host owns candidate materialization, GPU-broker submission, remote receipts and the final four-mode verifier.

## Integration surface

- register Qwen-Drive with ApxInf model and `AutoPolicy` dispatch;
- normalize the official checkpoint layout, including mixed-dtype tensors;
- add device-resident language, vision, expert and planner state;
- connect the public Python policy through the existing PyO3 boundary;
- add the CUDA attention and linear-attention FFI/kernel integration;
- preserve the existing Host-owned reference inputs and acceptance contract.

The detailed design and evidence record is in [`doc/kersor-qwen-drive-4090.md`](doc/kersor-qwen-drive-4090.md).

## RTX 4090 evidence

The current candidate has been built and executed on a real RTX 4090 through the exclusive GPU broker:

- the native CUDA extension compiled successfully;
- 723 model tensors loaded to the device in about 60 seconds;
- the VQA path entered inference, completed all 24 vision blocks and reached `vision_done`;
- the text prefill reached `prefill_layer k=3`;
- the fixed 300-second VQA gate expired at the following causal hdim256 path before `inference_returned`.

This proves that the model is being integrated and exercised on the target GPU. It does not yet prove full four-mode deployment acceptance. The PR remains draft for that reason.

The next KerSor revision targets the measured causal text-prefill bottleneck while retaining the working vision route. A new remote receipt is required before promoting this candidate.

## Review boundary

Please review the ApxInf integration and the separation between model code, DSH activation, Host evaluation and acceptance evidence. The companion KerSor planning changes are in [KerSor PR #117](https://github.com/qhy991/KerSor/pull/117).

The parallel Codex experiment reached native build/load and VQA diagnosis but then stopped because the Codex provider quota was exhausted. It has no new accepted ApxInf result, so this PR does not claim a second Codex-backed integration.

## Validation

- Python policy module: `python3 -m py_compile python/apxinf/apxinf/policies/impls/qwen_drive.py`
- Remote CUDA build and VQA attempt: passed compilation and model loading; failed the fixed 300-second VQA gate as described above.
- Full four-mode `native_deployment_valid=true`: pending.
