### PR TITLE
feat(cuda): 识别 GB10 (sm_121) 为 Blackwell sm100 家族

### DIFF
--- a/configs/tuning/nvidia/gb10-sm121/tactics.json
+++ b/configs/tuning/nvidia/gb10-sm121/tactics.json
@@ -1,0 +1,960 @@
+{
+  "cublas_version": "13.1",
+  "cuda_version": "13.0",
+  "device_name": "NVIDIA GB10",
+  "kernel_build_id": "kb1-be4aa1097f95160a9a1aeaa382eae5d8",
+  "records": [
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 1,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.018173440247774123,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 5,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 1,
+        "n": 3072,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.03659263923764229,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 32,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.00994431994855404,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 3,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 32,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.005854720007628203,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 4,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.0305318396538496,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 4,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4096,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.05007615983486176,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 2560,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.03422975957393646,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 2,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 8192,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.11166975855827332,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 3,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "geglu",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 8192,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.12814080029726027,
+      "tactic": {
+        "backend": "gemm_then_geglu",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 588,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.02428032048046589,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.030795520544052123,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4304,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.10843263745307924,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.045745919197797774,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 3456,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.07972096264362336,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 4304,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.09993984192609788,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.08510079711675644,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 1,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 16384,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.40965760111808774,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2560,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.107804157435894,
+      "tactic": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 32768,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.8993433594703675,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "geglu",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 32768,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 1.1152153539657592,
+      "tactic": {
+        "backend": "gemm_then_geglu",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 1,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.00983679998666048,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 1,
+        "n": 3072,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.011882240064442155,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 32,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.00985600009560585,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 32,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.009803520068526268,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.01751807987689972,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4096,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.02543743997812271,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 2560,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.02015744000673294,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 8192,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.04504192024469376,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 588,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.02494592003524303,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.02683135971426964,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4304,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.0699340796470642,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.03558783978223801,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 3456,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.06361088186502456,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 4304,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.08354048132896423,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.04975104033946991,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 16384,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.43938687920570374,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2560,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 0.06442112177610397,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    },
+    {
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 32768,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "milliseconds": 1.1516428756713868,
+      "tactic": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1
+      }
+    }
+  ],
+  "schema": "apxinf.cuda.tuning.v1",
+  "sm": 121
+}

