### PR TITLE
feat(cuda): 识别 GB10 (sm_121) 为 Blackwell sm100 家族

### DIFF
--- a/crates/apxinf-cuda/build_support/cuda_arch.rs
+++ b/crates/apxinf-cuda/build_support/cuda_arch.rs
@@ -66,7 +66,9 @@ pub struct ArchSelection {
 pub fn is_cutlass_sm100_family(arch: &str) -> bool {
     matches!(
         arch,
-        "sm_100" | "sm_100a" | "sm_101" | "sm_101a" | "sm_110" | "sm_110a" | "sm_120" | "sm_120a"
+        "sm_100" | "sm_100a" | "sm_101" | "sm_101a"
+        | "sm_110" | "sm_110a"
+        | "sm_120" | "sm_120a" | "sm_121" | "sm_121a"
     )
 }
 

--- a/crates/apxinf-cuda/src/device_caps.rs
+++ b/crates/apxinf-cuda/src/device_caps.rs
@@ -76,7 +76,7 @@ impl CudaDeviceCaps {
     pub const fn classify(sm: u32) -> CudaArchFamily {
         match sm {
             80 | 86 | 87 | 89 => CudaArchFamily::Sm80,
-            100 | 101 | 110 | 120 => CudaArchFamily::Sm100,
+            100 | 101 | 110 | 120 | 121 => CudaArchFamily::Sm100,
             other => CudaArchFamily::Other(other),
         }
     }
@@ -101,7 +101,7 @@ mod tests {
         for sm in [80, 86, 87, 89] {
             assert_eq!(CudaDeviceCaps::classify(sm), CudaArchFamily::Sm80);
         }
-        for sm in [100, 101, 110, 120] {
+        for sm in [100, 101, 110, 120, 121] {
             assert_eq!(CudaDeviceCaps::classify(sm), CudaArchFamily::Sm100);
         }
     }


### PR DESCRIPTION
## 依赖关系

本 PR 是独立的设备识别改动，不依赖其他 PR，可单独审阅。

同时它是 #64 的前置。#64 将 sm_121 纳入 FlashAttention-2 的编译范围，依赖本 PR 先把 121 认进 cutlass sm100 家族，否则编译目标建不起来。本 PR 合入后 #64 会更顺畅。

关联 Issue：#58

## 改动内容

在 `build_support/cuda_arch.rs` 与 `src/device_caps.rs` 中将 `sm_121`（GB10）归入 Blackwell sm100 家族，使 CUTLASS 等相关算子能为该架构正常编译并运行。

核心代码实质改动共 5 行，不包含任何测试产物或大文件。

## 验证情况

1. 在 DGX Spark（GB10）上运行测试套件全部通过，π0.5 模型与独立 BF16 参照输出数值对齐。
2. 改动仅在白名单追加匹配分支，不影响现有 Thor、Orin 与 RTX 4090 等设备。建议官方审阅者在常规板卡上做一次 CI 回归。