### PR TITLE
perf(vision): block-parallel reduction for layer_norm_bf16

### DIFF
--- a/crates/apxinf-cuda/adapters/core_kernels_adapter.cu
+++ b/crates/apxinf-cuda/adapters/core_kernels_adapter.cu
@@ -447,12 +447,15 @@ extern "C" cudaError_t apxinf_layer_norm_bf16(
     const void* input, const void* weight, const void* bias, void* output,
     uint32_t cols, uint32_t rows, float eps, void* stream)
 {
-    dim3 grid((cols + BLOCK_SIZE - 1) / BLOCK_SIZE, rows, 1);
+    // One block per row: block-parallel reduction over cols, matching the
+    // rms_norm_bf16 launch policy. The previous per-thread serial reduction
+    // made this the single largest GPU kernel in the vision tower.
+    dim3 grid(rows, 1, 1);
     dim3 block(BLOCK_SIZE, 1, 1);
     layer_norm_bf16_kernel<<<grid, block, 0, (cudaStream_t)stream>>>(
         (const __nv_bfloat16*)input, (const __nv_bfloat16*)weight,
         (const __nv_bfloat16*)bias, (__nv_bfloat16*)output,
-        cols, rows, eps);
+        rows, cols, eps);
     return cudaGetLastError();
 }
 