--- a/configs/tuning/nvidia/gb10-sm121/tuning_report.json
+++ b/configs/tuning/nvidia/gb10-sm121/tuning_report.json
@@ -1,0 +1,9373 @@
+{
+  "cublas_version": "13.1.1",
+  "cuda_version": "13.0",
+  "device_name": "NVIDIA GB10",
+  "kernel_build_id": "kb1-be4aa1097f95160a9a1aeaa382eae5d8",
+  "runs": [
+    {
+      "candidates": [
+        {
+          "backend": "gemm_then_geglu",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.12814080029726027
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "geglu",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 8192,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "gemm_then_geglu",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.12814080029726027
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "gemm_then_geglu",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 1.1152153539657592
+        },
+        {
+          "backend": "cutlass_bf16_dual_geglu_m522",
+          "correct": false,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "geglu",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 32768,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "gemm_then_geglu",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 1.1152153539657592
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.01891584023833275
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.023142400085926055
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.025703679993748663
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.02633344002068043
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.027704320400953292
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.020185599476099013
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.018173440247774123
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": 0.018920960426330565
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": 0.026736639365553858
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": 0.02551168017089367
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": 0.019406080394983292
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 1,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 5,
+        "implementation_version": 1,
+        "milliseconds": 0.018173440247774123
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03702015936374664
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03659263923764229
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.04031616047024727
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.04163967981934547
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.03874559953808784
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.05767551898956299
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.04359295979142189
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": 0.06087424010038376
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": 0.038836479932069776
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 1,
+        "n": 3072,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.03659263923764229
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.0363558392226696
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03656447932124138
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.04461055904626846
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.03422975957393646
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.03929600015282631
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.0447526390850544
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.04533759862184525
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 2560,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 2,
+        "implementation_version": 1,
+        "milliseconds": 0.03422975957393646
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.01216768018901348
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.012108800262212753
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.012784640081226826
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.010375679843127728
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.00994431994855404
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.02224256001412869
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.012016640231013296
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 32,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 3,
+        "implementation_version": 1,
+        "milliseconds": 0.00994431994855404
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.12098048090934752
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.11949440091848372
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.1282227197289467
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.1820032024383545
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.11166975855827332
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.16846463918685914
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.14921215951442718
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "row_major",
+        "m": 10,
+        "n": 8192,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 3,
+        "implementation_version": 1,
+        "milliseconds": 0.11166975855827332
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03157760076224804
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.030795520544052123
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.03405056059360504
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.03444479882717132
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.04065152034163475
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.030795520544052123
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.045745919197797774
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.05057663947343826
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.058079999089241025
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.05057408004999161
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.057222398966550826
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.06780927866697312
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.15939584136009216
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.045745919197797774
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.08092800289392471
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.07972096264362336
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.08761599779129028
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.1041728013753891
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.09294207960367204
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.10692735940217972
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.2157056021690369
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 3456,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.07972096264362336
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.1019328024983406
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.09993984192609788
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.12065024137496948
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.11560447812080384
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.10630911767482758
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.11993344128131866
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "row_major",
+        "m": 512,
+        "n": 4304,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.09993984192609788
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.4399347233772278
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.40965760111808774
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.5462348818778991
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.649093120098114
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 16384,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.40965760111808774
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.04063999906182289
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03439871892333031
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.036816639676690105
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.03989760026335716
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.05084031954407692
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.0305318396538496
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.04478335857391357
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 4,
+        "implementation_version": 1,
+        "milliseconds": 0.0305318396538496
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.0858150413632393
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.09562240153551102
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.08510079711675644
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.0949593597650528
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.10138624250888824
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.11443199932575226
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.274225914478302
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2048,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 1,
+        "implementation_version": 1,
+        "milliseconds": 0.08510079711675644
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.10838015764951706
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.107804157435894
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.1199219211935997
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.1372198408842087
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.15974911868572236
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.14497919917106628
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.28188287615776064
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 2560,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.107804157435894
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.8993433594703675
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.9084940767288208
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 1.0653913521766665
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 1.730709767341614
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "row_major",
+        "m": 522,
+        "n": 32768,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.8993433594703675
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.007895040083676577
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.006312959976494312
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.006044160071760416
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.005876480098813772
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.01150208007544279
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.005854720007628203
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.00586368003860116
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 32,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 4,
+        "implementation_version": 1,
+        "milliseconds": 0.005854720007628203
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.0501555198431015
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.05007615983486176
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.074410240650177
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.06285439848899842
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.056843520551919935
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.10075264185667038
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4096,
+        "layout": "row_major",
+        "m": 10,
+        "n": 1024,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.05007615983486176
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.11039743781089782
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.10843263745307924
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.11649407893419264
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.111105278134346
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.15123455822467805
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4304,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "cublaslt",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.10843263745307924
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02428032048046589
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02429696060717106
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 1,
+          "implementation_version": 1,
+          "milliseconds": 0.0305958404392004
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 2,
+          "implementation_version": 1,
+          "milliseconds": 0.03037184052169323
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 3,
+          "implementation_version": 1,
+          "milliseconds": 0.028362239971756936
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 4,
+          "implementation_version": 1,
+          "milliseconds": 0.028377599865198135
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 5,
+          "implementation_version": 1,
+          "milliseconds": 0.032738560736179353
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 6,
+          "implementation_version": 1,
+          "milliseconds": 0.03861503973603249
+        },
+        {
+          "backend": "cublaslt",
+          "correct": true,
+          "id": 7,
+          "implementation_version": 1,
+          "milliseconds": 0.05492224052548408
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 8,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 9,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 10,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 11,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 12,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 13,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 14,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 15,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 16,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 17,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 18,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 19,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 20,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 21,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 22,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 23,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 24,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 25,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 26,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 27,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 28,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 29,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 30,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 31,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 32,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 33,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 34,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 35,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 36,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 37,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 38,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 39,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 40,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 41,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 42,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 43,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 44,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 45,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 46,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 47,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 48,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 49,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 50,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 51,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 52,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 53,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 54,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 55,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 56,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 57,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 58,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 59,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 60,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 61,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 62,
+          "implementation_version": 1,
+          "milliseconds": null
+        },
+        {
+          "backend": "cublaslt",
+          "correct": false,
+          "id": 63,
+          "implementation_version": 1,
+          "milliseconds": null
+        }
+      ],
+      "key": {
+        "activation_dtype": "bf16",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 588,
+        "layout": "row_major",
+        "m": 512,
+        "n": 1152,
+        "op": "bf16",
+        "output_dtype": "bf16",
+        "scale_mode": "none",
+        "weight_dtype": "bf16",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.02428032048046589
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.00983679998666048
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 1,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.00983679998666048
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.011882240064442155
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 1,
+        "n": 3072,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.011882240064442155
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02015744000673294
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 2560,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.02015744000673294
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.00985600009560585
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 32,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.00985600009560585
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.04504192024469376
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1024,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 8192,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.04504192024469376
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02683135971426964
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.02683135971426964
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.03558783978223801
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.03558783978223801
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.06361088186502456
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 3456,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.06361088186502456
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.08354048132896423
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 1152,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 4304,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.08354048132896423
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.43938687920570374
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 16384,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.43938687920570374
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.01751807987689972
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.01751807987689972
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.04975104033946991
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2048,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.04975104033946991
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.06442112177610397
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 2560,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.06442112177610397
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 1.1516428756713868
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 2048,
+        "layout": "weight_output_major",
+        "m": 522,
+        "n": 32768,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 1.1516428756713868
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.009803520068526268
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 32,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.009803520068526268
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02543743997812271
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4096,
+        "layout": "weight_output_major",
+        "m": 10,
+        "n": 1024,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.02543743997812271
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.0699340796470642
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 4304,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.0699340796470642
+      }
+    },
+    {
+      "candidates": [
+        {
+          "backend": "vendor",
+          "correct": true,
+          "id": 0,
+          "implementation_version": 1,
+          "milliseconds": 0.02494592003524303
+        }
+      ],
+      "key": {
+        "activation_dtype": "i8",
+        "device": {
+          "multiprocessor_count": 48,
+          "sm": 121
+        },
+        "epilogue": "none",
+        "k": 588,
+        "layout": "weight_output_major",
+        "m": 512,
+        "n": 1152,
+        "op": "w8a8",
+        "output_dtype": "bf16",
+        "scale_mode": "dynamic_row_per_output_channel",
+        "weight_dtype": "i8",
+        "workspace_limit": 18446744073709551615
+      },
+      "winner": {
+        "backend": "vendor",
+        "id": 0,
+        "implementation_version": 1,
+        "milliseconds": 0.02494592003524303
+      }
+    }
+  ],
+  "schema": "apxinf.cuda.tuning-report.v1",
+  "sm": 121
+}

