### PR TITLE
fix(core, qwen3vl): 修复因果 Softmax 网格溢出并支持 Qwen3-VL 4B/8B 多尺寸适配

### DIFF
--- a/crates/apxinf-cuda/adapters/core_kernels_adapter.cu
+++ b/crates/apxinf-cuda/adapters/core_kernels_adapter.cu
@@ -128,7 +128,8 @@ extern "C" cudaError_t apxinf_attention_softmax_f32(
     const void* scores, void* output,
     uint32_t cols, uint32_t rows, uint32_t kv_offset, uint32_t n_heads, void* stream)
 {
-    dim3 grid((cols + BLOCK_SIZE - 1) / BLOCK_SIZE, rows, 1);
+    uint32_t n_col_blocks = (cols + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 grid(n_col_blocks * rows, 1, 1);
     dim3 block(BLOCK_SIZE, 1, 1);
     attention_softmax_f32_kernel<<<grid, block, 0, (cudaStream_t)stream>>>(
         (const float*)scores, (float*)output, cols, rows, kv_offset, n_heads);
@@ -330,7 +331,8 @@ extern "C" cudaError_t apxinf_attention_softmax_bf16(
     const void* scores, void* output,
     uint32_t cols, uint32_t rows, uint32_t kv_offset, uint32_t n_heads, void* stream)
 {
-    dim3 grid((cols + BLOCK_SIZE - 1) / BLOCK_SIZE, rows, 1);
+    uint32_t n_col_blocks = (cols + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 grid(n_col_blocks * rows, 1, 1);
     dim3 block(BLOCK_SIZE, 1, 1);
     attention_softmax_bf16_kernel<<<grid, block, 0, (cudaStream_t)stream>>>(
         (const __nv_bfloat16*)scores, (__nv_bfloat16*)output,
@@ -495,9 +497,8 @@ extern "C" cudaError_t apxinf_vision_sdpa_bf16(
     const void* q, const void* k, const void* v, void* out,
     uint32_t seq_len, uint32_t n_heads, uint32_t head_dim, float scale, void* stream)
 {
-    // Only head_dim=64 (Qwen3-VL vision) is supported; the kernel uses a
-    // 32-thread / 2-element-per-thread layout.
-    if (head_dim != 64) return cudaErrorInvalidConfiguration;
+    // The kernel assigns head_dim columns cyclically across a 32-thread
+    // warp, so any head_dim works (verified on 64 and 72).
     dim3 grid(seq_len, n_heads, 1);
     dim3 block(32, 1, 1);
     size_t smem = (seq_len + 1) * sizeof(float);

--- a/crates/apxinf-cuda/kernels/custom/attention.cuh
+++ b/crates/apxinf-cuda/kernels/custom/attention.cuh
@@ -57,8 +57,12 @@ __global__ void attention_softmax_f32_kernel(
     const float* scores, float* output,
     uint32_t cols, uint32_t rows, uint32_t kv_offset, uint32_t n_heads)
 {
-    uint32_t row = blockIdx.y;
-    uint32_t col = blockIdx.x * blockDim.x + threadIdx.x;
+    // Grid is 1-D: one block per (row, col-tile). Recover the row from the
+    // flat block id because dim3.y is capped at 65535 and rows can exceed it
+    // (seq_len * n_heads for long prefills, e.g. Qwen3-VL-4B image prefill).
+    uint32_t n_col_blocks = (cols + blockDim.x - 1) / blockDim.x;
+    uint32_t row = blockIdx.x / n_col_blocks;
+    uint32_t col = (blockIdx.x % n_col_blocks) * blockDim.x + threadIdx.x;
     if (row >= rows) return;
 
     // Map row index to sequence position: each position has n_heads rows
@@ -169,8 +173,11 @@ __global__ void attention_softmax_bf16_kernel(
     const __nv_bfloat16* scores, __nv_bfloat16* output,
     uint32_t cols, uint32_t rows, uint32_t kv_offset, uint32_t n_heads)
 {
-    uint32_t row = blockIdx.y;
-    uint32_t col = blockIdx.x * blockDim.x + threadIdx.x;
+    // Grid is 1-D (see attention_softmax_f32_kernel): dim3.y is capped at
+    // 65535 but rows = seq_len * n_heads can exceed it on multimodal prefills.
+    uint32_t n_col_blocks = (cols + blockDim.x - 1) / blockDim.x;
+    uint32_t row = blockIdx.x / n_col_blocks;
+    uint32_t col = (blockIdx.x % n_col_blocks) * blockDim.x + threadIdx.x;
     if (row >= rows) return;
 
     uint32_t seq_pos = row / n_heads;
@@ -249,33 +256,37 @@ __global__ void vision_sdpa_bf16_kernel(
     uint32_t head = blockIdx.y;
     uint32_t qi   = blockIdx.x;
     if (qi >= seq_len) return;
-    int tid = threadIdx.x;       // 0..31
-    int half = head_dim / 2;     // 32 for head_dim=64
-    int d0 = tid;                // first element this thread owns
-    int d1 = tid + half;         // second element
+    int tid = threadIdx.x;          // 0..31 (one warp)
+
+    // Generic head_dim: each thread owns columns d = tid + 32*j. Works for
+    // head_dim=64 (2 cols/thread) and head_dim=72 (3 cols for the first 8
+    // threads, 2 for the rest). Out-of-range lanes are masked but stay
+    // converged so every __shfl_xor_sync uses the full warp mask.
+    int n_per = (head_dim + 31) / 32;
 
     extern __shared__ float smem[];
-    float* scores = smem;        // [seq_len] + 1 scratch slot
+    float* scores = smem;           // [seq_len] + 1 scratch slot
 
-    const __nv_bfloat16* q_row = q  + qi * n_heads * head_dim + head * head_dim;
-    float q0 = __bfloat162float(q_row[d0]);
-    float q1 = __bfloat162float(q_row[d1]);
+    const __nv_bfloat16* q_row = q + qi * n_heads * head_dim + head * head_dim;
 
-    // Phase 1: scores[ki] = (Q[qi] · K[ki]) * scale. All threads iterate
-    // every ki so the shfl reduction stays converged.
+    // Phase 1: scores[ki] = (Q[qi] . K[ki]) * scale. All threads iterate
+    // every ki so the warp stays converged; per-thread partial dots are
+    // summed with a full-mask shuffle reduction.
     for (uint32_t ki = 0; ki < seq_len; ki++) {
         const __nv_bfloat16* k_row = k + ki * n_heads * head_dim + head * head_dim;
-        float dot = q0 * __bfloat162float(k_row[d0])
-                  + q1 * __bfloat162float(k_row[d1]);
-        for (int off = 16; off > 0; off >>= 1) dot += __shfl_xor_sync(0xffffffff, dot, off);
+        float dot = 0.0f;
+        for (int j = 0; j < n_per; j++) {
+            int d = tid + 32 * j;
+            if (d < (int)head_dim)
+                dot += __bfloat162float(q_row[d]) * __bfloat162float(k_row[d]);
+        }
+        for (int off = 16; off > 0; off >>= 1)
+            dot += __shfl_xor_sync(0xffffffff, dot, off);
         if (tid == 0) scores[ki] = dot * scale;
     }
     __syncthreads();
 
-    // Phase 2: softmax (max → exp → sum → normalize).
-    // For seq_len > 32, the max/sum reductions are strided — but the shfl
-    // only needs the threads that have data. Use mask = __activemask() to
-    // avoid deadlocks when some threads drop out.
+    // Phase 2: online-style softmax over seq_len scores (strided reads).
     float max_val = -INFINITY;
     for (uint32_t ki = tid; ki < seq_len; ki += 32u)
         max_val = fmaxf(max_val, scores[ki]);
@@ -299,18 +310,20 @@ __global__ void vision_sdpa_bf16_kernel(
     for (uint32_t ki = tid; ki < seq_len; ki += 32u) scores[ki] *= inv_sum;
     __syncthreads();
 
-    // Phase 3: out[qi, head, d0|d1] = sum_k scores[k] * V[k, head, d0|d1].
-    // All threads iterate every ki (d0/d1 differ per thread so no divergence).
-    float acc0 = 0.0f, acc1 = 0.0f;
-    for (uint32_t ki = 0; ki < seq_len; ki++) {
-        float s = scores[ki];
-        const __nv_bfloat16* v_row = v + ki * n_heads * head_dim + head * head_dim;
-        acc0 += s * __bfloat162float(v_row[d0]);
-        acc1 += s * __bfloat162float(v_row[d1]);
+    // Phase 3: out[qi, head, d] = sum_k scores[k] * V[k, head, d]. Each
+    // thread accumulates its owned columns independently (no reduction).
+    for (int j = 0; j < n_per; j++) {
+        int d = tid + 32 * j;
+        if (d < (int)head_dim) {
+            float acc = 0.0f;
+            for (uint32_t ki = 0; ki < seq_len; ki++) {
+                const __nv_bfloat16* v_row = v + ki * n_heads * head_dim + head * head_dim;
+                acc += scores[ki] * __bfloat162float(v_row[d]);
+            }
+            __nv_bfloat16* out_row = out + qi * n_heads * head_dim + head * head_dim;
+            out_row[d] = __float2bfloat16(acc);
+        }
     }
-    __nv_bfloat16* out_row = out + qi * n_heads * head_dim + head * head_dim;
-    out_row[d0] = __float2bfloat16(acc0);
-    out_row[d1] = __float2bfloat16(acc1);
 }
 
 

--- a/crates/apxinf-cuda/src/kernels/attention.rs
+++ b/crates/apxinf-cuda/src/kernels/attention.rs
@@ -368,7 +368,9 @@ pub fn softmax(ctx: &CudaContext, input: &Tensor) -> Result<Tensor> {
 
 /// Non-causal full attention for the vision tower. Q/K/V each
 /// `[seq, n_heads, head_dim]` bf16; returns `[seq, n_heads * head_dim]`.
-/// head_dim must be 64 (Qwen3-VL-2B vision).
+/// Non-causal full attention for the Qwen3-VL vision tower. Supports any
+/// head_dim (64 for Qwen3-VL-2B/4B, 72 for Qwen3-VL-8B); the CUDA kernel
+/// distributes head_dim columns cyclically across a 32-thread warp.
 pub fn vision(
     ctx: &CudaContext,
     q: &Tensor,
@@ -381,8 +383,8 @@ pub fn vision(
     if q.dtype() != DType::BF16 || k.dtype() != DType::BF16 || v.dtype() != DType::BF16 {
         return Err(Error::Other("vision_sdpa: only BF16 supported".into()));
     }
-    if head_dim != 64 {
-        return Err(Error::Other("vision_sdpa: head_dim must be 64".into()));
+    if head_dim == 0 || head_dim > 256 {
+        return Err(Error::Other("vision_sdpa: head_dim out of range".into()));
     }
     let device_id = ctx.device_id();
     let out_bytes = seq_len * n_heads * head_dim * DType::BF16.size_in_bytes();

--- a/crates/apxinf-model/src/qwen3vl/decode_graph.rs
+++ b/crates/apxinf-model/src/qwen3vl/decode_graph.rs
@@ -93,7 +93,7 @@ struct DecodeWorkspace {
     k_normed: CudaBuffer,     // [n_kv_heads*head_dim] post-QK-norm K
     q_rope: CudaBuffer,       // [hidden]
     k_rope: CudaBuffer,       // [n_kv_heads*head_dim]
-    attn_out: CudaBuffer,     // [hidden]
+    attn_out: CudaBuffer,     // [n_heads*head_dim] raw attention output
     attn_proj: CudaBuffer,    // [hidden]
     ffn_norm_out: CudaBuffer, // [hidden]
     mlp_hidden: CudaBuffer,   // [intermediate]
@@ -108,6 +108,9 @@ impl DecodeWorkspace {
     fn new(device_id: usize, cfg: &Qwen3VLDecodeGraphConfig) -> std::result::Result<Self, String> {
         let h = cfg.hidden_size;
         let kv = cfg.n_kv_heads * cfg.head_dim;
+        // Q projection width is n_heads * head_dim, which is NOT always
+        // hidden_size (Qwen3-VL-4B: 32*128=4096 vs hidden 2560).
+        let q_dim = cfg.n_heads * cfg.head_dim;
         let inter = cfg.intermediate_size;
         let vocab = cfg.vocab_size;
         let elem = cfg.dtype.size_in_bytes();
@@ -117,16 +120,16 @@ impl DecodeWorkspace {
             x: f(h)?,
             logits: f(vocab)?,
             norm_out: f(h)?,
-            q: f(h)?,
+            q: f(q_dim)?,
             k: f(kv)?,
             v: f(kv)?,
-            qkv: f(h + 2 * kv)?,
+            qkv: f(q_dim + 2 * kv)?,
             gate_up: f(2 * inter)?,
-            q_normed: f(h)?,
+            q_normed: f(q_dim)?,
             k_normed: f(kv)?,
-            q_rope: f(h)?,
+            q_rope: f(q_dim)?,
             k_rope: f(kv)?,
-            attn_out: f(h)?,
+            attn_out: f(q_dim)?,
             attn_proj: f(h)?,
             ffn_norm_out: f(h)?,
             mlp_hidden: f(inter)?,
@@ -180,6 +183,7 @@ fn decode_forward_capturable(
     let elem = cfg.dtype.size_in_bytes();
     let dtype = cfg.dtype;
     let kv_proj = n_kv_heads * head_dim;
+    let q_dim = n_heads * head_dim;
 
     if dtype != DType::BF16 {
         return Err(Error::Other("Qwen3-VL decode graph: bf16 only".into()));
@@ -219,14 +223,14 @@ fn decode_forward_capturable(
         let (q_view, k_view, v_view) = if let Some(qkv_w) = layer.qkv_packed {
             let norm_view = ws.norm_out.view(0, ws.norm_out.len()).map_err(Error::Cuda)?;
             let qkv_wv = weight_view(qkv_w, device_id)?;
-            let fused_n = hidden + 2 * kv_proj;
+            let fused_n = q_dim + 2 * kv_proj;
             kernels::gemm::write(ctx, dtype, 1, fused_n, hidden, 1.0, &norm_view, &qkv_wv, 0.0, &ws.qkv)
                 ?;
             (
-                ws.qkv.view(0, hidden * elem).map_err(Error::Cuda)?,
-                ws.qkv.view(hidden * elem, kv_proj * elem).map_err(Error::Cuda)?,
+                ws.qkv.view(0, q_dim * elem).map_err(Error::Cuda)?,
+                ws.qkv.view(q_dim * elem, kv_proj * elem).map_err(Error::Cuda)?,
                 ws.qkv
-                    .view((hidden + kv_proj) * elem, kv_proj * elem)
+                    .view((q_dim + kv_proj) * elem, kv_proj * elem)
                     .map_err(Error::Cuda)?,
             )
         } else {
@@ -234,7 +238,7 @@ fn decode_forward_capturable(
             let wq_v = weight_view(layer.wq, device_id)?;
             let wk_v = weight_view(layer.wk, device_id)?;
             let wv_v = weight_view(layer.wv, device_id)?;
-            kernels::gemm::write(ctx, dtype, 1, hidden, hidden, 1.0, &norm_view, &wq_v, 0.0, &ws.q)?;
+            kernels::gemm::write(ctx, dtype, 1, q_dim, hidden, 1.0, &norm_view, &wq_v, 0.0, &ws.q)?;
             kernels::gemm::write(ctx, dtype, 1, kv_proj, hidden, 1.0, &norm_view, &wk_v, 0.0, &ws.k)?;
             kernels::gemm::write(ctx, dtype, 1, kv_proj, hidden, 1.0, &norm_view, &wv_v, 0.0, &ws.v)?;
             (
@@ -363,9 +367,11 @@ fn decode_forward_capturable(
         )?;
 
         // ── wo projection ──
-        let ao_view = ws.attn_out.view(0, ws.attn_out.len()).map_err(Error::Cuda)?;
+        // Attention output width is n_heads*head_dim (q_dim), which is NOT
+        // always hidden_size (Qwen3-VL-4B: 32*128=4096 vs hidden 2560).
+        let ao_view = ws.attn_out.view(0, q_dim * elem).map_err(Error::Cuda)?;
         let wo_v = weight_view(layer.wo, device_id)?;
-        kernels::gemm::write(ctx, dtype, 1, hidden, hidden, 1.0, &ao_view, &wo_v, 0.0, &ws.attn_proj)?;
+        kernels::gemm::write(ctx, dtype, 1, hidden, q_dim, 1.0, &ao_view, &wo_v, 0.0, &ws.attn_proj)?;
 
         // ── Fused post-attn residual add + pre-FFN norm ──
         let ffn_norm_weight = weight_view(layer.ffn_norm_weight, device_id)?;

--- a/crates/apxinf-model/src/qwen3vl/general.rs
+++ b/crates/apxinf-model/src/qwen3vl/general.rs
@@ -78,8 +78,15 @@ impl GeneralQwen3VL {
         let mut weights = transfer_weights(&weights, &*backend)?;
         let vision_weights = transfer_vision_weights(&vision_weights, &*backend)?;
 
-        // Cache the transposed embedding for the tied lm_head matmul.
-        let lm_head = transpose_tensor_bf16_or_f32(&weights.token_embedding, &*backend)?;
+        // Output projection. Untied checkpoints ship lm_head.weight and it
+        // must be used verbatim; tied ones reuse the transposed embedding.
+        // Deciding this from the checkpoint (rather than the
+        // `tie_word_embeddings` config flag, which several shipped configs
+        // omit) is what makes 8B produce correct logits.
+        let lm_head = match &weights.lm_head {
+            Some(lm) => lm.clone(),
+            None => transpose_tensor_bf16_or_f32(&weights.token_embedding, &*backend)?,
+        };
 
         // Build fused weight matrices (qkv_packed, gate_up_packed) for the
         // fused-GEMM decode path. No-ops on backends without concat_2d.
@@ -534,6 +541,7 @@ fn transfer_weights(w: &Qwen3VLTextWeights, backend: &dyn Backend) -> Result<Qwe
     })).collect::<Result<Vec<_>>>()?;
     Ok(Qwen3VLTextWeights {
         token_embedding: backend.to_device(&w.token_embedding)?,
+        lm_head: w.lm_head.as_ref().map(|t| backend.to_device(t)).transpose()?,
         layers,
         output_norm_weight: backend.to_device(&w.output_norm_weight)?,
     })

--- a/crates/apxinf-model/src/qwen3vl/vision_weights.rs
+++ b/crates/apxinf-model/src/qwen3vl/vision_weights.rs
@@ -76,9 +76,12 @@ impl Qwen3VLVisionWeights {
         let patch_embed_weight = {
             let raw = tensors.remove("model.visual.patch_embed.proj.weight")
                 .ok_or_else(|| Error::Other("missing patch_embed.proj.weight".into()))?;
-            // Shape [1024, 3, 2, 16, 16] → reshape to [1024, 1536] then
-            // transpose to [1536, 1024] for matmul (cuBLAS row-major).
-            let flattened = reshape_5d_to_2d(&raw, 1024, 1536)?;
+            // Shape [embed_dim, 3, 2, 16, 16] → reshape to [embed_dim, patch_elems]
+            // then transpose for matmul (cuBLAS row-major). embed_dim differs per
+            // size (1024 for 2B/4B, 1152 for 8B), so read it from the config.
+            let patch_elems = vc.in_channels * vc.temporal_patch_size
+                * vc.patch_size * vc.patch_size;
+            let flattened = reshape_5d_to_2d(&raw, vc.hidden_size, patch_elems)?;
             transpose_2d(&flattened)?
         };
         let patch_embed_bias = tensors.remove("model.visual.patch_embed.proj.bias")

--- a/crates/apxinf-model/src/qwen3vl/weights.rs
+++ b/crates/apxinf-model/src/qwen3vl/weights.rs
@@ -14,9 +14,17 @@ use super::config::Qwen3VLConfig;
 /// All text-stack weights for Qwen3-VL, in the layout the decode graph
 /// wants (2D projections transposed to `[in, out]` for cuBLAS row-major).
 pub struct Qwen3VLTextWeights {
-    /// `[vocab_size, hidden_size]`. Doubles as the lm_head weight because
-    /// Qwen3-VL uses tied embeddings.
+    /// `[vocab_size, hidden_size]`. Doubles as the lm_head weight when the
+    /// checkpoint has no separate output projection (tied embeddings).
     pub token_embedding: Tensor,
+    /// Separate output projection for untied checkpoints, transposed to
+    /// `[hidden, vocab]`. `None` means tied.
+    ///
+    /// Presence is decided by the checkpoint, not by the `tie_word_embeddings`
+    /// config key: several shipped configs omit the key while still shipping a
+    /// real `lm_head.weight`, and trusting the key there yields logits that
+    /// are uncorrelated with the reference.
+    pub lm_head: Option<Tensor>,
     pub layers: Vec<Qwen3VLLayer>,
     pub output_norm_weight: Tensor,
 }
@@ -81,8 +89,14 @@ impl Qwen3VLTextWeights {
             .ok_or_else(|| Error::Other("missing model.language_model.embed_tokens.weight".into()))?;
         let output_norm_weight = tensors.remove("model.language_model.norm.weight")
             .ok_or_else(|| Error::Other("missing model.language_model.norm.weight".into()))?;
+        // Untied checkpoints carry their own output projection. Transpose it
+        // to [hidden, vocab] so it drops into the same GEMM as the tied path.
+        let lm_head = match tensors.remove("lm_head.weight") {
+            Some(t) => Some(transpose_2d(&t)?),
+            None => None,
+        };
 
-        Ok(Self { token_embedding, layers, output_norm_weight })
+        Ok(Self { token_embedding, lm_head, layers, output_norm_weight })
     }
 }
 


### PR DESCRIPTION
## 依赖关系

本 PR 是独立的尺寸修复，不依赖其他 PR，可单独审阅。

同时它是 #64 的前置。#64 的性能验证包含 4B 和 8B 两个尺寸，这两个尺寸需先合入本 PR 才能跑通（否则撞缓冲区溢出）。2B 尺寸不受此限制。

Fixes #56

## 摘要

本 PR 修复了 ApxInf 在多模态长序列下的公共 CUDA Kernel 网格维度溢出错误，并修正了 Transformer 解码图与权重加载中针对特定模型尺度的三处硬编码假设，完整支持 Qwen3-VL 4B 和 8B 尺寸的文本与长图推理。

问题排查与深层根因分析详见关联 Issue #56。

## 详细改动

1. **公共 Kernel：融合因果 Softmax 网格一维平铺（`crates/apxinf-core/cuda/core_kernels_adapter.cu`）**
   - 将二维网格改为一维网格启动（`dim3 grid(n_col_blocks * rows, 1, 1)`），kernel 内部反推行号与列块，消除 `gridDim.y <= 65535` 硬件硬顶，支持长序列与大头数多模态模型。
2. **模型解码图：泛化 Q 通路缓冲区与 GEMM 维度（`crates/apxinf-model/src/qwen3vl/decode_graph.rs`）**
   - 引入真实 Q 维度 `q_dim = cfg.n_heads * cfg.head_dim`，修正 Q 缓存分配宽度、QKV 切片偏移与输出 GEMM 收缩维（由 `hidden` 修正为 `q_dim`）。
3. **视觉前向与权重加载：支持动态宽度与 head_dim 72（`crates/apxinf-model/src/qwen3vl/vision_weights.rs`、`vision.rs`）**
   - 消除硬编码的常量 1024，改为从视觉配置动态读取；
   - 视觉注意力 Kernel 泛化线程列循环分配，放宽仅允许 head_dim 64 的限制，支持 8B 视觉塔的 head_dim 72。
4. **词表输出投影：自适应检测独立权重（`crates/apxinf-model/src/qwen3vl/weights.rs`）**
   - 优先检测 safetensors 中是否存在独立的 `lm_head.weight`，支持 8B 独立权重架构。

## 验证与测试结果

测试在 NVIDIA GB10（sm_121）上完成，采用 BF16 原版权重和贪心解码，对标 Hugging Face transformers 原生参考实现：

1. **纯文本 Prefill 精度**：
   - 4B 与参考实现完全一致，相关系数 0.99987；
   - 8B 修复前相关系数为 -0.004（乱码），修复后恢复为 **0.99991**。
2. **真实高清图片端到端生成（视觉理解）**：
   - 输入 1344×1792 高清图（9408 个视觉 patch，图文总计 2379 tokens），生成 256 个贪心 token：
     - **2B**：256 / 256 逐 token 完全一致；
     - **4B**：256 / 256 逐 token 完全一致（修复前在 prefill 时即因 Softmax grid 溢出崩溃）；
     - **8B**：255 / 256 逐 token 一致，仅末尾产生一个空格差异（属于 BF16 正常舍入差），图文识别全部准确。
3. **回归测试**：
   - 对原有 2B 尺寸逻辑均为空操作，数值严格无变化；
   - 全工作区 `cargo test` 单元测试全部通过（apxinf-model 67 项、apxinf-core 29 项、apxinf-loader 11 项、apxinf-tokenizer 1 项）；
   - 上游既有的 `multimodal_check` 2B 端到端检查顺利通过。

## 建议后续回归

因果 Softmax 网格溢出修复涉及公共底层 Kernel。我们已在 GB10 上验证通过，建议维护方在 Jetson Thor / Orin / RTX 4090 等主力平台上进行快速回归。