--- a/crates/apxinf-cuda/kernels/custom/normalization.cuh
+++ b/crates/apxinf-cuda/kernels/custom/normalization.cuh
@@ -93,33 +93,6 @@ __global__ void rms_norm_bf16_kernel(
 // with normalization along the last axis. Vision blocks have both weight
 // and bias, unlike the text stack's RMSNorm.
 
-__global__ void layer_norm_bf16_kernel(
-    const __nv_bfloat16* input, const __nv_bfloat16* weight,
-    const __nv_bfloat16* bias, __nv_bfloat16* output,
-    uint32_t cols, uint32_t rows, float eps)
-{
-    uint32_t col = blockIdx.x * blockDim.x + threadIdx.x;
-    uint32_t row = blockIdx.y;
-    if (col >= cols || row >= rows) return;
-
-    uint32_t offset = row * cols;
-    float sum = 0.0f;
-    for (uint32_t i = 0; i < cols; i++) {
-        sum += __bfloat162float(input[offset + i]);
-    }
-    float mean = sum / (float)cols;
-    float sum_sq = 0.0f;
-    for (uint32_t i = 0; i < cols; i++) {
-        float d = __bfloat162float(input[offset + i]) - mean;
-        sum_sq += d * d;
-    }
-    float inv_std = rsqrtf(sum_sq / (float)cols + eps);
-
-    float x = __bfloat162float(input[offset + col]);
-    float w = __bfloat162float(weight[col]);
-    float b = __bfloat162float(bias[col]);
-    output[offset + col] = __float2bfloat16(w * (x - mean) * inv_std + b);
-}
 
 
 


### PR DESCRIPTION
关联 Issue：#65（https://github.com/infinigence/ApxInf/issues/65）

## 摘要

视觉塔的 `layer_norm_bf16_kernel` 在 GB10 上占 GPU kernel 计算时间的 60.5%，是单一最大 kernel。根因是 `normalization.cuh` 里存在两个同名 kernel，adapter 调用因参数顺序精确匹配到了每线程串行归约的版本，而文件里另一个一行一 block、共享内存并行归约的版本（与语言塔 `rms_norm_bf16` 同一套写法）从未被选中。

本 PR 删除串行版本，并把 adapter 的启动配置对齐到并行归约版本。改动为 2 文件 5 增 29 删，无新依赖，复用仓库已有的 `block_sum` 共享内存归约。

实测该 kernel 单次中位耗时从 12.3 毫秒降到 177 微秒（约 70 倍），GPU kernel 总时间从约 1230 毫秒降到约 495 毫秒。输出与 Hugging Face 参考实现逐 token 对拍 256/256 一致。

## 问题背景

用 nsys 对 Qwen3-VL-2B 读图（9408 个图像 patch，2379 个 prompt token）做 GPU kernel 时间统计，`layer_norm_bf16_kernel` 占总时间 60.5%（743 毫秒，52 次调用，单次中位 12.3 毫秒），远超其他所有 kernel。

查 `normalization.cuh` 发现存在两个同名 `layer_norm_bf16_kernel`。一个是每线程串行归约版本，签名 `(uint32_t cols, uint32_t rows, ...)`，每个线程独立遍历整行 cols 个元素做两次全行归约（sum 与 sum_sq），无 block 内并行归约、无共享内存，block 内 256 线程对同一行重复计算 256 次 mean 与 inv_std。另一个是并行归约版本，签名 `(int rows, int cols, ...)`，一行一 block，block 内 stride 循环加 `block_sum` 共享内存归约，与语言塔 `rms_norm_bf16_kernel` 同款。

`core_kernels_adapter.cu` 的 `apxinf_layer_norm_bf16` 传参顺序为 `(cols, rows)`，两个 `uint32_t` 精确匹配串行版本的 `(uint32_t cols, uint32_t rows)`，编译器选中串行版本。并行版本需要 `int` 隐式转换，落选。语言塔的 RMSNorm 走的是并行版本，所以只有视觉塔中招。

GPU trace 证实：串行版本 grid 为 `(4, 9408)`（cols=1024 视觉塔隐藏宽，rows=9408 patch），单次 12.2 毫秒；并行版本同场景单次约 80 微秒（语言塔 rms_norm 实测值），效率差约 150 倍。

## 修改内容

1. 删除 `normalization.cuh` 中每线程串行归约的 `layer_norm_bf16_kernel`（-27 行）。
2. `core_kernels_adapter.cu` 的 `apxinf_layer_norm_bf16`：grid 从 `((cols+255)/256, rows)` 改为 `(rows, 1, 1)`，kernel 调用参数从 `(cols, rows)` 改为 `(rows, cols)`，对齐并行归约版本签名（+5 行含注释）。

数学完全等价（mean/variance 归一化加 affine 变换）。改动只涉及并行策略与归约顺序。浮点归约顺序变化会带来末位舍入差异，但实测输出落在 bf16 表示精度内，未暴露。

## 性能与正确性验证

测试环境为单卡 NVIDIA GB10（DGX Spark，48 SM，121 GiB 统一内存），官方 BF16 权重，贪心解码生成 256 token，输入一张 1344 乘 1792 分辨率图像（9408 个 patch，2379 个 prompt token）。

| 指标 | 优化前 | 优化后 |
|---|---:|---:|
| layer_norm GPU 占比 | 60.5% | 1.9% |
| layer_norm 单次中位 | 12.3 毫秒 | 177 微秒 |
| layer_norm 总时间 | 743 毫秒 | 9.4 毫秒 |
| GPU kernel 总时间 | 约 1230 毫秒 | 约 495 毫秒 |
| 端到端 TTFT | 2538 毫秒 | 2285 毫秒 |

输出正确性：2B 生成的 256 个 token 与 Hugging Face 原版输出逐 token 对拍 256/256 一致。

端到端 TTFT 降幅（约 10%）远小于 GPU kernel 降幅，因为 TTFT 大头已转移到 host 侧 D2H memcpy（约 1.26 秒）。本 PR 只解决 GPU 计算侧的 layer_norm 瓶颈，不涉及 host 侧传输。

## 影响范围与风险说明

1. 纯 kernel 内部改动。只改 `layer_norm_bf16_kernel` 的并行策略，不改数学定义、不改接口、不改调用方逻辑。
2. 依赖安全性。复用仓库已有的 `block_sum` 归约函数，无外部依赖。
3. 验证范围。本 PR 在 GB10（sm_121）上验证了 2B 尺寸。改动与模型尺寸无关（并行策略只依赖 cols 与 rows），但 4B 与 8B 未在本 PR 分支实测。建议在有多尺寸设备的维护环境补测。
4. 与其他改动独立。本 PR 不依赖任何其他 PR，可独立合入。