--- a/crates/apxinf-cuda/build_support/cuda_arch.rs
+++ b/crates/apxinf-cuda/build_support/cuda_arch.rs
@@ -66,7 +66,9 @@ pub struct ArchSelection {
 pub fn is_cutlass_sm100_family(arch: &str) -> bool {
     matches!(
         arch,
-        "sm_100" | "sm_100a" | "sm_101" | "sm_101a" | "sm_110" | "sm_110a" | "sm_120" | "sm_120a"
+        "sm_100" | "sm_100a" | "sm_101" | "sm_101a"
+        | "sm_110" | "sm_110a"
+        | "sm_120" | "sm_120a" | "sm_121" | "sm_121a"
     )
 }
 

--- a/crates/apxinf-cuda/src/device_caps.rs
+++ b/crates/apxinf-cuda/src/device_caps.rs
@@ -76,7 +76,7 @@ impl CudaDeviceCaps {
     pub const fn classify(sm: u32) -> CudaArchFamily {
         match sm {
             80 | 86 | 87 | 89 => CudaArchFamily::Sm80,
-            100 | 101 | 110 | 120 => CudaArchFamily::Sm100,
+            100 | 101 | 110 | 120 | 121 => CudaArchFamily::Sm100,
             other => CudaArchFamily::Other(other),
         }
     }
@@ -101,7 +101,7 @@ mod tests {
         for sm in [80, 86, 87, 89] {
             assert_eq!(CudaDeviceCaps::classify(sm), CudaArchFamily::Sm80);
         }
-        for sm in [100, 101, 110, 120] {
+        for sm in [100, 101, 110, 120, 121] {
             assert_eq!(CudaDeviceCaps::classify(sm), CudaArchFamily::Sm100);
         }
     }


### PR DESCRIPTION
关联 Issue：#58

## 改动内容

在 `build_support/cuda_arch.rs` 与 `src/device_caps.rs` 中将 `sm_121`（GB10）归入 Blackwell sm100 家族，使 CUTLASS 等相关算子能为该架构正常编译并运行。

核心代码实质改动共 5 行，不包含任何测试产物或大文件。

## 验证情况

1. 在 DGX Spark（GB10）上运行测试套件全部通过，π0.5 模型与独立 BF16 参照输出数值对齐。
2. 改动仅在白名单追加匹配分支，不影响现有 Thor、Orin 与 RTX 4090 等设备。建议官方审阅者在常规板卡上做一次 CI 回归。